### PR TITLE
fix: implement JSON-first feedback submission using CapacitorHttp for native bypass

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -22,47 +22,59 @@ export async function POST(req: NextRequest) {
     }
 
     try {
-        const formData = await req.formData()
-        const receivedKeys = Array.from(formData.keys())
-        console.log('Feedback API 수신 데이터 키:', receivedKeys)
+        const contentType = req.headers.get('content-type') || ''
+        let payloadValue: string | null = null
+        const files: { key: string, value: File }[] = []
+
+        if (contentType.includes('application/json')) {
+            const body = await req.json()
+            payloadValue = body.payload_json
+        } else {
+            const formData = await req.formData()
+            payloadValue = formData.get('payload_json') as string
+            
+            // 파일 필드 추출
+            for (const [key, value] of formData.entries()) {
+                if (key.startsWith('file') && value instanceof File) {
+                    files.push({ key, value })
+                }
+            }
+        }
 
         const webhookUrl = process.env.DISCORD_WEBHOOK_URL
-
         if (!webhookUrl) {
-            console.error('Discord Webhook URL이 설정되어 있지 않습니다.')
             return NextResponse.json(
-                { error: 'Server configuration error', detail: 'Discord Webhook URL is missing in server environment' }, 
+                { error: 'Server configuration error', detail: 'Discord Webhook URL is missing' }, 
                 { status: 500, headers: corsHeaders }
             )
         }
 
-        // 디스크로드로 보낼 새로운 FormData 구성 (Discord API 호환)
-        const discordFormData = new FormData()
-        
-        // payload_json 전달
-        const payloadValue = formData.get('payload_json')
-        if (payloadValue && typeof payloadValue === 'string') {
-            discordFormData.append('payload_json', payloadValue)
-        } else {
-            console.error('payload_json 필드가 없거나 문자열이 아닙니다.', receivedKeys)
+        if (!payloadValue || typeof payloadValue !== 'string') {
             return NextResponse.json(
-                { error: 'Invalid request data', detail: 'Missing or invalid payload_json field', keys: receivedKeys }, 
+                { error: 'Invalid request data', detail: 'payload_json is missing or invalid' }, 
                 { status: 400, headers: corsHeaders }
             )
         }
 
-        // 모든 파일 필드 찾아서 전달 (file0, file1, ...)
-        for (const [key, value] of formData.entries()) {
-            if (key.startsWith('file') && value instanceof File) {
-                discordFormData.append(key, value)
-            }
+        let response
+        if (files.length === 0) {
+            // 파일이 없으면 JSON 형식으로 디스크로드에 전송 (가장 안정적)
+            response = await fetch(webhookUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: payloadValue,
+            })
+        } else {
+            // 파일이 있으면 multipart/form-data 형식으로 전송
+            const discordFormData = new FormData()
+            discordFormData.append('payload_json', payloadValue)
+            files.forEach(f => discordFormData.append(f.key, f.value))
+            
+            response = await fetch(webhookUrl, {
+                method: 'POST',
+                body: discordFormData,
+            })
         }
-
-        // 디스크로드 Webhook 호출
-        const response = await fetch(webhookUrl, {
-            method: 'POST',
-            body: discordFormData,
-        })
 
         if (response.ok) {
             return NextResponse.json({ success: true }, { headers: corsHeaders })

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -55,15 +55,29 @@ export const sendBugReportToDiscord = async (data: BugReportData) => {
 
         console.log(`피드백 전송 시작 (${isNative ? 'Native' : 'Web'}): ${apiUrl}`);
 
-        // 리다이렉트와 CORS 문제가 해결되었으므로, 
-        // FormData를 가장 표준적으로 처리하는 fetch를 다시 사용합니다.
-        const res = await fetch(apiUrl, {
-            method: 'POST',
-            body: formData,
-        });
+        let status: number;
+        let responseData: any;
 
-        const status = res.status;
-        const responseData = await res.json().catch(() => ({}));
+        if (isNative) {
+            // 네이티브 환경에서는 CapacitorHttp를 사용하여 CORS를 우회하고 
+            // JSON 데이터를 직접 전송하여 FormData 직렬화 문제를 방지합니다.
+            const response = await CapacitorHttp.post({
+                url: apiUrl,
+                data: { payload_json: JSON.stringify(payload) },
+                headers: { 'Content-Type': 'application/json' }
+            });
+            status = response.status;
+            responseData = response.data;
+        } else {
+            // 웹 환경에서는 표준 fetch 사용
+            const res = await fetch(apiUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ payload_json: JSON.stringify(payload) }),
+            });
+            status = res.status;
+            responseData = await res.json().catch(() => ({}));
+        }
 
         if (status >= 200 && status < 300) {
             console.log('피드백 전송 성공!');


### PR DESCRIPTION
# PR: 피드백 전송 시스템 통합 해결 (JSON-first & Native Bypass)

## 개요
네이티브 앱 환경에서 발생하는 `ProgressEvent`, CORS, `FormData` 직렬화 문제를 근본적으로 해결하기 위해 통신 모델을 개선했습니다. 

## 주요 변경 사항

### 1. 클라이언트 전송 방식 혁신 (`src/utils/discord.ts`)
- **Native Bypass**: 네이티브 환경(Android/iOS)에서는 웹뷰의 `fetch` 대신 **`CapacitorHttp`**를 사용합니다. 이를 통해 웹뷰의 CORS 제약과 네트워크 레이어의 불안정성을 완전히 우회합니다.
- **JSON-first 통신**: `FormData` 대신 일반 JSON 객체를 전송하여 모바일 브라우저 엔진에서 발생할 수 있는 데이터 유실과 멀티파트 직렬화 오류를 차단했습니다.

### 2. 서버 수신 로직 유연화 (`src/app/api/feedback/route.ts`)
- **멀티 포맷 대응**: `application/json`과 `multipart/form-data`를 모두 자동으로 감지하고 파싱할 수 있게 고도화했습니다.
- **Discord 전송 최적화**: 첨부 파일이 없는 단순 피드백의 경우, 디스코드 Webhook으로도 즉시 JSON 전송을 시도하여 전송 시간을 단축하고 안정성을 높였습니다.

## 테스트 및 확인 사항
1. **운영 서버 배포**: 본 변경 사항을 Vercel에 가장 먼저 배포해야 합니다.
2. **앱 빌드**: `pnpm build:mobile && npx cap sync` 명령어로 앱을 빌드합니다.
3. **최종 확인**: 앱 실행 후 피드백을 전송하여 로그캣(Logcat)의 `피드백 전송 성공!` 메시지와 디스코드 채널의 수신 여부를 확인합니다.

## 관련 파일
- `src/app/api/feedback/route.ts`
- `src/utils/discord.ts`
