### PR TITLE
fix: move discord feedback webhook to server-side API to avoid CORS

### DIFF
--- a/docs/plans/invite_link_implementation.md
+++ b/docs/plans/invite_link_implementation.md
@@ -1,0 +1,99 @@
+# 초대 링크를 통한 즉시 참여 기능 구현 계획
+
+사용자가 이메일 입력 없이도 링크 공유만으로 동행자를 초대하고, 초대받은 사람이 여정 내용을 확인 후 즉시 참여할 수 있는 기능을 구현합니다.
+
+## User Review Required
+
+> [!IMPORTANT]
+> - **보안**: 초대 링크는 누구나 접근 가능하므로, 유출 시 의도치 않은 사용자가 참여할 수 있습니다. (기존 '동행자 제거' 기능으로 사후 관리 가능)
+> - **권한**: 링크를 통해 참여하는 사용자의 기본 권한은 '편집자(Editor)'로 설정할 예정입니다. 변경이 필요하시면 말씀해 주세요.
+
+## Proposed Changes
+
+### 1. Database (Supabase)
+
+#### [NEW] `supabase/add_join_trip_via_token_rpc.sql`
+- 특정 초대 토큰을 사용하여 안전하게 여정에 참여할 수 있도록 하는 RPC(Stored Procedure)를 추가합니다.
+
+```sql
+-- 초대 토큰으로 여정에 참여하는 함수
+CREATE OR REPLACE FUNCTION public.join_trip_via_token(token_val text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER -- 함수 생성자 권한으로 실행 (RLS 우회 가능)
+AS $$
+DECLARE
+    target_trip_id uuid;
+    current_user_email text;
+BEGIN
+    -- 1. 토큰으로 trip_id 조회
+    SELECT trip_id INTO target_trip_id FROM public.trip_shares WHERE share_token = token_val;
+    IF target_trip_id IS NULL THEN
+        RAISE EXCEPTION '유효하지 않은 초대 링크입니다.';
+    END IF;
+
+    -- 2. 현재 로그인한 사용자의 이메일 가져오기
+    current_user_email := auth.jwt() ->> 'email';
+
+    -- 3. 이미 멤버인지 확인
+    IF EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = target_trip_id AND user_id = auth.uid()) THEN
+        RETURN target_trip_id;
+    END IF;
+
+    -- 4. 멤버로 추가 (이미 'pending'인 데이터가 있다면 업데이트, 없으면 인서트)
+    INSERT INTO public.trip_members (trip_id, user_id, invited_email, role, status)
+    VALUES (target_trip_id, auth.uid(), current_user_email, 'editor', 'accepted')
+    ON CONFLICT (trip_id, invited_email) 
+    DO UPDATE SET user_id = auth.uid(), status = 'accepted';
+
+    RETURN target_trip_id;
+END;
+$$;
+```
+
+---
+
+### 2. Frontend Utilities
+
+#### [MODIFY] [collaboration.ts](file:///Users/ysjee141/mySources/travel-pack/src/utils/collaboration.ts)
+- `joinTripViaToken(token: string)` 메서드 추가 (RPC 호출)
+- 토큰을 통해 여정의 기본 정보를 가져오는 `getTripSummaryByToken(token: string)` 메서드 추가
+
+---
+
+### 3. New Pages & Routes
+
+#### [NEW] `src/app/join/[token]/page.tsx`
+- 초대받은 사람이 처음 도달하는 랜딩 페이지입니다.
+- **기능**:
+    - 여정 제목, 참여자 수, 방장 닉네임 요약 정보 표시
+    - '여정 참여하기' 버튼
+    - 비로그인 사용자의 경우 '로그인 후 참여하기' 안내 및 로그인 페이지 유도
+
+---
+
+### 4. UI Components
+
+#### [MODIFY] [CollaboratorModal.tsx](file:///Users/ysjee141/mySources/travel-pack/src/components/trips/CollaboratorModal.tsx)
+- 상단에 '초대 링크 보내기' 섹션 추가
+- 링크 복사 버튼 및 성공 메시지 구현
+
+---
+
+## Open Questions
+
+- **링크 만료**: 초대 링크에 유효 기간(예: 3일)을 설정할까요, 아니면 무제한으로 할까요? (기본적으로 `trip_shares`에 `expires_at` 컬럼이 있어 활용 가능합니다.)
+- **중복 참여**: 이미 참여 중인 사용자가 링크를 클릭했을 때 "이미 참여 중입니다"라고 안내하고 바로 여정 페이지로 이동시킬까요?
+
+## Verification Plan
+
+### Automated Tests
+- `join_trip_via_token` RPC 함수가 올바르게 작동하는지 SQL 에디터에서 테스트
+- 권한 없는 사용자가 토큰 없이 접근할 때 차단되는지 확인
+
+### Manual Verification
+1. 여행 소유자 계정으로 초대 링크 생성 및 복사
+2. 시크릿 창(또는 다른 브라우저)에서 초대 링크 접속
+3. 로그인 후 '참여하기' 클릭 -> 여정 상세 페이지로 리다이렉트 확인
+4. 방장 계정에서 참여자가 올바르게 추가되었는지 확인
+5. 방장 계정에서 참여자 강제 퇴장 기능 작동 여부 확인

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * 테스터 피드백을 디스코드 Webhook으로 전달하는 서버 사이드 API
+ * 클라이언트의 CORS 문제를 방지하고 Webhook URL을 숨기기 위해 사용합니다.
+ */
+export async function POST(req: NextRequest) {
+    try {
+        const formData = await req.formData()
+        const webhookUrl = process.env.DISCORD_WEBHOOK_URL
+
+        if (!webhookUrl) {
+            console.error('Discord Webhook URL이 설정되어 있지 않습니다.')
+            return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+        }
+
+        // 디스크로드로 보낼 새로운 FormData 구성
+        const discordFormData = new FormData()
+        
+        // payload_json 전달
+        const payloadJson = formData.get('payload_json')
+        if (payloadJson) {
+            discordFormData.append('payload_json', payloadJson)
+        }
+
+        // 모든 파일 필드 찾아서 전달 (file0, file1, ...)
+        for (const [key, value] of formData.entries()) {
+            if (key.startsWith('file') && value instanceof File) {
+                discordFormData.append(key, value)
+            }
+        }
+
+        // 디스크로드 Webhook 호출
+        const response = await fetch(webhookUrl, {
+            method: 'POST',
+            body: discordFormData,
+        })
+
+        if (response.ok) {
+            return NextResponse.json({ success: true })
+        } else {
+            const errorText = await response.text()
+            console.error('Discord Webhook 호출 실패:', errorText)
+            return NextResponse.json({ error: 'Discord delivery failed' }, { status: response.status })
+        }
+    } catch (err: any) {
+        console.error('Feedback API Error:', err)
+        return NextResponse.json({ error: err.message }, { status: 500 })
+    }
+}

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -11,14 +11,9 @@ interface BugReportData {
     files?: File[];
 }
 
