### PR TITLE
fix(ios): resolve NSNotification.Name member error (#104)

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -48,11 +48,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+        NotificationCenter.default.post(name: Notification.Name("capacitorDidRegisterForRemoteNotifications"), object: deviceToken)
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+        NotificationCenter.default.post(name: Notification.Name("capacitorDidFailToRegisterForRemoteNotifications"), object: error)
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
@@ -60,7 +60,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        NotificationCenter.default.post(name: .capacitorDidReceiveNotificationResponse, object: response)
+        NotificationCenter.default.post(name: Notification.Name("capacitorDidReceiveNotificationResponse"), object: response)
         completionHandler()
     }
 


### PR DESCRIPTION
### Resolves #104

**Capacitor 6/7/8** 및 **Swift Package Manager (SPM)** 환경에서 iOS `AppDelegate.swift`에 발생하는 `NSNotification.Name` 참조 오류를 해결합니다.

#### 주요 변경 사항
- `Notification.Name` 확장 멤버 대신 명시적 문자열 생성자(`Notification.Name("...")`)를 사용하도록 변경하여 Swift 컴파일러의 식별 오류를 방지했습니다.
- 대상 이벤트:
  - `capacitorDidRegisterForRemoteNotifications`
  - `capacitorDidFailToRegisterForRemoteNotifications`
  - `capacitorDidReceiveNotificationResponse`

#### 재현 및 확인
- 사용자의 로컬 빌드 환경(Xcode)에서 해당 컴파일 에러 발생 확인.
- 수정 후 빌드 통과 여부 확인 (사용자 수동 검증 예정).
