### PR TITLE
docs: AI 가이드 구축 및 프로젝트 명칭 통일 (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-# ✈️ Next Voyage (nexvoy-frontend)
+# ✈️ OnVoy (nexvoy-frontend)
 
-**Next Voyage**는 복잡한 여행 계획을 한눈에 정리하고, 현지 시간과 체크리스트를 스마트하게 관리할 수 있도록 돕는 프리미엄 여행 플래너 웹 앱입니다.
+**OnVoy**는 복잡한 여행 계획을 한눈에 정리하고, 현지 시간과 체크리스트를 스마트하게 관리할 수 있도록 돕는 프리미엄 여행 플래너 웹 앱입니다.
 
-![Next Voyage UI Mockup](https://via.placeholder.com/800x400.png?text=Next+Voyage+Smart+Travel+Planner) *<!-- 실제 이미지가 있다면 교체 가능 -->*
+![OnVoy UI Mockup](https://via.placeholder.com/800x400.png?text=OnVoy+Smart+Travel+Planner) *<!-- 실제 이미지가 있다면 교체 가능 -->*
+
+## 🤖 AI 어시스턴트를 위한 가이드 (For AI Assistants)
+
+이 프로젝트는 AI 코딩 어시스턴트(Antigravity 등)와의 협업을 적극적으로 지향합니다. AI 어시스턴트는 작업을 시작하기 전 반드시 다음 문서를 확인하십시오.
+
+- **[상세 AI 가이드 (AI Guide)](file:///Users/ysjee141/mySources/travel-pack/docs/ai-guide/README.md)**: 코딩 표준, 아키텍처, **표준 개발 프로세스**가 명시되어 있습니다.
+
+> [!IMPORTANT]
+> 모든 개발 작업은 `.agents/workflows/standard-dev-flow.md`에 정의된 프로세스를 엄격히 따라야 합니다.
 
 ## ✨ 주요 기능 (Key Features)
 
@@ -10,13 +19,12 @@
 - **🌍 현지 시간 자동 계산**: Google Maps API와 연동하여 여행지의 타임존을 자동으로 파악하고, 한국 시간과 현지 시간을 동시에 확인하며 계획을 세울 수 있습니다.
 - **✅ 스마트 체크리스트**: 카테고리별/템플릿별 그룹화 기능을 제공하며, 준비물 진행률을 프로그레스 바를 통해 실시간으로 확인합니다.
 - **📋 템플릿 관리**: 자주 사용하는 준비물 리스트를 템플릿으로 저장하고, 새로운 여행에 한 번의 클릭으로 불러올 수 있습니다.
-- **🔔 브라우저 알림 (Push Notifications)**: 설정한 일정 시간 전에 브라우저 푸시 알림을 통해 다음 일정을 놓치지 않게 도와줍니다. (Service Worker 기반)
 - **👤 마이페이지 & 프로필**: 닉네임 수정, 비밀번호 변경 및 나의 여행 통계 데이터를 확인할 수 있습니다.
 
 ## 🛠 기술 스택 (Tech Stack)
 
 ### **Frontend**
-- **Framework**: [Next.js 15 (App Router)](https://nextjs.org/)
+- **Framework**: [Next.js 16 (App Router)](https://nextjs.org/)
 - **Styling**: [Panda CSS](https://panda-css.com/) (Atomic CSS-in-JS)
 - **State Management**: [Zustand](https://docs.pmnd.rs/zustand/getting-started/introduction)
 - **Icons**: [Lucide React](https://lucide.dev/)
@@ -25,6 +33,9 @@
 ### **Backend & Infrastructure**
 - **BaaS**: [Supabase](https://supabase.com/) (Auth, Database, RLS)
 - **External API**: [Google Maps API](https://developers.google.com/maps) (Places, Time Zone)
+
+### **Native Mobile**
+- **Framework**: [Capacitor](https://capacitorjs.com/) (iOS, Android Support)
 
 ## 🚀 시작하기 (Getting Started)
 
@@ -47,10 +58,10 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
 ```bash
 pnpm dev
 ```
-이제 [http://localhost:3000](http://localhost:3000)에서 Next Voyage를 확인하실 수 있습니다.
+이제 [http://localhost:3000](http://localhost:3000)에서 OnVoy를 확인하실 수 있습니다.
 
 ## 📱 반응형 디자인
-Next Voyage는 모바일 우선주의(Mobile-First) 원칙에 따라 설계되었습니다. iPhone SE부터 대화면 데스크톱까지 모든 해상도에서 최적화된 UI/UX를 제공합니다.
+OnVoy는 모바일 우선주의(Mobile-First) 원칙에 따라 설계되었습니다. Web뿐만 아니라 Capacitor를 통해 iOS 및 Android 네이티브 앱 환경도 지원하며 모든 해상도에서 최적화된 UI/UX를 제공합니다.
 
 ---
-Next Voyage와 함께 더 편리하고 즐거운 여행을 계획해 보세요! 🗺️🧳
+OnVoy와 함께 더 편리하고 즐거운 여행을 계획해 보세요! 🗺️🧳

--- a/docs/ai-guide/README.md
+++ b/docs/ai-guide/README.md
@@ -1,0 +1,32 @@
+# 🤖 OnVoy AI 가이드 (AI Guide)
+
+이 가이드는 **OnVoy** 프로젝트에 참여하는 AI 코딩 어시스턴트(Antigravity 등)를 위한 기술 문서입니다. 프로젝트의 구조, 코딩 스타일, 그리고 가장 중요한 **표준 개발 프로세스**를 정의합니다.
+
+> [!IMPORTANT]
+> 모든 AI 어시스턴트는 작업을 시작하기 전 본 문서를 숙지해야 하며, 특히 **표준 개발 프로세스**를 엄격히 준수해야 합니다.
+
+## 📚 문서 목차
+
+1.  **[가이드 개요 및 프로젝트 소개](file:///Users/ysjee141/mySources/travel-pack/docs/ai-guide/README.md)** (현재 문서)
+2.  **[코딩 표준 및 스타일 가이드](file:///Users/ysjee141/mySources/travel-pack/docs/ai-guide/coding-standards.md)**: Panda CSS, Next.js App Router, TypeScript 규칙.
+3.  **[아키텍처 및 핵심 워크플로우](file:///Users/ysjee141/mySources/travel-pack/docs/ai-guide/architecture.md)**: 프로젝트 구조 및 **표준 개발 프로세스** 상세 설명.
+4.  **[Supabase 활용 가이드](file:///Users/ysjee141/mySources/travel-pack/docs/ai-guide/supabase-guide.md)**: 인증, 데이터베이스 인터페이스, RLS 정책.
+5.  **[Capacitor 및 모바일 개발 가이드](file:///Users/ysjee141/mySources/travel-pack/docs/ai-guide/capacitor-guide.md)**: 네이티브 기능 연동 및 모바일 빌드 프로세스.
+
+## 🚀 온보딩 (Onboarding for AI)
+
+이 프로젝트에서 작업을 수행할 때 반드시 다음 단계를 거치십시오:
+
+1.  **컨텍스트 이해**: `README.md`와 본 가이드를 읽고 OnVoy의 목적과 기술 스택을 파악합니다.
+2.  **워크플로우 준수**: `.agents/workflows/standard-dev-flow.md`에 정의된 **표준 개발 프로세스**를 모든 작업의 기본으로 삼습니다.
+    - 리서치 -> 구현 계획(Implementation Plan) -> 작업 리스트(Task List) -> 검증 -> Walkthrough -> PR 생성.
+3.  **코드 품질**: Panda CSS를 사용한 원자적 디자인(Atomic Design)을 지향하며, 타입 안정성을 최우선으로 합니다.
+
+## 🛠 주요 기술 스택 일람
+
+- **Core**: Next.js 16 (App Router), React 19
+- **Styling**: Panda CSS
+- **State**: Zustand
+- **Backend/Auth**: Supabase (Auth, PostgreSQL, Storage, RLS)
+- **Native**: Capacitor (iOS, Android)
+- **Monitoring**: Sentry

--- a/docs/ai-guide/architecture.md
+++ b/docs/ai-guide/architecture.md
@@ -1,0 +1,51 @@
+# 🏗️ OnVoy 프로젝트 구조 및 아키텍처
+
+OnVoy의 효율적인 개발과 유지보수를 위해 AI 어시스턴트가 반드시 숙지해야 할 프로젝트 구조와 워크플로우를 설명합니다.
+
+## 1. 📂 폴더 구조 안내
+
+```text
+/
+├── .agents/          # AI를 위한 워크플로우 정의 (중요!)
+├── docs/             # 프로젝트 문서 (현재 문서 포함)
+├── src/              # 소스 코드 메인 디렉토리
+│   ├── app/          # Next.js App Router (Page, Layout)
+│   ├── components/   # UI 공통 컴포넌트
+│   ├── hooks/        # 커스텀 React Hooks
+│   ├── services/     # 외부 API 및 Supabase 통신 로직 (중앙화)
+│   ├── stores/       # Zustand 상태 저장소
+│   ├── utils/        # 공통 유틸리티 함수
+│   └── assets/       # 이미지, 아이콘 등 정적 자산
+├── supabase/         # Supabase 마이그레이션 및 설정
+├── android/          # Capacitor 기반 Android 네이티브 프로젝트
+└── ios/              # Capacitor 기반 iOS 네이티브 프로젝트
+```
+
+## 2. 🔄 핵심 워크플로우 (중요!)
+
+사용자의 피드백에 따라 **표준 개발 프로세스(Standard Dev Flow)**를 가장 우선적으로 준수해야 합니다.
+
+### [필독] 표준 개발 프로세스
+이 프로세스는 `/Users/ysjee141/mySources/travel-pack/.agents/workflows/standard-dev-flow.md` 에 상세히 명시되어 있으며, AI는 모든 작업 시 이를 **절대적으로 준수**해야 합니다.
+
+1.  **리서치(Research)**: `view_file` 등을 통해 관련 코드와 문서를 충분히 분석합니다.
+2.  **구현 계획(Implementation Plan)**: `implementation_plan.md` 아티팩트를 작성하고 사용자의 승인을 받습니다. (필수!)
+3.  **작업 리스트(Task List)**: `task.md` 에 작업 항목을 나열하고 진행 상황(`[/]`, `[x]`)을 실시간으로 업데이트합니다.
+4.  **검증(Verification)**: 빌드 확인(`pnpm build`, `pnpm build:mobile`) 및 기능 테스트를 수행합니다.
+5.  **마무리(Walkthrough)**: `walkthrough.md` 를 작성하여 변경 사항을 요약하고 보고합니다.
+
+> [!CAUTION]
+> 위 프로세스를 누락하는 것은 작업의 실패로 간주됩니다. 특히 **구현 계획 승인** 단계를 절대 건너뛰지 마십시오.
+
+## 3. 🧠 상태 관리 전략 (Zustand)
+
+- **UI Store**: 모달, 사이드바 등 UI의 전역 상태를 관리합니다.
+- **Data Store**: 네트워크 상태, 사용자 프로필 정보 등 비즈니스 데이터를 관리합니다.
+- **Persistence**: 필요한 경우 `zustand/middleware`의 `persist` 기능을 사용하여 브라우저 저장소(LocalStorage)에 데이터를 유지합니다.
+
+## 4. 🌐 플랫폼 아키텍처
+
+OnVoy는 하나의 코드베이스로 웹과 모바일을 동시에 지원합니다.
+- **Web**: Next.js App Router 기반의 풀 렌더링.
+- **Native (Capacitor)**: 웹 뷰를 감싸는 하이브리드 방식.
+- **Bridge**: `CapacitorHttp` 등을 통해 네이티브 기능을 호출하며, 웹환경과 네이티브 환경의 차이를 서비스 레이어(`src/services`)에서 추상화합니다.

--- a/docs/ai-guide/capacitor-guide.md
+++ b/docs/ai-guide/capacitor-guide.md
@@ -1,0 +1,55 @@
+# 📱 Capacitor 및 모바일 개발 가이드
+
+OnVoy의 하이브리드 앱 환경인 Capacitor를 다루기 위한 AI 지침입니다.
+
+## 1. ⚙️ 플랫폼 정보 및 설정
+
+- **App ID**: `xyz.nexvoy.app`
+- **프로젝트 명칭**: `OnVoy`
+- **빌드 방식**: Next.js의 정적 내보내기(`next export` → `out` 폴더)를 Capacitor가 로드합니다.
+
+## 2. 🧩 주요 Capacitor 플러그인
+
+- **CapacitorHttp**: 기본 `fetch` 대신 네이티브 HTTP 라이브러리를 사용하여 CORS 문제를 우회하고 성능을 높입니다.
+- **CapacitorUpdater**: OTA(Over-The-Air) 업데이트 기능을 위해 `@capgo/capacitor-updater`를 사용합니다.
+- **SplashScreen**: 앱 기동 시 스플래시 화면 제어.
+- **Push Notifications**: `@capacitor/push-notifications`를 통한 푸시 알림 연동.
+
+## 3. 🛠 모바일 전용 빌드 프로세스
+
+모바일 앱 배포를 위해 반드시 다음 워크플로우를 숙지하십시오.
+
+### pnpm build:mobile
+이 명령어는 다음과 같은 작업을 수행합니다:
+1.  API, Auth 등 모바일 환경에서 불필요한 서버 측 기능을 임시로 격리합니다.
+2.  `BUILD_TARGET=mobile` 환경 변수와 함께 `next build`를 실행하여 정적 자산을 생성합니다.
+3.  생성된 `out` 폴더를 Capacitor 네이티브 폴더로 동기화할 준비를 합니다.
+
+```bash
+# 모바일 빌드 실행
+pnpm build:mobile
+
+# 결과물 동기화
+npx cap sync
+```
+
+## 4. 💻 플랫폼별 분기 로직
+
+코드 내에서 웹과 네이티브를 구분해야 하는 경우 다음 패턴을 사용합니다.
+
+```tsx
+import { Capacitor } from '@capacitor/core';
+
+if (Capacitor.isNativePlatform()) {
+  // 모바일 네이티브 환경 전용 로직
+  // (예: StatusBar 설정, Native Share 호출 등)
+} else {
+  // 일반적인 웹 브라우저 환경
+}
+```
+
+## 5. 🤖 AI 주의 사항
+
+1.  **CORS 주의**: 모바일 앱 환경에서는 브라우저와 다른 CORS 정책이 적용됩니다. `src/services`에서 외부 통신 시 `CapacitorHttp`가 적절히 구성되어 있는지 확인하십시오.
+2.  **Asset 경로**: 모든 이미지나 정적 자산의 경로는 정적 빌드 후에도 깨지지 않도록 절대 경로 혹은 적절한 자산 관리 방식을 사용해야 합니다.
+3.  **네이티브 UI**: 모바일 환경에서는 `Safe Area`를 고려한 레이아웃이 필요합니다. 상단 노치나 하단 네비게이션 영역이 UI를 가리지 않도록 Panda CSS 유틸리티를 활용하십시오.

--- a/docs/ai-guide/coding-standards.md
+++ b/docs/ai-guide/coding-standards.md
@@ -1,0 +1,58 @@
+# 🎨 OnVoy 코딩 표준 및 스타일 가이드
+
+OnVoy 프로젝트의 코딩 스타일을 유지하기 위해 AI 어시스턴트가 준수해야 할 핵심 지침입니다.
+
+## 1. 스타일링 가이드: Panda CSS
+
+본 프로젝트는 [Panda CSS](https://panda-css.com/)를 사용하여 스타일을 관리합니다.
+
+### 핵심 원칙
+- **Utility-First**: 인라인 스타일 대신 Panda CSS의 스타일 유틸리티를 사용합니다.
+- **Tokens 사용**: `panda.config.ts` 에 정의된 브랜드 토큰을 우선적으로 사용하십시오.
+  - colors: `brand.primary`, `brand.primaryDark`, `brand.secondary`, `brand.accent` 등.
+  - shadows: `airbnb`, `floating`, `dimensional` 등.
+- **반응형 디자인**: `base`, `sm`, `md`, `lg`, `xl` 등 표준 중단점을 활용하십시오.
+
+### 코드 예시
+```tsx
+import { css } from '../../styled-system/css';
+
+export const Button = () => (
+  <button className={css({
+    bg: 'brand.primary',
+    color: 'white',
+    px: '4',
+    py: '2',
+    borderRadius: 'md',
+    boxShadow: 'floating',
+    cursor: 'pointer',
+    _hover: { bg: 'brand.primaryDark' },
+    _active: { transform: 'scale(0.98)' }
+  })}>
+    여행 시작하기
+  </button>
+);
+```
+
+## 2. React & Next.js 가이드
+
+### App Router 활용
+- **서버 컴포넌트(Server Components)**: 기본적으로 모든 컴포넌트는 서버 컴포넌트로 작성합니다. 데이터 패칭과 SEO가 필요한 페이지의 경우 필수입니다.
+- **클라이언트 컴포넌트(Client Components)**: 인터랙션(Button Click, Form Input, Hooks usage)이 필요한 경우에만 상단에 `'use client'` 지침을 추가하여 최소한으로 사용합니다.
+
+### 컴포넌트 구조
+- `src/components`: 재사용 가능한 UI 컴포넌트를 위치합니다.
+- `src/app`: 라우팅 구조를 따르며, 각 페이지의 `page.tsx`와 레이아웃을 관리합니다.
+
+## 3. TypeScript 규칙
+
+- **엄격한 타입 선언**: `any` 사용을 엄격히 금지합니다.
+- **Interface vs Type**: 객체의 구조를 정의할 때는 확장이 용이한 `interface`를 우선적으로 사용합니다. 유니온 타입이나 교차 타입이 필요한 경우에만 `type`을 사용합니다.
+- **Zustand Store 타입**: 스토어의 상태와 액션을 명확히 분리하여 정의합니다.
+
+## 4. 파일 네이밍 및 경로
+
+- **컴포넌트**: `PascalCase.tsx` (예: `PrimaryButton.tsx`)
+- **훅**: `useCamelCase.ts` (예: `useChecklist.ts`)
+- **유틸리티/서비스**: `camelCase.ts` (예: `supabaseClient.ts`)
+- **경로**: 절대 경로 별칭(alias)을 적극 활용합니다 (예: `@/components/...`).

--- a/docs/ai-guide/supabase-guide.md
+++ b/docs/ai-guide/supabase-guide.md
@@ -1,0 +1,35 @@
+# ☁️ OnVoy Supabase 활용 가이드
+
+OnVoy의 백엔드 인프라인 Supabase를 효과적으로 활용하기 위한 AI 지침입니다.
+
+## 1. 📂 클라이언트 및 서버 설정
+
+프로젝트는 `@supabase/ssr` 패키지를 사용하여 서버와 클라이언트 환경에 맞는 인스턴스를 생성합니다.
+
+- **브라우저 환경**: `src/utils/supabase/client.ts`의 `createClient()`를 사용합니다.
+- **서버 환경 (Action/Route)**: `src/utils/supabase/server.ts`의 `createClient()`를 사용합니다.
+- **미들웨어**: `src/utils/supabase/middleware.ts`에서 세션 갱신 및 인증 체크를 수행합니다.
+
+## 2. 🔐 인증 (Authentication)
+
+- 모든 보호된 경로는 미들웨어에서 인증 여부를 확인합니다.
+- 인증 관련 컴포넌트는 반드시 `src/utils/supabase/client.ts`를 사용하여 클라이언트 측에서 세션을 관리해야 합니다.
+
+## 3. 📊 데이터베이스 인터페이스 (PostgreSQL)
+
+- **RLS (Row Level Security)**: 모든 테이블에는 RLS 정책이 적용되어 있습니다. 데이터 쿼리 시 현재 로그인한 사용자의 ID(`auth.uid()`)를 기반으로 보안이 유지되므로 별도의 복잡한 필터링 로직 이전에 RLS가 작동함을 이해해야 합니다.
+- **Types**: 데이터베이스 스키마 기반의 타입을 정의하여 타입 안정성을 확보하십시오.
+
+## 4. 📝 RLS 정책 생성 지침
+
+보안상의 이유로 AI가 새로운 테이블을 생성하거나 수동으로 쿼리할 때 다음 RLS 원칙을 준수해야 합니다:
+
+1.  `ENABLE ROW LEVEL SECURITY;` 를 가장 먼저 실행합니다.
+2.  사용자 본인의 데이터에만 접근할 수 있도록 정책을 설정합니다.
+    - 예: `CREATE POLICY "Users can only see their own trips" ON trips FOR SELECT USING (user_id = auth.uid());`
+3.  공유 기능이 필요한 경우, `shared_members` 테이블 등 관계형 체크를 통해 정책을 확장합니다.
+
+## 5. 📁 Storage (파일 관리)
+
+- 여행 사진, 프로필 이미지 등은 Supabase Storage를 사용합니다.
+- 적절한 버킷 권한과 파일 경로(예: `user_id/trip_id/image.jpg`)를 준수하십시오.


### PR DESCRIPTION
## 📝 작업 개요
AI 코딩 어시스턴트의 효율적인 협업을 위한 가이드 문서를 구축하고, 서비스 명칭을 **OnVoy**로 일관되게 정비하였습니다.

## 🚀 주요 변경 사항
- **상세 AI 가이드 구축 (`docs/ai-guide/`)**:
  - `README.md`: 프로젝트 개요 및 AI 온보딩 프로세스
  - `coding-standards.md`: Panda CSS, Next.js, TS 코딩 표준
  - `architecture.md`: 프로젝트 구조 및 **Standard Dev Flow** 강조
  - `supabase-guide.md`: Supabase 클라이언트/서버 활용 및 RLS 지침
  - `capacitor-guide.md`: 네이티브 플러그인 및 모바일 빌드 가이드
- **루트 README.md 업데이트**:
  - 프로젝트 명칭을 'Next Voyage'에서 'OnVoy'로 변경
  - AI 어시스턴트용 가이드 섹션 추가

## 🔗 관련 이슈
- Resolves #109

## ✅ 자체 검증 항목
- [x] 모든 문서 내 내부 링크 정상 작동 확인
- [x] OnVoy 명칭 통일 여부 확인
- [x] 표준 개발 프로세스(Standard Dev Flow) 단계 준수 확인