### PR TITLE
fix: 메인 화면 진입 시 닉네임 깜빡임(Flickering) 현상 수정

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -250,7 +250,13 @@ export default function HomeClient() {
 
       if (localUser) {
         setUser(localUser)
-        setNickname(localUser.email?.split('@')[0] || '여행자')
+        // 1. 프로필 캐시 확인 (닉네임 깜빡임 방지)
+        const cachedProfile = await CacheUtil.getProfile()
+        if (cachedProfile?.nickname) {
+            setNickname(cachedProfile.nickname)
+        } else {
+            setNickname(localUser.email?.split('@')[0] || '여행자')
+        }
         try {
           // 캐시된 목록 즉시 적용
           const cachedTrips = await CacheUtil.get<any[]>('offline_home_all_trips')
@@ -281,6 +287,9 @@ export default function HomeClient() {
         .single()
 
       setNickname(profile?.nickname || networkUser.email?.split('@')[0] || '여행자')
+      if (profile) {
+        await CacheUtil.setProfile(profile)
+      }
       setShowNicknamePrompt(!profile?.nickname)
 
       // 1. 내가 멤버로 참여(수락)한 여행 ID들 가져오기

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -39,5 +39,14 @@ export const CacheUtil = {
     
     async getAuthUser() {
         return await this.get<any>('auth_last_user')
+    },
+
+    // 유저 프로필 정보 (닉네임 등)
+    async setProfile(profile: any) {
+        await this.set('auth_last_profile', profile)
+    },
+
+    async getProfile() {
+        return await this.get<any>('auth_last_profile')
     }
 }


### PR DESCRIPTION
## 📌 개요
메인 화면 진입 시 사용자 닉네임이 로드되기 전까지 이메일 아이디가 잠깐 노출되었다가 바뀌는 UI 깜빡임(Flickering) 현상을 해결합니다.

## ✨ 변경 사항

### 1. 로컬 프로필 캐싱 로직 추가 (`src/utils/cache.ts`)
- `CacheUtil`에 `setProfile` / `getProfile` 메서드를 추가하여 유저의 프로필 정보(닉네임 등)를 로컬 저장소에 영구적으로 저장하고 불러올 수 있게 했습니다.
- 이를 통해 네트워크 지연 없이 이전 세션에서 확인된 닉네임을 즉시 렌더링할 수 있습니다.

### 2. 초기 렌더링 시점 최적화 (`src/app/HomeClient.tsx`)
- **즉시 적용**: `loadCacheFirst()` 단계에서 인증 세션과 함께 로컬 캐싱된 프로필을 함께 로드하여, 닉네임을 이메일 아이디보다 우선적으로 화면에 표시하도록 수정했습니다.
- **백그라운드 동기화**: `fetchNetworkBackground()`에서 서버의 최신 프로필 데이터를 가져온 후 로컬 캐시를 최신화하여 데이터 일관성을 유지합니다.

## 📸 변경 전/후 비교
- **변경 전**: 안녕하세요 `user123`님 (아이디) → (약 0.5초 후) → 안녕하세요 `홍길동`님 (닉네임)
- **변경 후**: 진입 시 즉시 안녕하세요 `홍길동`님 (닉네임) 표시

## ✅ 테스트 항목
- [x] 최초 로그인 후 메인 진입 시 닉네임이 정상적으로 캐싱되는지 확인
- [x] 페이지 새로고침 시 이메일 아이디 노출 없이 닉네임이 즉시 표시되는지 확인
- [x] 오프라인 상태에서도 마지막으로 확인된 닉네임이 유지되는지 확인
