### PR TITLE
fix: 이메일 가입 인증 시 발생하는 인증 오류 해결 및 안정성 개선

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "xyz.nexvoy.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3
-        versionName "0.1.2"
+        versionCode 4
+        versionName "0.1.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -2,7 +2,13 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@/utils/supabase/server'
 
 export async function GET(request: Request) {
-    const { searchParams, origin } = new URL(request.url)
+    const { searchParams, origin: defaultOrigin } = new URL(request.url)
+    
+    // Determine the user-facing origin (handling reverse proxies/load balancers)
+    const forwardedHost = request.headers.get('x-forwarded-host')
+    const isLocalEnv = process.env.NODE_ENV === 'development'
+    const origin = isLocalEnv ? defaultOrigin : (forwardedHost ? `https://${forwardedHost}` : defaultOrigin)
+    
     const code = searchParams.get('code')
     // if "next" is in param, use it as the redirect URL
     const next = searchParams.get('next') ?? '/'
@@ -10,23 +16,31 @@ export async function GET(request: Request) {
     // Handle Supabase errors passed via query params (e.g. invalid or expired token)
     const error_description = searchParams.get('error_description')
     if (error_description) {
+        console.error('Supabase auth error:', error_description)
         return NextResponse.redirect(`${origin}/auth/error?message=${encodeURIComponent(error_description)}`)
     }
 
     if (code) {
         const supabase = await createClient()
         const { error } = await supabase.auth.exchangeCodeForSession(code)
+        
         if (!error) {
-            const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer
-            const isLocalEnv = process.env.NODE_ENV === 'development'
-            if (isLocalEnv) {
-                // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-                return NextResponse.redirect(`${origin}${next}`)
-            } else if (forwardedHost) {
-                return NextResponse.redirect(`https://${forwardedHost}${next}`)
-            } else {
-                return NextResponse.redirect(`${origin}${next}`)
-            }
+            return NextResponse.redirect(`${origin}${next}`)
+        }
+
+        // --- Handle Exchange Error ---
+        console.error('Auth exchange error:', error.message)
+        
+        // Check if we already have a session (in case of duplicate/pre-fetch requests)
+        const { data: { session } } = await supabase.auth.getSession()
+        if (session) {
+            return NextResponse.redirect(`${origin}${next}`)
+        }
+
+        // If this is a signup verification flow, the email is likely verified even if exchange failed (e.g. cross-device PKCE)
+        // Redirect to success page instead of error page to avoid confusing the user.
+        if (next.includes('success')) {
+            return NextResponse.redirect(`${origin}/auth/success?verified=true`)
         }
     }
 

--- a/src/app/auth/success/page.tsx
+++ b/src/app/auth/success/page.tsx
@@ -3,8 +3,13 @@
 import { css } from 'styled-system/css'
 import { CheckCircle2 } from 'lucide-react'
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
 
-export default function AuthSuccessPage() {
+function SuccessContent() {
+    const searchParams = useSearchParams()
+    const isVerifiedOnly = searchParams.get('verified') === 'true'
+
     return (
         <div className={css({
             minH: '100vh',
@@ -55,10 +60,12 @@ export default function AuthSuccessPage() {
                     lineHeight: 1.5,
                     wordBreak: 'keep-all'
                 })}>
-                    환영합니다. 계정 인증이 성공적으로 완료되었습니다. 이제 Onvoy의 모든 기능을 이용하실 수 있습니다.
+                    {isVerifiedOnly 
+                        ? '이메일 인증이 완료되었습니다. 보안을 위해 다시 한 번 로그인해 주세요.'
+                        : '환영합니다. 계정 인증이 성공적으로 완료되었습니다. 이제 Onvoy의 모든 기능을 이용하실 수 있습니다.'}
                 </p>
                 <Link
-                    href="/"
+                    href={isVerifiedOnly ? '/login' : '/'}
                     className={css({
                         display: 'flex',
                         alignItems: 'center',
@@ -76,9 +83,17 @@ export default function AuthSuccessPage() {
                         _active: { transform: 'scale(0.98)' }
                     })}
                 >
-                    홈으로 이동
+                    {isVerifiedOnly ? '로그인하러 가기' : '홈으로 이동'}
                 </Link>
             </div>
         </div>
+    )
+}
+
+export default function AuthSuccessPage() {
+    return (
+        <Suspense fallback={<div className={css({ minH: '100vh', bg: '#fbfbfb' })} />}>
+            <SuccessContent />
+        </Suspense>
     )
 }


### PR DESCRIPTION
# Pull Request: 이메일 가입 인증 오류 해결 및 안정성 개선

## 🚀 개요
사용자가 회원가입 후 수신한 인증 메일의 링크를 클릭했을 때, 실제로는 인증이 완료되었음에도 불구하고 앱상에서 "인증 오류"가 표시되는 현상을 해결했습니다.

## 🔍 배경 및 문제 분석
- **현상**: 인증 메일 링크 클릭 시 `invalid_code` 오류 발생 및 [/auth/error](cci:7://file:///Users/ysjee141/mySources/travel-pack/src/app/auth/error:0:0-0:0) 페이지 리다이렉트. 하지만 수동 로그인은 가능함.
- **주요 원인**:
  - **PKCE Mismatch**: 가입 시도 브라우저와 인증 링크 클릭 브라우저가 다를 경우 세션 교환에 필요한 쿠키가 없어 오류 발생.
  - **Link Pre-fetching**: Gmail/Outlook 등 메일 클라이언트가 보안 검사를 위해 링크를 미리 방문하여 일회성 `code`를 선소모하는 현상.
  - 기존 로직은 세션 교환 실패 시 사용자의 실제 인증 상태(이미 검증됨)와 관계없이 무조건 에러 페이지를 표시하고 있었습니다.

## 🛠️ 주요 수정 사항

### 1. [auth/callback/route.ts](cci:7://file:///Users/ysjee141/mySources/travel-pack/src/app/auth/callback/route.ts:0:0-0:0) 로직 강화
- **세션 교환 실패 대응**: `exchangeCodeForSession`이 실패하더라도 이미 세션(`getSession`)이 존재하는지 확인하여 중복 요청에 대응합니다.
- **성공 가이드 리다이렉트**: 가입 인증([signup](cci:7://file:///Users/ysjee141/mySources/travel-pack/src/app/signup:0:0-0:0)) 흐름에서 세션 교환에 실패하더라도, 인증 자체는 성공했을 확률이 높으므로 `/auth/success?verified=true`로 리다이렉트하여 "인증 완료"를 안내합니다.
- **Origin 처리 개선**: Vercel/Proxy 환경에서 올바른 도메인으로 안내되도록 `x-forwarded-host` 헤더 참조 로직을 통일했습니다.

### 2. [auth/success/page.tsx](cci:7://file:///Users/ysjee141/mySources/travel-pack/src/app/auth/success/page.tsx:0:0-0:0) UI 개선
- `verified=true` 파라미터 유무에 따라 사용자 안내 문구를 분기했습니다.
  - **자동 로그인 성공**: "환영합니다! 이제 모든 기능을 이용하실 수 있습니다."
  - **수동 로그인 필요**: "이메일 인증이 완료되었습니다. 보안을 위해 다시 한 번 로그인해 주세요." (로그인 버튼 노출)

### 3. 기타 사항
- Android 빌드 버전 업데이트 (`Version Code: 4`, `Version Name: 0.1.3`)

## ✨ 기대 효과
- 사용자에게 당혹스러운 "인증 실패" 대신 "인증 성공 및 로그인 안내"를 제공하여 UX 일관성을 유지합니다.
- 크로스 디바이스(PC 가입 -> 모바일 인증) 상황에서도 자연스러운 흐름을 확보했습니다.

## 🧪 테스트 방법
1. 브라우저 A에서 회원가입 진행.
2. 브라우저 B(혹은 모바일)에서 수신된 인증 링크 클릭.
3. `/auth/success?verified=true` 페이지 진입 및 로그인 유도 메시지 확인.
4. 로그인 시 정상 서비스 이용 가능 여부 확인.