+import { Capacitor } from '@capacitor/core';
+
 export const sendBugReportToDiscord = async (data: BugReportData) => {
-    const webhookUrl = process.env.NEXT_PUBLIC_DISCORD_WEBHOOK_URL;
-
-    if (!webhookUrl) {
-        console.error('Discord Webhook URL이 설정되어 있지 않습니다.');
-        return { success: false, error: '설정 오류' };
-    }
-
     try {
         const formData = new FormData();
         
@@ -41,6 +36,7 @@ export const sendBugReportToDiscord = async (data: BugReportData) => {
             ]
         };
 
+        // 클라이언트에서 payload_json을 문자열로 추가
         formData.append('payload_json', JSON.stringify(payload));
 
         // 2. 파일 첨부 (있을 경우)
@@ -50,7 +46,12 @@ export const sendBugReportToDiscord = async (data: BugReportData) => {
             });
         }
 
-        const response = await fetch(webhookUrl, {
+        // 3. 서버 API 호출 (CORS 회피 및 보안을 위해 서버 사이드 API 사용)
+        const isNative = Capacitor.isNativePlatform();
+        const baseUrl = isNative ? (process.env.NEXT_PUBLIC_APP_URL || '') : '';
+        const apiUrl = `${baseUrl}/api/feedback`;
+
+        const response = await fetch(apiUrl, {
             method: 'POST',
             body: formData,
         });
@@ -58,12 +59,12 @@ export const sendBugReportToDiscord = async (data: BugReportData) => {
         if (response.ok) {
             return { success: true };
         } else {
-            const errorText = await response.text();
-            console.error('Discord 전송 실패:', errorText);
+            const errorData = await response.json().catch(() => ({}));
+            console.error('피드백 전송 실패 (API 에러):', errorData);
             return { success: false, error: '전송 실패' };
         }
     } catch (error) {
-        console.error('Discord 전송 중 오류 발생:', error);
+        console.error('피드백 전송 중 오류 발생:', error);
         return { success: false, error: '시스템 오류' };
     }
 };


### PR DESCRIPTION
## 📝 개요
테스터 피드백 제출 시 앱(모바일) 환경에서 발생하던 "시스템 오류"를 해결하고, 보안을 강화하기 위해 디스코드 전송 로직을 서버 사이드로 이전했습니다.

## 🚀 변경 사항
- **서버 사이드 API 신설**: 
  - `src/app/api/feedback/route.ts`를 추가하여 클라이언트 대신 서버에서 디스코드 Webhook을 호출합니다.
  - 이를 통해 브라우저/앱 WebView의 **CORS 이슈**를 원천적으로 해결했습니다.
- **클라이언트 로직 업데이트**: 
  - `src/utils/discord.ts`에서 디스코드 URL을 직접 호출하던 방식을 내부 API 호출로 전환했습니다.
  - `Capacitor.isNativePlatform()`을 사용하여 네이티브 앱 환경에서도 올바른 서버 주소로 요청을 보낼 수 있도록 대응했습니다.
- **보안 강화**: 
  - `NEXT_PUBLIC_DISCORD_WEBHOOK_URL`을 서버 전용 환경 변수인 `DISCORD_WEBHOOK_URL`로 전환하여 외부 노출을 방지했습니다.

## 🧪 테스트 결과
- [x] 텍스트 피드백 전송 성공 (200 OK)
- [x] 이미지 첨부 피드백 전송 성공
- [x] 로컬 환경(`pnpm dev`)에서 디스코드 채널로 메시지 도착 확인

## 📌 참고 사항
- 로컬 테스트 시 `.env.local` 파일에서 `NEXT_PUBLIC_DISCORD_WEBHOOK_URL` 대신 `DISCORD_WEBHOOK_URL`이 설정되어 있어야 합니다.
- 앱 환경에서 테스트 시 `NEXT_PUBLIC_APP_URL`이 올바르게 설정되어 있는지 확인이 필요합니다.
