### PR TITLE
Fix/feedback transmission data

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -23,23 +23,32 @@ export async function POST(req: NextRequest) {
 
     try {
         const formData = await req.formData()
+        const receivedKeys = Array.from(formData.keys())
+        console.log('Feedback API 수신 데이터 키:', receivedKeys)
+
         const webhookUrl = process.env.DISCORD_WEBHOOK_URL
 
         if (!webhookUrl) {
             console.error('Discord Webhook URL이 설정되어 있지 않습니다.')
             return NextResponse.json(
-                { error: 'Server configuration error' }, 
+                { error: 'Server configuration error', detail: 'Discord Webhook URL is missing in server environment' }, 
                 { status: 500, headers: corsHeaders }
             )
         }
 
-        // 디스크로드로 보낼 새로운 FormData 구성
+        // 디스크로드로 보낼 새로운 FormData 구성 (Discord API 호환)
         const discordFormData = new FormData()
         
         // payload_json 전달
-        const payloadJson = formData.get('payload_json')
-        if (payloadJson) {
-            discordFormData.append('payload_json', payloadJson as string)
+        const payloadValue = formData.get('payload_json')
+        if (payloadValue && typeof payloadValue === 'string') {
+            discordFormData.append('payload_json', payloadValue)
+        } else {
+            console.error('payload_json 필드가 없거나 문자열이 아닙니다.', receivedKeys)
+            return NextResponse.json(
+                { error: 'Invalid request data', detail: 'Missing or invalid payload_json field', keys: receivedKeys }, 
+                { status: 400, headers: corsHeaders }
+            )
         }
 
         // 모든 파일 필드 찾아서 전달 (file0, file1, ...)

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -55,52 +55,35 @@ export const sendBugReportToDiscord = async (data: BugReportData) => {
 
         console.log(`피드백 전송 시작 (${isNative ? 'Native' : 'Web'}): ${apiUrl}`);
 
-        let response;
-        if (isNative) {
-            // 네이티브 환경에서는 CapacitorHttp를 직접 사용하여 CORS 및 브릿지 이슈를 방지합니다.
-            response = await CapacitorHttp.post({
-                url: apiUrl,
-                data: formData,
-                headers: {
-                    // CapacitorHttp는 FormData를 보낼 때 Content-Type을 자동으로 설정합니다.
-                }
-            });
-        } else {
-            // 웹 환경에서는 표준 fetch 사용
-            const fetchRes = await fetch(apiUrl, {
-                method: 'POST',
-                body: formData,
-            });
-            
-            response = {
-                status: fetchRes.status,
-                data: await fetchRes.json().catch(() => ({})),
-            };
-        }
+        // 리다이렉트와 CORS 문제가 해결되었으므로, 
+        // FormData를 가장 표준적으로 처리하는 fetch를 다시 사용합니다.
+        const res = await fetch(apiUrl, {
+            method: 'POST',
+            body: formData,
+        });
 
-        if (response.status >= 200 && response.status < 300) {
+        const status = res.status;
+        const responseData = await res.json().catch(() => ({}));
+
+        if (status >= 200 && status < 300) {
+            console.log('피드백 전송 성공!');
             return { success: true };
         } else {
-            console.error('피드백 전송 실패 (API 에러):', response.status, response.data);
+            console.error('피드백 전송 실패 (API 에러):', status, JSON.stringify(responseData));
             return { 
                 success: false, 
                 error: '전송 실패', 
-                detail: `Status: ${response.status}` 
+                detail: `Status: ${status}, Msg: ${responseData.error || 'Unknown'}` 
             };
         }
     } catch (error: any) {
-        // 상세 에러 로깅 (ProgressEvent 등인 경우에도 속성을 노출)
         console.error('피드백 전송 중 예외 발생:', error);
         
         let detail = 'Unknown Error';
         if (error instanceof Error) {
             detail = error.message;
         } else if (error && typeof error === 'object') {
-            try {
-                detail = JSON.stringify(error);
-            } catch (e) {
-                detail = 'Object (non-serializable)';
-            }
+            try { detail = JSON.stringify(error); } catch (e) { detail = 'Non-serializable object'; }
         }
 
         return { success: false, error: '시스템 오류', detail };


### PR DESCRIPTION
# PR: 피드백 전송 데이터 유실 수정 및 디버깅 강화

## 개요
네이티브 앱에서 서버로 `FormData` 전송 시 발생하던 데이터 누락 문제(Discord 50006 에러)를 해결하고, 서버/클라이언트 간 통신 가시성을 높였습니다.

## 변경 사항
- **통신 방식 변경**: `CapacitorHttp` 대신 표준 `fetch`를 사용하여 `FormData` 직렬화 안정성을 확보했습니다. (서버 측 리다이렉트 해결로 네이티브 fetch 사용 가능)
- **서버 로그 강화**: `NextResponse` 수신 시 모든 `FormData` 키를 로깅하여 데이터 도착 여부를 확인할 수 있게 했습니다.
- **예외 처리**: 필수 필드(`payload_json`) 누락 시 상세 사유를 포함한 400 에러를 응답하도록 개선했습니다.
- **클라이언트 로그**: API 에러 발생 시 서버가 보낸 실제 메시지를 로그에 출력하여 원인 파악을 용이하게 했습니다.

## 테스트 방법
1. 운영 서버에 `src/app/api/feedback/route.ts`의 변경 사항을 다시 배포합니다.
2. 앱에서 피드백을 전송하고, 실패 시 로그에 찍히는 `Msg: ...` 내용을 확인합니다.
3. 전송 성공 시 디스코드 채널에 임베드 메시지가 정상적으로 들어왔는지 확인합니다.
