### PR TITLE
feat(itinerary): 체크리스트 스타일 통일 및 임박 일정 알림 추가

### DIFF
--- a/src/app/trips/checklist/ChecklistClient.tsx
+++ b/src/app/trips/checklist/ChecklistClient.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { analytics } from '@/services/AnalyticsService'
 import { css } from 'styled-system/css'
-import { Plus, CheckSquare, Square, Trash2, Settings, ChevronDown, Check, ListTodo, Users, User, Info, X, SortAsc, Clock, CheckCircle } from 'lucide-react'
+import { Plus, CheckSquare, Square, Trash2, Settings, ChevronDown, Check, ListTodo, Users, User, Info, X, SortAsc, Clock, CheckCircle, LayoutGrid, List } from 'lucide-react'
 import Link from 'next/link'
 import TemplateModal from '@/components/trips/TemplateModal'
 import { CacheUtil } from '@/utils/cache'
@@ -27,21 +27,22 @@ const SortDropdown = ({ sortBy, setSortBy }: any) => {
             <button 
                 onClick={() => setIsOpen(!isOpen)}
                 className={css({
-                    display: 'flex', alignItems: 'center', gap: '4px',
-                    bg: 'white', border: '1px solid #DDDDDD', borderRadius: '16px',
-                    px: '12px', py: '6px', fontSize: '12px', fontWeight: '700', color: '#555', cursor: 'pointer',
-                    transition: 'all 0.2s', _hover: { borderColor: '#999' }
+                    display: 'flex', alignItems: 'center', gap: '6px',
+                    bg: 'white', border: '1px solid #DDDDDD', borderRadius: '8px',
+                    px: '16px', h: '42px', fontSize: '13px', fontWeight: '800', color: '#222', cursor: 'pointer',
+                    transition: 'all 0.2s', _hover: { bg: '#F7F7F7', borderColor: '#222' },
+                    _active: { transform: 'scale(0.98)' }
                 })}
             >
                 {selected.icon}
                 <span className={css({ display: { base: 'none', sm: 'inline' } })}>{selected.label}</span>
-                <ChevronDown size={14} />
+                <ChevronDown size={14} className={css({ ml: '2px', color: '#888' })} />
             </button>
             {isOpen && (
                 <>
                     <div className={css({ position: 'fixed', inset: 0, zIndex: 10 })} onClick={() => setIsOpen(false)} />
                     <div className={css({
-                        position: 'absolute', top: '100%', right: 0, mt: '4px',
+                        position: 'absolute', top: '100%', left: 0, mt: '4px',
                         bg: 'white', border: '1px solid #eee', borderRadius: '12px',
                         boxShadow: '0 4px 16px rgba(0,0,0,0.1)', zIndex: 11, minW: '130px',
                         overflow: 'hidden'
@@ -73,32 +74,36 @@ const SortDropdown = ({ sortBy, setSortBy }: any) => {
 const CustomViewDropdown = ({ groupBy, setGroupBy }: any) => {
     const [isOpen, setIsOpen] = useState(false);
     const options = [
-        { value: 'category', label: '카테고리별 보기' },
-        { value: 'template', label: '템플릿별 보기' }
+        { value: 'category', label: '카테고리별 보기', icon: <LayoutGrid size={14} /> },
+        { value: 'template', label: '템플릿별 보기', icon: <List size={14} /> }
     ];
-    const currentLabel = options.find(o => o.value === groupBy)?.label || '카테고리별 보기';
+    const selected = options.find(o => o.value === groupBy) || options[0];
 
     return (
         <div className={css({ position: 'relative' })}>
             <button 
                 onClick={() => setIsOpen(!isOpen)}
                 className={css({
-                    display: 'flex', alignItems: 'center', gap: '4px',
-                    bg: 'white', border: '1px solid #3B82F6', borderRadius: '16px',
-                    px: '12px', py: '6px', fontSize: '12px', fontWeight: '700', color: '#3B82F6', cursor: 'pointer',
-                    boxShadow: '0 2px 8px rgba(16, 185, 129, 0.1)'
+                    display: 'flex', alignItems: 'center', gap: '6px',
+                    bg: 'white', border: '1px solid #DDDDDD', borderRadius: '8px',
+                    px: { base: '12px', sm: '16px' }, 
+                    h: '42px', 
+                    fontSize: '13px', fontWeight: '800', color: '#222', cursor: 'pointer',
+                    transition: 'all 0.2s', _hover: { bg: '#F7F7F7', borderColor: '#222' },
+                    _active: { transform: 'scale(0.98)' }
                 })}
             >
-                {currentLabel}
-                <ChevronDown size={14} />
+                {selected.icon}
+                <span className={css({ display: { base: 'none', sm: 'inline' } })}>{selected.label}</span>
+                <ChevronDown size={14} className={css({ ml: '2px', color: '#888' })} />
             </button>
             {isOpen && (
                 <>
                     <div className={css({ position: 'fixed', inset: 0, zIndex: 10 })} onClick={() => setIsOpen(false)} />
                     <div className={css({
-                        position: 'absolute', top: '100%', right: 0, mt: '4px',
+                        position: 'absolute', top: '100%', left: 0, mt: '4px',
                         bg: 'white', border: '1px solid #eee', borderRadius: '12px',
-                        boxShadow: '0 4px 16px rgba(0,0,0,0.1)', zIndex: 11, minW: '130px',
+                        boxShadow: '0 4px 16px rgba(0,0,0,0.1)', zIndex: 11, minW: '140px',
                         overflow: 'hidden'
                     })}>
                         {options.map(opt => (
@@ -106,14 +111,15 @@ const CustomViewDropdown = ({ groupBy, setGroupBy }: any) => {
                                 key={opt.value}
                                 onClick={() => { setGroupBy(opt.value); setIsOpen(false); }}
                                 className={css({
-                                    display: 'flex', alignItems: 'center', justifyContent: 'space-between', w: '100%', textAlign: 'left', px: '14px', py: '10px', fontSize: '13px',
+                                    display: 'flex', alignItems: 'center', gap: '8px', w: '100%', textAlign: 'left', px: '14px', py: '12px', fontSize: '13px',
                                     bg: groupBy === opt.value ? '#EFF6FF' : 'transparent',
                                     color: groupBy === opt.value ? '#3B82F6' : '#555',
                                     fontWeight: groupBy === opt.value ? '700' : '500',
                                     border: 'none', cursor: 'pointer', _hover: { bg: '#f9f9f9' }
                                 })}
                             >
-                                {opt.label}
+                                {opt.icon}
+                                <span className={css({ flex: 1, whiteSpace: 'nowrap' })}>{opt.label}</span>
                                 {groupBy === opt.value && <Check size={14} />}
                             </button>
                         ))}
@@ -836,67 +842,101 @@ export default function ChecklistPage({ isActive = true }: { isActive?: boolean 
                             totalItems > 0 && <span className={css({ color: 'brand.primary', ml: '8px' })}>{progressPercent}%</span>
                         )}
                     </h2>
-                    
-                    <div className={css({ display: 'flex', gap: '8px' })}>
-                        {totalItems > 0 && <SortDropdown sortBy={sortBy} setSortBy={setSortBy} />}
-                        {totalItems > 0 && <CustomViewDropdown groupBy={groupBy} setGroupBy={setGroupBy} />}
-                    </div>
                 </div>
 
                 {/* PC/모바일 분기 액션 버튼 및 필터 라인 */}
                 <div className={css({ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexDirection: { base: 'column', sm: 'row' }, gap: '16px' })}>
                     
-                    {/* PC 좌측: 보기 옵션 토글 */}
-                    <div className={css({ display: { base: 'none', sm: totalItems > 0 ? 'inline-flex' : 'none' }, bg: '#f1f3f4', p: '4px', borderRadius: '8px' })}>
-                        <button
-                            onClick={() => setGroupBy('category')}
-                            className={css({ px: '16px', py: '6px', fontSize: '14px', fontWeight: groupBy === 'category' ? 'bold' : 'normal', bg: groupBy === 'category' ? 'white' : 'transparent', color: groupBy === 'category' ? '#111' : '#666', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: groupBy === 'category' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', transition: 'all 0.2s' })}
-                        >
-                            카테고리별 보기
-                        </button>
-                        <button
-                            onClick={() => setGroupBy('template')}
-                            className={css({ px: '16px', py: '6px', fontSize: '14px', fontWeight: groupBy === 'template' ? 'bold' : 'normal', bg: groupBy === 'template' ? 'white' : 'transparent', color: groupBy === 'template' ? '#111' : '#666', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: groupBy === 'template' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', transition: 'all 0.2s' })}
-                        >
-                            템플릿별 보기
-                        </button>
+                    {/* PC 좌측: 그룹핑 + 정렬 컨트롤 그룹 */}
+                    <div className={css({ display: { base: 'none', sm: 'flex' }, alignItems: 'center', gap: '12px' })}>
+                        <div className={css({ display: totalItems > 0 ? 'inline-flex' : 'none', bg: '#f1f3f4', p: '4px', borderRadius: '8px' })}>
+                            <button
+                                onClick={() => setGroupBy('category')}
+                                className={css({ px: '16px', py: '6px', fontSize: '14px', fontWeight: groupBy === 'category' ? 'bold' : 'normal', bg: groupBy === 'category' ? 'white' : 'transparent', color: groupBy === 'category' ? '#111' : '#666', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: groupBy === 'category' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', transition: 'all 0.2s' })}
+                            >
+                                카테고리별 보기
+                            </button>
+                            <button
+                                onClick={() => setGroupBy('template')}
+                                className={css({ px: '16px', py: '6px', fontSize: '14px', fontWeight: groupBy === 'template' ? 'bold' : 'normal', bg: groupBy === 'template' ? 'white' : 'transparent', color: groupBy === 'template' ? '#111' : '#666', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: groupBy === 'template' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', transition: 'all 0.2s' })}
+                            >
+                                템플릿별 보기
+                            </button>
+                        </div>
+
+                        {totalItems > 0 && <SortDropdown sortBy={sortBy} setSortBy={setSortBy} />}
                     </div>
+
                     {/* PC에서 totalItems === 0 일 때 우측 버튼들을 오른쪽으로 밀기 위한 빈 공간용 div */}
                     {totalItems === 0 && <div className={css({ display: { base: 'none', sm: 'block' } })}></div>}
 
-                    {/* 모바일/PC 액션 버튼 */}
+                    {/* 액션 및 필터 컨트롤 그룹 (주로 모바일/PC 액션) */}
                     {isOnline && (
-                        <div className={css({ display: 'flex', gap: '8px', w: { base: '100%', sm: 'auto' }, flexWrap: 'nowrap' })}>
-                            {/* 항목 추가 버튼 (PC에서만 보임, 모바일은 하단 Sticky) */}
-                            <button
-                                onClick={() => setIsAdding(!isAdding)}
-                                className={css({
-                                    display: { base: 'none', sm: 'flex' }, alignItems: 'center', justifyContent: 'center', gap: '6px',
-                                    bg: '#222', color: 'white', px: '16px', py: '10px',
-                                    borderRadius: '8px', fontWeight: '800', fontSize: '14px', cursor: 'pointer', border: 'none',
-                                    _hover: { bg: '#000' }, whiteSpace: 'nowrap'
-                                })}
-                            >
-                                <Plus size={16} /> 항목 추가
-                            </button>
+                        <div className={css({ 
+                            display: 'flex', 
+                            flexDirection: { base: 'column', sm: 'row' },
+                            gap: '8px', 
+                            w: { base: '100%', sm: 'auto' },
+                            alignItems: { base: 'stretch', sm: 'center' }
+                        })}>
+                            {/* 모바일 전용 필터 및 액션 통합 행 (그룹핑 | 정렬 | 템플릿) */}
+                            <div className={css({ 
+                                display: { base: 'flex', sm: 'none' }, 
+                                gap: '8px',
+                                w: '100%',
+                                mb: '4px'
+                            })}>
+                                {totalItems > 0 && <CustomViewDropdown groupBy={groupBy} setGroupBy={setGroupBy} />}
+                                {totalItems > 0 && <SortDropdown sortBy={sortBy} setSortBy={setSortBy} />}
+                                
+                                <button
+                                    onClick={() => setIsTemplateModalOpen(true)}
+                                    className={css({
+                                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '5px',
+                                        px: '12px', h: '42px',
+                                        bg: 'white', color: '#222', border: '1px solid #DDDDDD', borderRadius: '8px',
+                                        fontSize: '13px', fontWeight: '800', cursor: 'pointer',
+                                        flex: '1',
+                                        whiteSpace: 'nowrap', transition: 'all 0.2s',
+                                        _hover: { bg: '#F7F7F7', borderColor: '#222' },
+                                        _active: { transform: 'scale(0.98)' }
+                                    })}
+                                >
+                                    <ListTodo size={14} /> 템플릿
+                                </button>
+                            </div>
 
-                            <button
-                                onClick={() => setIsTemplateModalOpen(true)}
-                                className={css({
-                                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '5px',
-                                    px: '16px', py: { base: '10px', sm: '10px' },
-                                    bg: 'white', color: '#222', border: '1px solid #DDDDDD', borderRadius: '8px',
-                                    fontSize: '13px', fontWeight: '800', cursor: 'pointer',
-                                    w: { base: '100%', sm: 'auto' }, flex: { base: 1, sm: 'none' },
-                                    flexShrink: 0,
-                                    whiteSpace: 'nowrap', transition: 'all 0.2s',
-                                    _hover: { bg: '#F7F7F7', borderColor: '#222' },
-                                    _active: { transform: 'scale(0.98)' }
-                                })}
-                            >
-                                <ListTodo size={15} />
-                                <span>템플릿 불러오기</span>
-                            </button>
+                            <div className={css({ display: { base: 'none', sm: 'flex' }, gap: '8px', w: { base: '100%', sm: 'auto' } })}>
+                                {/* 항목 추가 버튼 (PC에서만 보임, 모바일은 하단 Sticky) */}
+                                <button
+                                    onClick={() => setIsAdding(!isAdding)}
+                                    className={css({
+                                        display: { base: 'none', sm: 'flex' }, alignItems: 'center', justifyContent: 'center', gap: '6px',
+                                        bg: '#222', color: 'white', px: '16px', h: '42px',
+                                        borderRadius: '8px', fontWeight: '800', fontSize: '14px', cursor: 'pointer', border: 'none',
+                                        _hover: { bg: '#000' }, whiteSpace: 'nowrap'
+                                    })}
+                                >
+                                    <Plus size={16} /> 항목 추가
+                                </button>
+
+                                <button
+                                    onClick={() => setIsTemplateModalOpen(true)}
+                                    className={css({
+                                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '5px',
+                                        px: '16px', h: '42px',
+                                        bg: 'white', color: '#222', border: '1px solid #DDDDDD', borderRadius: '8px',
+                                        fontSize: '13px', fontWeight: '800', cursor: 'pointer',
+                                        w: { base: '100%', sm: 'auto' }, flex: { base: '1', sm: 'none' },
+                                        flexShrink: '0',
+                                        whiteSpace: 'nowrap', transition: 'all 0.2s',
+                                        _hover: { bg: '#F7F7F7', borderColor: '#222' },
+                                        _active: { transform: 'scale(0.98)' }
+                                    })}
+                                >
+                                    <ListTodo size={14} /> 템플릿 불러오기
+                                </button>
+                            </div>
                         </div>
                     )}
                 </div>

--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { css } from 'styled-system/css'
-import { Plus, UserPlus, Share2, ChevronDown, Check } from 'lucide-react'
+import { Plus, UserPlus, Share2, ChevronDown, Check, Clock } from 'lucide-react'
 import NewPlanModal from '@/components/trips/NewPlanModal'
 import CollaboratorModal from '@/components/trips/CollaboratorModal'
 import ShareModal from '@/components/trips/ShareModal'
@@ -24,26 +24,27 @@ const CustomTimeDropdown = ({ timeDisplayMode, setTimeDisplayMode }: any) => {
     const currentLabel = options.find(o => o.value === timeDisplayMode)?.label || '현지 시간';
 
     return (
-        <div className={css({ position: 'relative', display: { base: 'block', sm: 'none' } })}>
+        <div className={css({ position: 'relative' })}>
             <button 
                 onClick={() => setIsOpen(!isOpen)}
                 className={css({
                     display: 'flex', alignItems: 'center', gap: '4px',
-                    bg: 'white', border: '1px solid #3B82F6', borderRadius: '16px',
-                    px: '12px', py: '6px', fontSize: '12px', fontWeight: '700', color: '#3B82F6', cursor: 'pointer',
-                    boxShadow: '0 2px 8px rgba(16, 185, 129, 0.1)'
+                    bg: 'white', border: '1px solid #DDDDDD', borderRadius: '8px',
+                    px: '12px', h: '42px', fontSize: '13px', fontWeight: '800', color: '#222', cursor: 'pointer',
+                    transition: 'all 0.2s', _active: { transform: 'scale(0.95)' }
                 })}
             >
-                {currentLabel}
-                <ChevronDown size={14} />
+                <Clock size={14} className={css({ color: '#888' })} />
+                <span className={css({ whiteSpace: 'nowrap' })}>{currentLabel}</span>
+                <ChevronDown size={14} className={css({ color: '#888' })} />
             </button>
             {isOpen && (
                 <>
                     <div className={css({ position: 'fixed', inset: 0, zIndex: 10 })} onClick={() => setIsOpen(false)} />
                     <div className={css({
-                        position: 'absolute', top: '100%', right: 0, mt: '4px',
+                        position: 'absolute', top: '100%', left: 0, mt: '4px',
                         bg: 'white', border: '1px solid #eee', borderRadius: '12px',
-                        boxShadow: '0 4px 16px rgba(0,0,0,0.1)', zIndex: 11, minW: '110px',
+                        boxShadow: '0 4px 16px rgba(0,0,0,0.1)', zIndex: 11, minW: '120px',
                         overflow: 'hidden'
                     })}>
                         {options.map(opt => (
@@ -234,64 +235,96 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
         fetchPlans()
     }
 
+    // 24시간 이내 가장 가까운 일정 계산
+    const nextPlanInfo = useMemo(() => {
+        const now = new Date()
+        const upcoming = plans
+            .map(p => ({ ...p, startTime: new Date(p.start_datetime_local) }))
+            .filter(p => p.startTime > now)
+            .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
+
+        if (upcoming.length > 0) {
+            const diffMs = upcoming[0].startTime.getTime() - now.getTime()
+            const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
+            const diffMinutes = Math.floor(diffMs / (1000 * 60))
+
+            if (diffHours < 24) {
+                if (diffHours >= 1) return `다음 일정까지 ${diffHours}시간 전`
+                return `다음 일정까지 ${diffMinutes}분 전`
+            }
+        }
+        return null
+    }, [plans])
+
     return (
         <div className={css({ bg: 'white', p: { base: '12px', sm: '24px' }, pb: { base: '80px', sm: '24px' }, borderRadius: '16px', boxShadow: '0 4px 12px rgba(0,0,0,0.03)' })}>
             <div className={css({ display: 'flex', justifyContent: 'space-between', alignItems: { base: 'center', sm: 'flex-start' }, mb: { base: '16px', sm: '24px' }, flexDirection: { base: 'column', sm: 'row' }, gap: '16px' })}>
-                {/* 1. 타이틀 & 시간 필터 */}
-                <div className={css({ display: 'flex', w: { base: '100%', sm: 'auto' }, justifyContent: 'space-between', alignItems: { base: 'center', sm: 'flex-start' }, flexDirection: { base: 'row', sm: 'column' } })}>
-                    <h2 className={css({ fontSize: { base: '18px', sm: '20px' }, fontWeight: 'bold', mb: { base: 0, sm: '12px' } })}>여정 채워가기</h2>
+                {/* 1. 요약 정보 영역 (PC/모바일 공통) */}
+                <div className={css({ display: 'flex', alignItems: 'center', gap: '8px' })}>
+                    <h2 className={css({ fontSize: { base: '18px', sm: '20px' }, fontWeight: 'bold', color: '#222' })}>
+                        {nextPlanInfo ? (
+                            <>
+                                <span className={css({ color: '#FF4D4F' })}>●</span> {nextPlanInfo}
+                            </>
+                        ) : (
+                            <>
+                                전체 일정 <span className={css({ color: '#666', fontWeight: 'normal', ml: '4px' })}>{plans.length}개</span>
+                            </>
+                        )}
+                    </h2>
+                </div>
 
+                {/* 2. 컨트롤 영역 (PC 시간 토글 & 모바일 액션 버튼 그룹) */}
+                <div className={css({ 
+                    display: 'flex', flexDirection: { base: 'column', sm: 'row' }, alignItems: { base: 'flex-start', sm: 'center' },
+                    gap: '12px', w: { base: '100%', sm: 'auto' } 
+                })}>
                     {/* PC 전용 시간 표시 옵션 토글 */}
-                    <div className={css({ display: { base: 'none', sm: 'inline-flex' }, bg: '#f1f3f4', p: '2px', borderRadius: '8px', gap: '2px', w: 'auto' })}>
+                    <div className={css({ display: { base: 'none', sm: 'inline-flex' }, bg: '#f1f3f4', p: '2px', borderRadius: '8px', gap: '2px', w: 'auto', h: '42px', alignItems: 'center' })}>
                         <button
                             onClick={() => setTimeDisplayMode('local')}
-                            className={css({ flex: 'none', px: '12px', py: '6px', fontSize: '12px', fontWeight: timeDisplayMode === 'local' ? 'bold' : 'normal', bg: timeDisplayMode === 'local' ? 'white' : 'transparent', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: timeDisplayMode === 'local' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', color: '#172554', whiteSpace: 'nowrap' })}
+                            className={css({ h: '38px', px: '16px', fontSize: '13px', fontWeight: timeDisplayMode === 'local' ? '800' : '500', bg: timeDisplayMode === 'local' ? 'white' : 'transparent', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: timeDisplayMode === 'local' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', color: '#222', whiteSpace: 'nowrap', transition: 'all 0.2s' })}
                         >
                             현지 시간
                         </button>
                         <button
                             onClick={() => setTimeDisplayMode('kst')}
-                            className={css({ flex: 'none', px: '12px', py: '6px', fontSize: '12px', fontWeight: timeDisplayMode === 'kst' ? 'bold' : 'normal', bg: timeDisplayMode === 'kst' ? 'white' : 'transparent', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: timeDisplayMode === 'kst' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', color: '#172554', whiteSpace: 'nowrap' })}
+                            className={css({ h: '38px', px: '16px', fontSize: '13px', fontWeight: timeDisplayMode === 'kst' ? '800' : '500', bg: timeDisplayMode === 'kst' ? 'white' : 'transparent', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: timeDisplayMode === 'kst' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', color: '#222', whiteSpace: 'nowrap', transition: 'all 0.2s' })}
                         >
                             한국 시간
                         </button>
                         <button
                             onClick={() => setTimeDisplayMode('both')}
-                            className={css({ flex: 'none', px: '12px', py: '6px', fontSize: '12px', fontWeight: timeDisplayMode === 'both' ? 'bold' : 'normal', bg: timeDisplayMode === 'both' ? 'white' : 'transparent', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: timeDisplayMode === 'both' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', color: '#172554', whiteSpace: 'nowrap' })}
+                            className={css({ h: '38px', px: '16px', fontSize: '13px', fontWeight: timeDisplayMode === 'both' ? '800' : '500', bg: timeDisplayMode === 'both' ? 'white' : 'transparent', borderRadius: '6px', border: 'none', cursor: 'pointer', boxShadow: timeDisplayMode === 'both' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none', color: '#222', whiteSpace: 'nowrap', transition: 'all 0.2s' })}
                         >
                             동시 표기
                         </button>
                     </div>
 
-                    {/* 모바일 전용 시간 표시 드롭다운 */}
-                    <CustomTimeDropdown timeDisplayMode={timeDisplayMode} setTimeDisplayMode={setTimeDisplayMode} />
-                </div>
-
-                {/* 2. 버튼 영역: 모바일 1줄(flex/order), PC 다단구조 */}
-                <div className={css({ 
-                    display: 'flex', flexDirection: { base: 'row', sm: 'column' }, alignItems: { base: 'center', sm: 'flex-start' },
-                    gap: '8px', w: { base: '100%', sm: 'auto' } 
-                })}>
                     <div className={css({ 
-                        display: 'flex', gap: '8px', flexShrink: 0, w: { base: 'auto', sm: '100%' },
-                        order: { base: 1, sm: -1 } 
+                        display: 'flex', gap: '8px', w: '100%', alignItems: 'center'
                     })}>
+                        {/* 모바일 전용 시간 드롭다운 (고정 너비) */}
+                        <div className={css({ display: { base: 'block', sm: 'none' }, flexShrink: 0, w: '115px' })}>
+                            <CustomTimeDropdown timeDisplayMode={timeDisplayMode} setTimeDisplayMode={setTimeDisplayMode} />
+                        </div>
+
                         <button
                             onClick={() => setIsCollaboratorModalOpen(true)}
                             className={css({
                                 display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px',
                                 bg: 'white', color: '#222',
-                                px: { base: '0', sm: '12px' }, w: { base: '44px', sm: 'auto' }, h: '44px',
+                                px: '12px', h: '42px',
                                 borderRadius: '8px', fontWeight: '800', fontSize: '13px',
                                 border: '1px solid #DDDDDD', whiteSpace: 'nowrap',
                                 transition: 'all 0.2s',
                                 _hover: { bg: '#F7F7F7' }, _active: { transform: 'scale(0.92)' },
                                 opacity: !isOnline ? 0.5 : 1, cursor: !isOnline ? 'not-allowed' : 'pointer',
-                                flex: { base: 'none', sm: 1 }
+                                flex: 1
                             })}
                             disabled={!isOnline}
                         >
-                            <UserPlus size={16} /> <span className={css({ display: { base: 'none', sm: 'inline' } })}>동행자</span>
+                            <UserPlus size={16} /> <span>동행자</span>
                         </button>
                         {userRole === 'owner' && (
                             <button
@@ -299,28 +332,29 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
                                 className={css({
                                     display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px',
                                     bg: 'white', color: '#222',
-                                    px: { base: '0', sm: '12px' }, w: { base: '44px', sm: 'auto' }, h: '44px',
+                                    px: '12px', h: '42px',
                                     borderRadius: '8px', fontWeight: '800', fontSize: '13px',
                                     border: '1px solid #DDDDDD', whiteSpace: 'nowrap',
                                     transition: 'all 0.2s',
                                     _hover: { bg: '#F7F7F7' }, _active: { transform: 'scale(0.92)' },
                                     opacity: !isOnline ? 0.5 : 1, cursor: !isOnline ? 'not-allowed' : 'pointer',
-                                    flex: { base: 'none', sm: 1 }
+                                    flex: 1
                                 })}
                                 disabled={!isOnline}
                             >
-                                <Share2 size={16} /> <span className={css({ display: { base: 'none', sm: 'inline' } })}>공유</span>
+                                <Share2 size={16} /> <span>공유</span>
                             </button>
                         )}
+
                     </div>
-                    {/* PC 전용 일정 추가 버튼 (모바일에서는 Sticky CTA로 대체됨) */}
+                    
+                    {/* PC 전용 일정 추가 버튼 */}
                     {(userRole === 'owner' || userRole === 'editor') && isOnline && (
                         <button
                             onClick={() => { setEditingPlan(null); setIsModalOpen(true) }}
                             className={css({
                                 display: { base: 'none', sm: 'flex' },
-                                order: { base: -1, sm: 1 },
-                                flex: { base: 1, sm: 'none' }, w: { base: 'auto', sm: '100%' }, h: '44px',
+                                w: '100%', h: '42px',
                                 alignItems: 'center', justifyContent: 'center', gap: '6px',
                                 bg: '#222', color: 'white', px: '16px', borderRadius: '8px',
                                 fontWeight: '800', fontSize: '15px', cursor: 'pointer', border: 'none', whiteSpace: 'nowrap',


### PR DESCRIPTION
Resolves #81

체크리스트의 디자인 시스템을 일정표 탭에도 적용하고 모바일 사용성을 대폭 개선했습니다.

### 주요 변경 사항
- **디자인 통일**: 모든 버튼과 드롭다운에 8px 곡률, 42px 높이, 회색 테두리(#DDDDDD) 디자인을 적용하여 UI 일관성을 확보했습니다.
- **모바일 최적화**: 
  - [현지 시간] [동행자] [공유]를 한 줄에 배치하여 공간을 절약했습니다.
  - 모바일에서도 버튼 텍스트를 노출하여 직관성을 높였습니다.
  - FAB와 중복되는 상단 '일정 추가' 버튼을 제거했습니다.
- **동적 가이드**: 24시간 이내에 예정된 일정이 있을 경우 "다음 일정까지 N시간 전"이라는 안내를 상단 요약 영역에 노출합니다.
- **레이아웃 정리**: 불필요한 "여행 일정표" 타이틀을 제거하고 버튼 그룹을 전진 배치하여 미니멀한 룩을 구현했습니다.