### PR TITLE
fix: 여행 수정 즉각 반영 및 최소 금액 0원 이슈 수정 (resolves #37)

### DIFF
--- a/src/app/trips/checklist/ChecklistClient.tsx
+++ b/src/app/trips/checklist/ChecklistClient.tsx
@@ -793,7 +793,7 @@ export default function ChecklistPage({ isActive = true }: { isActive?: boolean 
                     onClick={() => setIsAdding(true)}
                     className={css({
                         position: 'fixed',
-                        bottom: '90px',
+                        bottom: 'calc(90px + env(safe-area-inset-bottom))',
                         right: '20px',
                         w: '56px',
                         h: '56px',

--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -375,7 +375,7 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
                     onClick={() => { setEditingPlan(null); setIsModalOpen(true) }}
                     className={css({
                         position: 'fixed',
-                        bottom: '90px', // BNB(64px) + 여점(26px)
+                        bottom: 'calc(90px + env(safe-area-inset-bottom))', // BNB(64px) + 여점(26px) + Safe Area
                         right: '20px',
                         w: '56px',
                         h: '56px',

--- a/src/app/trips/detail/TripLayoutClient.tsx
+++ b/src/app/trips/detail/TripLayoutClient.tsx
@@ -88,7 +88,10 @@ export default function TripLayoutClient() {
                 borderBottom: '1px solid #eaeaea'
             })}>
                 {/* 제목, 날짜·인원 표시 + 수정/삭제 아이콘 (통합 레이아웃) */}
-                <TripHeaderActions trip={trip} />
+                <TripHeaderActions
+                    trip={trip}
+                    onUpdate={(updated) => setTrip((prev: any) => ({ ...prev, ...updated }))}
+                />
             </div>
 
             {/* Tab Navigation (Instant React State Switch) */}

--- a/src/components/trips/NewPlanModal.tsx
+++ b/src/components/trips/NewPlanModal.tsx
@@ -54,7 +54,7 @@ export default function NewPlanModal({ tripId, isOpen, onClose, onSuccess, editD
             setLocationLng(editData.location_lng ?? null)
             setGooglePlaceId(editData.google_place_id ?? null)
             setTimezoneString(editData.timezone_string || 'Asia/Seoul')
-            setCost(editData.cost || '')
+            setCost(editData.cost || 0)
             setMemo(editData.memo || '')
 
             // YYYY-MM-DDTHH:mm:ss 포맷에서 날짜/시간 분리 (문자열 파싱)

--- a/src/components/trips/TripHeaderActions.tsx
+++ b/src/components/trips/TripHeaderActions.tsx
@@ -21,9 +21,10 @@ interface TripHeaderActionsProps {
         children_count: number
         user_id: string
     }
+    onUpdate?: (updatedFields: Partial<TripHeaderActionsProps['trip']>) => void
 }
 
-export default function TripHeaderActions({ trip }: TripHeaderActionsProps) {
+export default function TripHeaderActions({ trip, onUpdate }: TripHeaderActionsProps) {
     const router = useRouter()
     const supabase = createClient()
 
@@ -171,6 +172,15 @@ export default function TripHeaderActions({ trip }: TripHeaderActionsProps) {
             setErrorMsg(error.message)
         } else {
             setShowEditModal(false)
+            if (onUpdate) {
+                onUpdate({
+                    destination,
+                    start_date: startDate,
+                    end_date: endDate,
+                    adults_count: adults,
+                    children_count: children,
+                })
+            }
             router.refresh()
         }
     }


### PR DESCRIPTION
## 📌 개요
Resolves: #37

기존에 보고된 세 가지 주요 버그('여행 수정 모달 미반영', '빈 금액 일정 저장 실패', '모바일 모달 하단 버튼 겹침')를 해결했습니다.

## 🛠 수정 사항
1. **여행 내용(목적지, 시작/종료일, 인원수) 변경 사항 즉각 렌더링 적용**
   - **문제:** `TripHeaderActions` 컴포넌트에서 정보를 수정한 뒤 `router.refresh()`만 호출해, 모달이 닫힌 뒤 부모 컴포넌트(`TripLayoutClient`)에 존재하는 클라이언트 측 상태(State)가 즉각 파싱되지 않았습니다.
   - **해결 방안:** `TripHeaderActions` 컴포넌트의 Props에 `onUpdate` 콜백을 추가했습니다. 업데이트 API가 성공하면 이 콜백을 통해 상위 뷰포트 상태를 병합(Merge)하여 모달이 닫힘과 동시에 변경 사항을 화면에 새로 그려주도록 로직을 추가했습니다.

2. **일정 수정 시 금액이 비어 있을 때 오류 파생 방지 (DB INSERT 에러 수정)**
   - **문제:** `NewPlanModal`에서 기존 데이터를 초기화하는 `useEffect` 단계에서, DB상 `cost` 값이 0이거나 없을 때 안전 장치로 할당된 변수가 빈 문자열(`''`)이었습니다. 이를 그대로 수정 전송 시 PostgreSQL 쪽에서 Integer 처리에 실패해 저장이 막히는 오류가 있었습니다.
   - **해결 방안:** 초기화 값을 빈 문자열에서 숫자 `0`으로 수정(`setCost(editData.cost || 0)`)하여 안전한 페이로드 송신이 이루어지게 처리했습니다.

3. **모바일 웹앱 환경에서의 Floating Action Button(FAB) 하단 잘림 해결**
   - **문제:** `TripClient`, `ChecklistClient` 내 '새 일정 추가' / '템플릿 추가' 둥근 하단 액션 버튼이, 모바일 네이티브 하단 여백(`safe-area-inset-bottom`)을 고려하지 않고 고정 `fixed` 높이를 가져 네비게이션바(Bottom Navi)와 겹치는 현상이 있었습니다.
   - **해결 방안:** CSS 속성에 `calc(90px + env(safe-area-inset-bottom))` 공식을 추가시켜 모바일 iOS/AOS의 Safe Area 환경 대응이 자동으로 이루어지도록 조치했습니다.

## 📝 확인 부탁드리는 내용
- [ ] '여행 수정' 후 즉각적으로 헤더의 여행 이름과 인원수가 반영되는지 확인
- [ ] 예산 비용란을 조작하지 않거나 초기 상태 그대로 '일정 수정 내용'만 저장했을 때 정상적으로 액션이 완료되는지 확인
- [ ] (AOS / iOS) 모바일 환경에서 우측 하단의 ✚ 버튼들이 하단 탭바와 시각적으로 충돌하지 않는 지침 여부
