### PR TITLE
feat: 여행 동선 시각화(Route Map) 기능 구현

### DIFF
--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -229,7 +229,6 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
         }
     }, [isActive, fetchTrip, fetchPlans, fetchUserRole])
 
-    // 드롭다운 외부 클릭 감지를 위한 이벤트 리스너 (심플 버전으로 대체)
 
     const handleDeletePlan = async (planId: string) => {
         if (!confirm('이 일정을 삭제하시겠습니까? (연결된 정보도 함께 삭제됩니다)')) return
@@ -262,6 +261,19 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
 
     const handleModalSuccess = () => {
         fetchPlans()
+    }
+
+    const handleToggleVisit = async (planId: string, isVisited: boolean) => {
+        // 낙관적 UI 업데이트
+        setPlans(prev => prev.map(p => p.id === planId ? { ...p, is_visited: isVisited } : p))
+        // 디테일 모달이 열려 있으면 선택된 plan도 업데이트
+        setSelectedPlanForDetail((prev: any) => prev && prev.id === planId ? { ...prev, is_visited: isVisited } : prev)
+        const { error } = await supabase.from('plans').update({ is_visited: isVisited }).eq('id', planId)
+        if (error) {
+            // 실패 시 롤백
+            setPlans(prev => prev.map(p => p.id === planId ? { ...p, is_visited: !isVisited } : p))
+            setSelectedPlanForDetail((prev: any) => prev && prev.id === planId ? { ...prev, is_visited: !isVisited } : prev)
+        }
     }
 
     const handlePlanDetail = (plan: any) => {
@@ -424,6 +436,7 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
                     onEdit={handleEditPlan}
                     onDelete={handleDeletePlan}
                     onDetail={handlePlanDetail}
+                    onToggleVisit={handleToggleVisit}
                 />
             )}
 
@@ -438,6 +451,7 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
                     onClose={() => setIsDetailModalOpen(false)}
                     onEdit={handleEditPlan}
                     onDelete={handleDeletePlan}
+                    onToggleVisit={handleToggleVisit}
                 />
             )}
 

--- a/src/app/trips/detail/TripLayoutClient.tsx
+++ b/src/app/trips/detail/TripLayoutClient.tsx
@@ -3,36 +3,43 @@
 import { createClient } from '@/utils/supabase/client'
 import { css } from 'styled-system/css'
 import Link from 'next/link'
-import { ArrowLeft, Calendar, ListChecks } from 'lucide-react'
+import { ArrowLeft, Calendar, ListChecks, MapPin } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import TripHeaderActions from '@/components/trips/TripHeaderActions'
 import { useEffect, useState } from 'react'
 import { analytics } from '@/services/AnalyticsService'
+import dynamic from 'next/dynamic'
 import TripClient from './TripClient'
 import ChecklistClient from '../checklist/ChecklistClient'
+
+const RouteMapView = dynamic(() => import('@/components/trips/RouteMapView'), { ssr: false })
 import { useUIStore } from '@/stores/useUIStore'
 import { CacheUtil } from '@/utils/cache'
 
 export default function TripLayoutClient() {
     const searchParams = useSearchParams()
     const id = searchParams.get('id')
-    const initialTab = searchParams.get('tab') === 'checklist' ? 'checklist' : 'plans'
+    const initialTab = (() => {
+        const tab = searchParams.get('tab')
+        if (tab === 'checklist' || tab === 'plans' || tab === 'map') return tab
+        return 'plans'
+    })()
     const router = useRouter()
     const supabase = createClient()
 
     const [trip, setTrip] = useState<any>(null)
     const [loading, setLoading] = useState(true)
-    const [activeTab, setActiveTab] = useState<'plans' | 'checklist'>(initialTab)
+    const [activeTab, setActiveTab] = useState<'plans' | 'checklist' | 'map'>(initialTab)
     const { setMobileTitle } = useUIStore()
 
     useEffect(() => {
         const urlTab = searchParams.get('tab')
-        if (urlTab === 'checklist' || urlTab === 'plans') {
+        if (urlTab === 'checklist' || urlTab === 'plans' || urlTab === 'map') {
             setActiveTab(urlTab)
         }
     }, [searchParams])
 
-    const handleTabChange = (tab: 'plans' | 'checklist') => {
+    const handleTabChange = (tab: 'plans' | 'checklist' | 'map') => {
         if (tab !== activeTab) {
             analytics.logTabSwitch(activeTab, tab)
             // 탭 전환 시 페이지 최상단으로 부드럽게 스크롤
@@ -196,6 +203,31 @@ export default function TripLayoutClient() {
                     >
                         <ListChecks size={18} strokeWidth={activeTab === 'checklist' ? 2.5 : 2} /> 준비물
                     </button>
+                    <button
+                        onClick={() => handleTabChange('map')}
+                        className={css({
+                            display: 'flex', alignItems: 'center', gap: '8px', px: '4px', h: '48px',
+                            cursor: 'pointer', border: 'none', bg: 'transparent',
+                            color: activeTab === 'map' ? 'brand.primary' : 'brand.muted',
+                            fontWeight: '700',
+                            fontSize: '15px',
+                            position: 'relative',
+                            transition: 'all 0.2s',
+                            _after: {
+                                content: '""',
+                                position: 'absolute',
+                                bottom: '0',
+                                left: '0',
+                                right: '0',
+                                h: '3px',
+                                bg: activeTab === 'map' ? 'brand.primary' : 'transparent',
+                                borderRadius: '3px 3px 0 0'
+                            },
+                            _active: { transform: 'scale(0.96)' },
+                        })}
+                    >
+                        <MapPin size={18} strokeWidth={activeTab === 'map' ? 2.5 : 2} /> 지도
+                    </button>
                 </div>
             </div>
 
@@ -206,6 +238,13 @@ export default function TripLayoutClient() {
                 </div>
                 <div style={{ display: activeTab === 'checklist' ? 'block' : 'none' }}>
                     <ChecklistClient isActive={activeTab === 'checklist'} />
+                </div>
+                <div style={{ display: activeTab === 'map' ? 'block' : 'none' }}>
+                    <RouteMapView
+                        tripStartDate={trip?.start_date || ''}
+                        tripEndDate={trip?.end_date || ''}
+                        isActive={activeTab === 'map'}
+                    />
                 </div>
             </div>
         </div>

--- a/src/components/trips/PlanDetailModal.tsx
+++ b/src/components/trips/PlanDetailModal.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState, useCallback } from 'react'
 import { css } from 'styled-system/css'
 import {
     X, ChevronLeft, MapPin, Clock, Wallet, FileText, Globe,
-    Pencil, Trash2, BookOpen, ExternalLink, Link2, Bell
+    Pencil, Trash2, BookOpen, ExternalLink, Link2, Bell,
+    Circle, CheckCircle2
 } from 'lucide-react'
 import { getCurrencyFromTimezone, formatCurrency, formatKRW } from '@/utils/currency'
 import { useNetworkStore } from '@/stores/useNetworkStore'
@@ -22,11 +23,12 @@ interface PlanDetailModalProps {
     onClose: () => void
     onEdit: (plan: any) => void
     onDelete: (id: string) => void
+    onToggleVisit: (planId: string, isVisited: boolean) => void
 }
 
 export default function PlanDetailModal({
     plan, exchangeRates, formatLocalTime, formatKstTime, timeDisplayMode,
-    userRole, onClose, onEdit, onDelete,
+    userRole, onClose, onEdit, onDelete, onToggleVisit,
 }: PlanDetailModalProps) {
     const [tab, setTab] = useState<'info' | 'refs'>('info')
     const [mapError, setMapError] = useState(false)
@@ -207,15 +209,46 @@ export default function PlanDetailModal({
                                 {plan.location || '장소 지정 안됨'}
                             </div>
                         </div>
-                        <h2 className={css({ 
-                            fontSize: { base: '26px', sm: '32px' }, 
-                            fontWeight: '900', 
+                        <h2 className={css({
+                            fontSize: { base: '26px', sm: '32px' },
+                            fontWeight: '900',
                             lineHeight: 1.2,
                             textShadow: '0 2px 15px rgba(0,0,0,0.4)',
                             wordBreak: 'break-word'
                         })}>
                             {plan.title}
                         </h2>
+                        {(userRole === 'owner' || userRole === 'editor') && (
+                            <button
+                                onClick={() => onToggleVisit(plan.id, !plan.is_visited)}
+                                className={css({
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: '6px',
+                                    mt: '10px',
+                                    bg: 'rgba(255,255,255,0.15)',
+                                    border: 'none',
+                                    cursor: 'pointer',
+                                    color: 'white',
+                                    px: '12px',
+                                    py: '6px',
+                                    borderRadius: '20px',
+                                    backdropFilter: 'blur(10px)',
+                                    fontSize: '13px',
+                                    fontWeight: '700',
+                                    transition: 'all 0.2s',
+                                    opacity: plan.is_visited ? 0.8 : 1,
+                                    _hover: { bg: 'rgba(255,255,255,0.25)' }
+                                })}
+                                aria-label={plan.is_visited ? '방문 취소' : '방문 완료'}
+                            >
+                                {plan.is_visited
+                                    ? <CheckCircle2 size={16} />
+                                    : <Circle size={16} />
+                                }
+                                {plan.is_visited ? '방문 완료' : '방문 전'}
+                            </button>
+                        )}
                     </div>
                 </div>
 

--- a/src/components/trips/PlanList.tsx
+++ b/src/components/trips/PlanList.tsx
@@ -24,6 +24,7 @@ interface Plan {
     memo: string
     image_url: string
     is_completed: boolean
+    is_visited: boolean
     timezone_string: string
 }
 
@@ -39,20 +40,22 @@ interface PlanListProps {
     onEdit: (plan: any) => void
     onDelete: (id: string) => void
     onDetail: (plan: any) => void
+    onToggleVisit: (planId: string, isVisited: boolean) => void
 }
 
-export default function PlanList({ 
-    plans, 
+export default function PlanList({
+    plans,
     exchangeRates,
-    activeDropdown, 
-    setActiveDropdown, 
-    userRole, 
-    timeDisplayMode, 
-    formatLocalTime, 
-    formatKstTime, 
-    onEdit, 
+    activeDropdown,
+    setActiveDropdown,
+    userRole,
+    timeDisplayMode,
+    formatLocalTime,
+    formatKstTime,
+    onEdit,
     onDelete,
-    onDetail 
+    onDetail,
+    onToggleVisit
 }: PlanListProps) {
     if (!plans || plans.length === 0) {
         return (
@@ -116,7 +119,7 @@ export default function PlanList({
                                     zIndex: 1,
                                     boxShadow: '0 0 0 1px brand.primary/30'
                                 })} />
-                                <PlanCard 
+                                <PlanCard
                                     plan={plan}
                                     exchangeRates={exchangeRates}
                                     userRole={userRole}
@@ -126,6 +129,7 @@ export default function PlanList({
                                     onEdit={onEdit}
                                     onDelete={onDelete}
                                     onDetail={onDetail}
+                                    onToggleVisit={onToggleVisit}
                                 />
                             </div>
                         ))}
@@ -136,16 +140,17 @@ export default function PlanList({
     )
 }
 
-function PlanCard({ 
-    plan, 
-    exchangeRates, 
-    userRole, 
-    timeDisplayMode, 
-    formatLocalTime, 
-    formatKstTime, 
-    onEdit, 
-    onDelete, 
-    onDetail 
+function PlanCard({
+    plan,
+    exchangeRates,
+    userRole,
+    timeDisplayMode,
+    formatLocalTime,
+    formatKstTime,
+    onEdit,
+    onDelete,
+    onDetail,
+    onToggleVisit
 }: {
     plan: any
     exchangeRates: Record<string, number>
@@ -156,6 +161,7 @@ function PlanCard({
     onEdit: (plan: any) => void
     onDelete: (id: string) => void
     onDetail: (plan: any) => void
+    onToggleVisit: (planId: string, isVisited: boolean) => void
 }) {
     const [isTooltipOpen, setIsTooltipOpen] = useState(false)
     const currency = getCurrencyFromTimezone(plan.timezone_string || 'Asia/Seoul')
@@ -180,7 +186,7 @@ function PlanCard({
                     opacity: 0.95
                 } : {}
             } : {},
-            opacity: plan.is_completed ? 0.7 : 1,
+            opacity: plan.is_completed ? 0.7 : plan.is_visited ? 0.6 : 1,
             cursor: 'pointer',
             // background 처리
             _before: plan.image_url ? {
@@ -209,7 +215,40 @@ function PlanCard({
             <div className={css({ display: 'flex', gap: '14px', position: 'relative', zIndex: 2 })}>
                 <div className={css({ flex: 1, minW: 0 })}>
                     <div className={css({ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: '4px' })}>
-                        <h4 className={css({ fontSize: '17px', fontWeight: '700', color: 'brand.secondary', textDecoration: plan.is_completed ? 'line-through' : 'none' })}>{plan.title}</h4>
+                        <div className={css({ display: 'flex', alignItems: 'center', gap: '8px', flex: 1, minW: 0 })}>
+                            {(userRole === 'owner' || userRole === 'editor') && (
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        onToggleVisit(plan.id, !plan.is_visited)
+                                    }}
+                                    className={css({
+                                        bg: 'transparent',
+                                        border: 'none',
+                                        cursor: 'pointer',
+                                        p: '2px',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        flexShrink: 0,
+                                        transition: 'all 0.2s',
+                                        _hover: { transform: 'scale(1.15)' }
+                                    })}
+                                    aria-label={plan.is_visited ? '방문 취소' : '방문 완료'}
+                                >
+                                    {plan.is_visited
+                                        ? <CheckCircle2 size={20} className={css({ color: 'brand.primary' })} />
+                                        : <Circle size={20} className={css({ color: 'brand.muted' })} />
+                                    }
+                                </button>
+                            )}
+                            <h4 className={css({
+                                fontSize: '17px',
+                                fontWeight: '700',
+                                color: 'brand.secondary',
+                                textDecoration: plan.is_completed ? 'line-through' : plan.is_visited ? 'line-through' : 'none'
+                            })}>{plan.title}</h4>
+                        </div>
                         {(userRole === 'owner' || userRole === 'editor') && (
                             <div className={css({ display: 'flex', gap: '4px' })}>
                                 <button 

--- a/src/components/trips/RouteMapInfoModal.tsx
+++ b/src/components/trips/RouteMapInfoModal.tsx
@@ -1,0 +1,286 @@
+'use client'
+
+import { useCallback } from 'react'
+import { css } from 'styled-system/css'
+import { Navigation2, Eye, CheckCircle2, Circle, X } from 'lucide-react'
+import { Capacitor } from '@capacitor/core'
+import { useModalBackButton } from '@/hooks/useModalBackButton'
+import { useBottomSheetDrag } from '@/hooks/useBottomSheetDrag'
+
+interface RouteMapInfoModalProps {
+    plan: {
+        id: string
+        title: string
+        location?: string
+        address?: string
+        start_datetime_local?: string
+        memo?: string
+        is_visited: boolean
+        location_lat?: number
+        location_lng?: number
+    }
+    onClose: () => void
+    onToggleVisit: (planId: string, isVisited: boolean) => void
+    onDetail: (plan: RouteMapInfoModalProps['plan']) => void
+    userRole: 'owner' | 'editor' | 'viewer' | null
+}
+
+function formatTimeDisplay(dateString?: string): string {
+    if (!dateString) return ''
+    try {
+        const localIso = dateString.replace(' ', 'T')
+        const timePart = localIso.split('T')[1]
+        if (!timePart) return ''
+        const [h, m] = timePart.split(':')
+        const hour = parseInt(h, 10)
+        const ampm = hour < 12 ? '오전' : '오후'
+        const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour
+        return `${ampm} ${String(displayHour).padStart(2, '0')}:${m}`
+    } catch {
+        return ''
+    }
+}
+
+export default function RouteMapInfoModal({
+    plan,
+    onClose,
+    onToggleVisit,
+    onDetail,
+    userRole,
+}: RouteMapInfoModalProps) {
+    const handleClose = useCallback(() => {
+        onClose()
+    }, [onClose])
+
+    const { handleRef: dragHandleRef, dragY, isDragging } = useBottomSheetDrag(handleClose)
+
+    useModalBackButton(true, handleClose, `routeMapInfo_${plan.id}`)
+
+    const timeStr = formatTimeDisplay(plan.start_datetime_local)
+
+    const handleNavigate = () => {
+        if (!plan.location_lat || !plan.location_lng) return
+        const url = `https://www.google.com/maps/dir/?api=1&destination=${plan.location_lat},${plan.location_lng}`
+        if (Capacitor.isNativePlatform()) {
+            window.open(url, '_system')
+        } else {
+            window.open(url, '_blank')
+        }
+    }
+
+    const handleDetail = () => {
+        onDetail(plan)
+        onClose()
+    }
+
+    const canEdit = userRole === 'owner' || userRole === 'editor'
+
+    return (
+        <div
+            className={css({
+                position: 'fixed',
+                bottom: 0,
+                left: 0,
+                right: 0,
+                zIndex: 200,
+                animation: 'slideUp 0.3s ease-out',
+            })}
+            style={{
+                transform: `translateY(${dragY}px)`,
+                transition: isDragging ? 'none' : 'transform 0.2s ease',
+            }}
+        >
+            <div
+                className={css({
+                    bg: 'white',
+                    borderRadius: '20px 20px 0 0',
+                    boxShadow: '0 -4px 20px rgba(0,0,0,0.12)',
+                    px: '20px',
+                    pb: 'calc(20px + max(env(safe-area-inset-bottom, 0px), var(--safe-area-inset-bottom, 0px)))',
+                    maxH: '320px',
+                })}
+            >
+                {/* Handle bar */}
+                <div ref={dragHandleRef} className={css({
+                    display: 'flex',
+                    justifyContent: 'center',
+                    py: '12px',
+                    cursor: 'ns-resize',
+                    touchAction: 'none',
+                })}>
+                    <div
+                        className={css({
+                            w: '40px',
+                            h: '4px',
+                            bg: 'brand.border',
+                            borderRadius: '2px',
+                        })}
+                    />
+                </div>
+
+                {/* Header: Title + Close */}
+                <div className={css({ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', mb: '8px' })}>
+                    <div className={css({ flex: 1, minW: 0 })}>
+                        <h3
+                            className={css({
+                                fontSize: '17px',
+                                fontWeight: '700',
+                                color: 'brand.secondary',
+                                lineHeight: '1.4',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                            })}
+                        >
+                            {plan.title}
+                        </h3>
+                        {plan.address && (
+                            <p
+                                className={css({
+                                    fontSize: '13px',
+                                    color: 'brand.muted',
+                                    mt: '2px',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                })}
+                            >
+                                {plan.address}
+                            </p>
+                        )}
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className={css({
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            w: '32px',
+                            h: '32px',
+                            borderRadius: '50%',
+                            border: 'none',
+                            bg: 'bg.softCotton',
+                            cursor: 'pointer',
+                            flexShrink: 0,
+                            ml: '12px',
+                            transition: 'all 0.2s',
+                            _hover: { bg: 'brand.border' },
+                            _active: { transform: 'scale(0.9)' },
+                        })}
+                        aria-label="닫기"
+                    >
+                        <X size={16} className={css({ color: 'brand.muted' })} />
+                    </button>
+                </div>
+
+                {/* Time + Visit toggle */}
+                <div className={css({ display: 'flex', alignItems: 'center', gap: '12px', mb: '12px' })}>
+                    {timeStr && (
+                        <span className={css({ fontSize: '13px', color: 'brand.muted', fontWeight: '600' })}>
+                            {timeStr}
+                        </span>
+                    )}
+                    {canEdit && (
+                        <button
+                            onClick={() => onToggleVisit(plan.id, !plan.is_visited)}
+                            className={css({
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                border: 'none',
+                                bg: 'transparent',
+                                cursor: 'pointer',
+                                px: '0',
+                                fontSize: '13px',
+                                fontWeight: '600',
+                                color: plan.is_visited ? 'brand.primary' : 'brand.muted',
+                                transition: 'all 0.2s',
+                                _active: { transform: 'scale(0.95)' },
+                            })}
+                        >
+                            {plan.is_visited ? (
+                                <CheckCircle2 size={18} strokeWidth={2.5} />
+                            ) : (
+                                <Circle size={18} />
+                            )}
+                            {plan.is_visited ? '방문 완료' : '방문 전'}
+                        </button>
+                    )}
+                </div>
+
+                {/* Memo (max 2 lines) */}
+                {plan.memo && (
+                    <p
+                        className={css({
+                            fontSize: '13px',
+                            color: 'brand.muted',
+                            lineHeight: '1.5',
+                            mb: '16px',
+                            overflow: 'hidden',
+                            display: '-webkit-box',
+                            lineClamp: 2,
+                        })}
+                        style={{ WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}
+                    >
+                        {plan.memo}
+                    </p>
+                )}
+
+                {/* Action buttons */}
+                <div className={css({ display: 'flex', gap: '8px' })}>
+                    {plan.location_lat && plan.location_lng && (
+                        <button
+                            onClick={handleNavigate}
+                            className={css({
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                gap: '6px',
+                                flex: 1,
+                                h: '44px',
+                                bg: 'white',
+                                color: 'brand.secondary',
+                                border: '1px solid',
+                                borderColor: 'brand.border',
+                                borderRadius: '12px',
+                                fontSize: '14px',
+                                fontWeight: '700',
+                                cursor: 'pointer',
+                                transition: 'all 0.2s',
+                                _hover: { bg: 'bg.softCotton', borderColor: 'brand.primary' },
+                                _active: { transform: 'scale(0.96)' },
+                            })}
+                        >
+                            <Navigation2 size={16} />
+                            길찾기
+                        </button>
+                    )}
+                    <button
+                        onClick={handleDetail}
+                        className={css({
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            gap: '6px',
+                            flex: 1,
+                            h: '44px',
+                            bg: 'brand.primary',
+                            color: 'white',
+                            border: 'none',
+                            borderRadius: '12px',
+                            fontSize: '14px',
+                            fontWeight: '700',
+                            cursor: 'pointer',
+                            transition: 'all 0.2s',
+                            _hover: { bg: 'brand.primaryDark' },
+                            _active: { transform: 'scale(0.96)' },
+                        })}
+                    >
+                        <Eye size={16} />
+                        상세보기
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/trips/RouteMapView.tsx
+++ b/src/components/trips/RouteMapView.tsx
@@ -1,0 +1,594 @@
+'use client'
+
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
+import { css } from 'styled-system/css'
+import { useLoadScript, GoogleMap, OverlayView } from '@react-google-maps/api'
+import { WifiOff, MapPin, AlertCircle } from 'lucide-react'
+import { useSearchParams } from 'next/navigation'
+import { createClient } from '@/utils/supabase/client'
+import { useNetworkStore } from '@/stores/useNetworkStore'
+import { collaboration } from '@/utils/collaboration'
+import { getCurrencyFromTimezone } from '@/utils/currency'
+import { ExchangeService } from '@/services/ExternalApiService'
+import RouteMapInfoModal from '@/components/trips/RouteMapInfoModal'
+import PlanDetailModal from '@/components/trips/PlanDetailModal'
+
+const GOOGLE_MAPS_LIBRARIES: ('places')[] = ['places']
+
+const MAP_STYLES: google.maps.MapTypeStyle[] = [
+    { featureType: 'poi', elementType: 'labels', stylers: [{ visibility: 'off' }] },
+    { featureType: 'transit', elementType: 'labels.icon', stylers: [{ visibility: 'off' }] },
+]
+
+const MAP_CONTAINER_STYLE = { width: '100%', height: '100%' }
+
+interface Plan {
+    id: string
+    title: string
+    location?: string
+    address?: string
+    start_datetime_local?: string
+    end_datetime_local?: string
+    memo?: string
+    is_visited: boolean
+    location_lat?: number
+    location_lng?: number
+    google_place_id?: string
+    timezone_string?: string
+}
+
+interface RouteMapViewProps {
+    tripStartDate: string
+    tripEndDate: string
+    isActive: boolean
+}
+
+function formatLocalTime(dateString: string): string {
+    try {
+        const localIso = dateString.replace(' ', 'T')
+        const timePart = localIso.split('T')[1]
+        if (!timePart) return ''
+        const [h, m] = timePart.split(':')
+        const hour = parseInt(h, 10)
+        const ampm = hour < 12 ? '오전' : '오후'
+        const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour
+        return `${ampm} ${String(displayHour).padStart(2, '0')}:${m}`
+    } catch {
+        return dateString
+    }
+}
+
+function formatKstTime(dateString: string, localTimeZone: string): string {
+    try {
+        const localIso = dateString.replace(' ', 'T')
+        const fakeUtc = new Date(localIso + 'Z')
+        const fmt = new Intl.DateTimeFormat('en-US', {
+            timeZone: localTimeZone,
+            year: 'numeric', month: '2-digit', day: '2-digit',
+            hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
+        })
+        const parts = fmt.formatToParts(fakeUtc)
+        const get = (type: string) => parts.find(p => p.type === type)?.value?.padStart(2, '0') ?? '00'
+        const inTzStr = `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}`
+        const fakeTzUtc = new Date(inTzStr + 'Z')
+        const tzOffsetMs = fakeUtc.getTime() - fakeTzUtc.getTime()
+        const actualUtc = new Date(fakeUtc.getTime() + tzOffsetMs)
+        return new Intl.DateTimeFormat('ko-KR', {
+            hour: '2-digit', minute: '2-digit', timeZone: 'Asia/Seoul'
+        }).format(actualUtc)
+    } catch {
+        return ''
+    }
+}
+
+function getDateLabel(dateStr: string): string {
+    const d = new Date(dateStr + 'T00:00:00')
+    const month = d.getMonth() + 1
+    const day = d.getDate()
+    const weekDays = ['일', '월', '화', '수', '목', '금', '토']
+    const weekDay = weekDays[d.getDay()]
+    return `${month}/${day}(${weekDay})`
+}
+
+function generateDateRange(startDate: string, endDate: string): string[] {
+    const dates: string[] = []
+    const start = new Date(startDate + 'T00:00:00')
+    const end = new Date(endDate + 'T00:00:00')
+    const current = new Date(start)
+    while (current <= end) {
+        const yyyy = current.getFullYear()
+        const mm = String(current.getMonth() + 1).padStart(2, '0')
+        const dd = String(current.getDate()).padStart(2, '0')
+        dates.push(`${yyyy}-${mm}-${dd}`)
+        current.setDate(current.getDate() + 1)
+    }
+    return dates
+}
+
+function getPlanDate(plan: Plan): string {
+    if (!plan.start_datetime_local) return ''
+    return plan.start_datetime_local.split('T')[0] || plan.start_datetime_local.split(' ')[0] || ''
+}
+
+export default function RouteMapView({
+    tripStartDate,
+    tripEndDate,
+    isActive,
+}: RouteMapViewProps) {
+    const searchParams = useSearchParams()
+    const tripId = searchParams.get('id')
+    const supabase = createClient()
+    const { isOnline } = useNetworkStore()
+
+    const [plans, setPlans] = useState<Plan[]>([])
+    const [userRole, setUserRole] = useState<'owner' | 'editor' | 'viewer' | null>(null)
+    const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null)
+    const [detailPlan, setDetailPlan] = useState<Plan | null>(null)
+    const [selectedDate, setSelectedDate] = useState<string>('all')
+    const [dataLoaded, setDataLoaded] = useState(false)
+    const [exchangeRates, setExchangeRates] = useState<Record<string, number>>({})
+
+    const mapRef = useRef<google.maps.Map | null>(null)
+    const polylineRef = useRef<google.maps.Polyline | null>(null)
+    const dateChipsRef = useRef<HTMLDivElement>(null)
+
+    const { isLoaded } = useLoadScript({
+        googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string,
+        libraries: GOOGLE_MAPS_LIBRARIES,
+        language: 'ko',
+    })
+
+    // Fetch plans — tripId 변경 시 이전 데이터를 즉시 초기화 후 새 데이터 패칭
+    // 단일 effect로 통합하여 cleanup과 fetch 사이의 race condition 방지
+    useEffect(() => {
+        // tripId가 변경되면 항상 기존 상태를 먼저 초기화
+        setPlans([])
+        setSelectedPlan(null)
+        setSelectedDate('all')
+        setDataLoaded(false)
+
+        if (!isActive || !tripId || !isOnline) return
+        let cancelled = false
+
+        const fetchData = async () => {
+            const [plansResult, roleResult] = await Promise.all([
+                supabase
+                    .from('plans')
+                    .select('*')
+                    .eq('trip_id', tripId)
+                    .order('start_datetime_local', { ascending: true }),
+                collaboration.getUserRole(tripId),
+            ])
+
+            if (cancelled) return
+
+            if (plansResult.data) {
+                setPlans(plansResult.data.map((p: any) => ({ ...p, is_visited: p.is_visited ?? false })) as Plan[])
+            }
+            if (roleResult.data) {
+                setUserRole(roleResult.data as 'owner' | 'editor' | 'viewer')
+            }
+            setDataLoaded(true)
+        }
+
+        fetchData()
+        return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isActive, tripId, isOnline])
+
+    // Fetch exchange rates for detail modal
+    useEffect(() => {
+        if (plans.length === 0) return
+        const uniqueTimezones = Array.from(new Set(plans.map(p => p.timezone_string || 'Asia/Seoul')))
+        uniqueTimezones.forEach(async (tz) => {
+            const currency = getCurrencyFromTimezone(tz)
+            if (currency.code !== 'KRW' && !exchangeRates[currency.code]) {
+                try {
+                    const data = await ExchangeService.getExchangeRate(currency.code)
+                    if (data?.rate) {
+                        setExchangeRates(prev => ({ ...prev, [currency.code]: data.rate }))
+                    }
+                } catch { /* ignore */ }
+            }
+        })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [plans])
+
+    // Date filter chips
+    const dateChips = useMemo(() => {
+        const dates = generateDateRange(tripStartDate, tripEndDate)
+        return [
+            { value: 'all', label: '전체' },
+            ...dates.map((d, i) => ({
+                value: d,
+                label: `${i + 1}일차 ${getDateLabel(d)}`,
+            })),
+        ]
+    }, [tripStartDate, tripEndDate])
+
+    // Filter plans with valid coordinates
+    const validPlans = useMemo(() => {
+        return plans.filter(
+            (p) =>
+                p.location_lat != null &&
+                p.location_lng != null &&
+                (p.location_lat !== 0 || p.location_lng !== 0)
+        )
+    }, [plans])
+
+    // Apply date filter
+    const filteredPlans = useMemo(() => {
+        if (selectedDate === 'all') return validPlans
+        return validPlans.filter((p) => getPlanDate(p) === selectedDate)
+    }, [validPlans, selectedDate])
+
+    // Count of plans without coordinates
+    const noLocationCount = useMemo(() => {
+        return plans.filter(
+            (p) =>
+                p.location_lat == null ||
+                p.location_lng == null ||
+                (p.location_lat === 0 && p.location_lng === 0)
+        ).length
+    }, [plans])
+
+    // Polyline path
+    const polylinePath = useMemo(() => {
+        return filteredPlans
+            .filter((p) => p.location_lat && p.location_lng)
+            .map((p) => ({
+                lat: Number(p.location_lat),
+                lng: Number(p.location_lng),
+            }))
+    }, [filteredPlans])
+
+    // Fit bounds when map + filtered plans change
+    const fitBoundsToMarkers = useCallback(() => {
+        if (!mapRef.current || filteredPlans.length === 0) return
+        const bounds = new google.maps.LatLngBounds()
+        filteredPlans.forEach((p) => {
+            if (p.location_lat && p.location_lng) {
+                bounds.extend({ lat: Number(p.location_lat), lng: Number(p.location_lng) })
+            }
+        })
+        mapRef.current.fitBounds(bounds, { top: 60, right: 40, bottom: 80, left: 40 })
+    }, [filteredPlans])
+
+    useEffect(() => {
+        fitBoundsToMarkers()
+    }, [fitBoundsToMarkers])
+
+    // Polyline 직접 관리 — @react-google-maps/api의 <Polyline>은 언마운트 시 정리가 불안정하여
+    // Google Maps API를 직접 사용하여 확실한 cleanup을 보장
+    useEffect(() => {
+        // 이전 polyline 확실히 제거
+        if (polylineRef.current) {
+            polylineRef.current.setMap(null)
+            polylineRef.current = null
+        }
+
+        if (!mapRef.current || polylinePath.length < 2) return
+
+        polylineRef.current = new google.maps.Polyline({
+            path: polylinePath,
+            map: mapRef.current,
+            strokeColor: '#1D4ED8',
+            strokeOpacity: 0.8,
+            strokeWeight: 4,
+        })
+
+        return () => {
+            if (polylineRef.current) {
+                polylineRef.current.setMap(null)
+                polylineRef.current = null
+            }
+        }
+    }, [polylinePath])
+
+    const onMapLoad = useCallback(
+        (map: google.maps.Map) => {
+            mapRef.current = map
+            fitBoundsToMarkers()
+        },
+        [fitBoundsToMarkers]
+    )
+
+    const handleToggleVisit = useCallback(
+        async (planId: string, isVisited: boolean) => {
+            // Optimistic update
+            setPlans((prev) => prev.map((p) => (p.id === planId ? { ...p, is_visited: isVisited } : p)))
+            setSelectedPlan((prev) => (prev && prev.id === planId ? { ...prev, is_visited: isVisited } : prev))
+
+            const { error } = await supabase.from('plans').update({ is_visited: isVisited }).eq('id', planId)
+            if (error) {
+                // Rollback
+                setPlans((prev) => prev.map((p) => (p.id === planId ? { ...p, is_visited: !isVisited } : p)))
+                setSelectedPlan((prev) => (prev && prev.id === planId ? { ...prev, is_visited: !isVisited } : prev))
+            }
+        },
+        [supabase]
+    )
+
+    const handleDetail = useCallback(
+        (plan: Plan) => {
+            setSelectedPlan(null)
+            // RouteMapInfoModal의 useModalBackButton cleanup이 10ms 후 history.back()을 호출하므로,
+            // 그 이후에 PlanDetailModal을 마운트해야 popstate 충돌을 방지할 수 있음
+            setTimeout(() => setDetailPlan(plan), 60)
+        },
+        []
+    )
+
+    const handleDeletePlan = useCallback(
+        async (planId: string) => {
+            if (!confirm('이 일정을 삭제하시겠습니까?')) return
+            const { error } = await supabase.from('plans').delete().eq('id', planId)
+            if (!error) {
+                setPlans(prev => prev.filter(p => p.id !== planId))
+                setDetailPlan(null)
+            }
+        },
+        [supabase]
+    )
+
+    // Offline fallback
+    if (!isOnline) {
+        return (
+            <div
+                className={css({
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    py: '80px',
+                    gap: '16px',
+                    color: 'brand.muted',
+                })}
+            >
+                <WifiOff size={48} strokeWidth={1.5} />
+                <p className={css({ fontSize: '16px', fontWeight: '700', color: 'brand.secondary' })}>
+                    인터넷 연결 필요
+                </p>
+                <p className={css({ fontSize: '14px', textAlign: 'center', lineHeight: '1.6' })}>
+                    지도를 보려면 인터넷 연결이 필요합니다.
+                </p>
+            </div>
+        )
+    }
+
+    if (!isLoaded) {
+        return (
+            <div
+                className={css({
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    py: '80px',
+                    color: 'brand.muted',
+                    fontSize: '14px',
+                })}
+            >
+                지도를 불러오는 중...
+            </div>
+        )
+    }
+
+    const defaultCenter = { lat: 37.5665, lng: 126.978 } // Seoul fallback
+
+    return (
+        <div className={css({ position: 'relative', bg: 'white' })}>
+            {/* Date filter chips */}
+            <div
+                ref={dateChipsRef}
+                className={css({
+                    display: 'flex',
+                    gap: '8px',
+                    px: '16px',
+                    py: '12px',
+                    overflowX: 'auto',
+                    WebkitOverflowScrolling: 'touch',
+                    scrollbarWidth: 'none',
+                    '&::-webkit-scrollbar': { display: 'none' },
+                })}
+            >
+                {dateChips.map((chip) => (
+                    <button
+                        key={chip.value}
+                        onClick={() => setSelectedDate(chip.value)}
+                        className={css({
+                            flexShrink: 0,
+                            px: '14px',
+                            h: '36px',
+                            borderRadius: '18px',
+                            fontSize: '13px',
+                            fontWeight: '700',
+                            border: '1px solid',
+                            cursor: 'pointer',
+                            transition: 'all 0.2s',
+                            whiteSpace: 'nowrap',
+                            bg: selectedDate === chip.value ? 'brand.primary' : 'white',
+                            color: selectedDate === chip.value ? 'white' : 'brand.secondary',
+                            borderColor: selectedDate === chip.value ? 'brand.primary' : 'brand.border',
+                            _active: { transform: 'scale(0.95)' },
+                        })}
+                    >
+                        {chip.label}
+                    </button>
+                ))}
+            </div>
+
+            {/* Map container */}
+            <div
+                className={css({
+                    position: 'relative',
+                    h: { base: 'calc(100dvh - 260px)', sm: 'calc(100vh - 300px)' },
+                    minH: '400px',
+                })}
+            >
+                <GoogleMap
+                    mapContainerStyle={MAP_CONTAINER_STYLE}
+                    center={filteredPlans.length > 0 ? undefined : defaultCenter}
+                    zoom={filteredPlans.length > 0 ? undefined : 12}
+                    onLoad={onMapLoad}
+                    options={{
+                        disableDefaultUI: true,
+                        zoomControl: true,
+                        gestureHandling: 'greedy',
+                        styles: MAP_STYLES,
+                    }}
+                >
+                    {/* Custom numbered markers via OverlayView */}
+                    {filteredPlans.map((plan, index) => {
+                        if (!plan.location_lat || !plan.location_lng) return null
+                        const position = {
+                            lat: Number(plan.location_lat),
+                            lng: Number(plan.location_lng),
+                        }
+                        return (
+                            <OverlayView
+                                key={plan.id}
+                                position={position}
+                                mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
+                                getPixelPositionOffset={() => ({ x: -16, y: -40 })}
+                            >
+                                <div
+                                    onClick={() => setSelectedPlan(plan)}
+                                    className={css({
+                                        cursor: 'pointer',
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        alignItems: 'center',
+                                        transition: 'transform 0.15s',
+                                        _hover: { transform: 'scale(1.1)' },
+                                    })}
+                                >
+                                    {/* Marker circle */}
+                                    <div
+                                        className={css({
+                                            w: '32px',
+                                            h: '32px',
+                                            borderRadius: '50%',
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'center',
+                                            color: 'white',
+                                            fontSize: '13px',
+                                            fontWeight: '800',
+                                            boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
+                                            border: '2px solid white',
+                                            bg: plan.is_visited ? 'brand.muted' : 'brand.primary',
+                                        })}
+                                    >
+                                        {index + 1}
+                                    </div>
+                                    {/* Tail triangle */}
+                                    <div
+                                        className={css({
+                                            w: '0',
+                                            h: '0',
+                                            borderLeft: '6px solid transparent',
+                                            borderRight: '6px solid transparent',
+                                            borderTop: plan.is_visited ? '8px solid token(colors.brand.muted)' : '8px solid token(colors.brand.primary)',
+                                            mt: '-1px',
+                                        })}
+                                    />
+                                </div>
+                            </OverlayView>
+                        )
+                    })}
+
+                    {/* Polyline은 useEffect에서 직접 Google Maps API로 관리 (cleanup 안정성) */}
+                </GoogleMap>
+
+                {/* Info modal when marker is selected */}
+                {selectedPlan && (
+                    <RouteMapInfoModal
+                        plan={selectedPlan}
+                        onClose={() => setSelectedPlan(null)}
+                        onToggleVisit={handleToggleVisit}
+                        onDetail={handleDetail}
+                        userRole={userRole}
+                    />
+                )}
+            </div>
+
+            {/* Plan detail modal — 지도 탭에서 직접 렌더링 */}
+            {detailPlan && (
+                <PlanDetailModal
+                    plan={detailPlan}
+                    exchangeRates={exchangeRates}
+                    formatLocalTime={formatLocalTime}
+                    formatKstTime={formatKstTime}
+                    timeDisplayMode="both"
+                    userRole={userRole}
+                    onClose={() => setDetailPlan(null)}
+                    onEdit={() => { /* 편집은 일정표 탭의 NewPlanModal 필요 — 모달 닫기만 */ setDetailPlan(null) }}
+                    onDelete={handleDeletePlan}
+                    onToggleVisit={handleToggleVisit}
+                />
+            )}
+
+            {/* No location info notice */}
+            {noLocationCount > 0 && dataLoaded && (
+                <div
+                    className={css({
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        px: '16px',
+                        py: '10px',
+                        bg: 'bg.softCotton',
+                        borderTop: '1px solid',
+                        borderColor: 'brand.border',
+                    })}
+                >
+                    <AlertCircle size={16} className={css({ color: 'brand.muted', flexShrink: 0 })} />
+                    <p className={css({ fontSize: '13px', color: 'brand.muted' })}>
+                        위치 정보 없는 일정 {noLocationCount}개가 지도에 표시되지 않았습니다.
+                    </p>
+                </div>
+            )}
+
+            {/* Empty state */}
+            {dataLoaded && validPlans.length === 0 && plans.length > 0 && (
+                <div
+                    className={css({
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        py: '40px',
+                        gap: '12px',
+                    })}
+                >
+                    <MapPin size={32} className={css({ color: 'brand.muted' })} />
+                    <p className={css({ fontSize: '14px', color: 'brand.muted', textAlign: 'center', lineHeight: '1.6' })}>
+                        위치 정보가 있는 일정이 없습니다.
+                        <br />
+                        일정 추가 시 장소를 검색하면 지도에 표시됩니다.
+                    </p>
+                </div>
+            )}
+
+            {dataLoaded && plans.length === 0 && (
+                <div
+                    className={css({
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        py: '40px',
+                        gap: '12px',
+                    })}
+                >
+                    <MapPin size={32} className={css({ color: 'brand.muted' })} />
+                    <p className={css({ fontSize: '14px', color: 'brand.muted', textAlign: 'center', lineHeight: '1.6' })}>
+                        등록된 일정이 없습니다.
+                        <br />
+                        일정을 추가하면 동선을 지도에서 확인할 수 있습니다.
+                    </p>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/components/trips/TripSwitcherModal.tsx
+++ b/src/components/trips/TripSwitcherModal.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { formatDate } from '@/utils/date'
 import { useScrollLock } from '@/hooks/useScrollLock'
+import { useBottomSheetDrag } from '@/hooks/useBottomSheetDrag'
 
 interface Trip {
     id: string
@@ -32,13 +33,8 @@ export default function TripSwitcherModal() {
     const [activeTab, setActiveTab] = useState<'ongoing' | 'upcoming' | 'completed'>('ongoing')
     const [loading, setLoading] = useState(true)
     
-    // 드래그 제스처 상태
-    const [dragY, setDragY] = useState(0)
-    const [startY, setStartY] = useState(0)
-    const [isDragging, setIsDragging] = useState(false)
     const [mounted, setMounted] = useState(false)
     const [closing, setClosing] = useState(false)
-    const [scrollTop, setScrollTop] = useState(0)
 
     const handleClose = () => {
         setClosing(true)
@@ -46,14 +42,14 @@ export default function TripSwitcherModal() {
         setTimeout(() => {
             setIsTripSwitcherOpen(false)
             setClosing(false)
-            setDragY(0)
         }, 200)
     }
+
+    const { handleRef: dragHandleRef, dragY, isDragging } = useBottomSheetDrag(handleClose)
 
     useEffect(() => {
         if (isTripSwitcherOpen) {
             setClosing(false)
-            setDragY(0)
             const timer = setTimeout(() => setMounted(true), 10)
             return () => clearTimeout(timer)
         } else {
@@ -158,41 +154,6 @@ export default function TripSwitcherModal() {
 
     const currentList = activeTab === 'ongoing' ? ongoing : activeTab === 'upcoming' ? upcoming : completed
 
-    const handleTouchStart = (e: React.TouchEvent) => {
-        // 드래그 시작 시점 기록
-        setStartY(e.touches[0].clientY)
-        setIsDragging(true)
-    }
-
-    const handleTouchMove = (e: React.TouchEvent) => {
-        if (!isDragging) return
-        const deltaY = e.touches[0].clientY - startY
-        
-        // 스크롤 가드: 리스트가 맨 위가 아니거나, 위로 드래그하는 경우 무시
-        if (scrollTop > 5 && deltaY > 0) return
-        
-        if (deltaY > 0) {
-            // 드래그 중인 경우 기본 스크롤 방지
-            if (e.cancelable) e.preventDefault()
-            setDragY(deltaY)
-        }
-    }
-
-    const handleTouchEnd = () => {
-        if (!isDragging) return
-        setIsDragging(false)
-        
-        if (dragY > 100) {
-            handleClose()
-        } else {
-            setDragY(0)
-        }
-    }
-
-    const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-        setScrollTop(e.currentTarget.scrollTop)
-    }
-
     return (
         <div className={css({
             position: 'fixed',
@@ -207,10 +168,7 @@ export default function TripSwitcherModal() {
             justifyContent: 'center',
             animation: closing ? 'fadeOut 0.2s ease-in forwards' : 'fadeIn 0.2s ease-out',
         })}>
-            <div 
-                onTouchStart={handleTouchStart}
-                onTouchMove={handleTouchMove}
-                onTouchEnd={handleTouchEnd}
+            <div
                 className={css({
                     bg: 'white',
                     w: '100%',
@@ -221,17 +179,19 @@ export default function TripSwitcherModal() {
                     flexDirection: 'column',
                     boxShadow: '0 -10px 40px rgba(0,0,0,0.1)',
                     position: 'relative',
-                    // 진입/퇴장/드래그 상태에 따른 애니메이션 처리
-                    animation: closing ? 'slideDown 0.2s cubic-bezier(0.2, 0, 0, 1) forwards' : 
+                    // 진입/퇴장 애니메이션
+                    animation: closing ? 'slideDown 0.2s cubic-bezier(0.2, 0, 0, 1) forwards' :
                               !mounted ? 'slideUp 0.3s cubic-bezier(0.2, 0, 0, 1)' : 'none',
                     overflow: 'hidden',
+                })}
+                style={{
                     transform: `translateY(${dragY}px)`,
                     transition: isDragging ? 'none' : 'transform 0.2s cubic-bezier(0.2, 0, 0, 1)',
-                })}
+                }}
             >
                 {/* 상단 드래그 핸들 영역 */}
-                <div className={css({ 
-                    w: '100%', py: '14px', display: 'flex', justifyContent: 'center', 
+                <div ref={dragHandleRef} className={css({
+                    w: '100%', py: '14px', display: 'flex', justifyContent: 'center',
                     cursor: 'ns-resize',
                     touchAction: 'none' // 핸들바는 즉시 반응하도록
                 })}>
@@ -312,15 +272,13 @@ export default function TripSwitcherModal() {
                 </div>
 
                 {/* 리스트 영역 */}
-                <div 
-                    onScroll={handleScroll}
-                    className={css({ 
-                        flex: 1, 
-                        overflowY: 'auto', 
-                        px: '20px', 
+                <div
+                    className={css({
+                        flex: 1,
+                        overflowY: 'auto',
+                        px: '20px',
                         py: '10px',
-                        // 스크롤 최상단일 때만 터치 이벤트 전파 방지
-                        touchAction: scrollTop === 0 ? 'pan-x' : 'auto'
+                        overscrollBehavior: 'contain',
                     })}
                 >
                     {loading ? (

--- a/src/hooks/useBottomSheetDrag.ts
+++ b/src/hooks/useBottomSheetDrag.ts
@@ -1,0 +1,75 @@
+import { useRef, useState, useEffect, useCallback } from 'react'
+
+interface UseBottomSheetDragOptions {
+    threshold?: number  // 닫기 임계값 (기본 100px)
+}
+
+interface UseBottomSheetDragReturn {
+    handleRef: (node: HTMLDivElement | null) => void
+    dragY: number
+    isDragging: boolean
+}
+
+export function useBottomSheetDrag(
+    onClose: () => void,
+    options?: UseBottomSheetDragOptions
+): UseBottomSheetDragReturn {
+    const { threshold = 100 } = options || {}
+    const [handleEl, setHandleEl] = useState<HTMLDivElement | null>(null)
+    const [dragY, setDragY] = useState(0)
+    const [isDragging, setIsDragging] = useState(false)
+    const startYRef = useRef(0)
+    const dragYRef = useRef(0)
+    const onCloseRef = useRef(onClose)
+
+    useEffect(() => {
+        onCloseRef.current = onClose
+    }, [onClose])
+
+    // callback ref — DOM 마운트/언마운트 시점을 정확히 감지
+    const handleRef = useCallback((node: HTMLDivElement | null) => {
+        setHandleEl(node)
+    }, [])
+
+    useEffect(() => {
+        if (!handleEl) return
+
+        const onTouchStart = (e: TouchEvent) => {
+            startYRef.current = e.touches[0].clientY
+            setIsDragging(true)
+        }
+
+        const onTouchMove = (e: TouchEvent) => {
+            const deltaY = e.touches[0].clientY - startYRef.current
+            if (deltaY > 0) {
+                if (e.cancelable) e.preventDefault()
+                dragYRef.current = deltaY
+                setDragY(deltaY)
+            } else {
+                dragYRef.current = 0
+                setDragY(0)
+            }
+        }
+
+        const onTouchEnd = () => {
+            setIsDragging(false)
+            if (dragYRef.current > threshold) {
+                onCloseRef.current()
+            }
+            dragYRef.current = 0
+            setDragY(0)
+        }
+
+        handleEl.addEventListener('touchstart', onTouchStart, { passive: true })
+        handleEl.addEventListener('touchmove', onTouchMove, { passive: false })
+        handleEl.addEventListener('touchend', onTouchEnd)
+
+        return () => {
+            handleEl.removeEventListener('touchstart', onTouchStart)
+            handleEl.removeEventListener('touchmove', onTouchMove)
+            handleEl.removeEventListener('touchend', onTouchEnd)
+        }
+    }, [handleEl, threshold])
+
+    return { handleRef, dragY, isDragging }
+}


### PR DESCRIPTION
## Summary
- 여행 상세 페이지에 **지도 보기 탭** 추가 (일정표/준비물/지도 3탭 구조)
- Google Maps 위에 **커스텀 번호 마커** + **Polyline 동선 연결** + **날짜별 필터링**
- **방문 상태(is_visited) 토글 UI** — 일정표, 상세 모달, 지도 모달 3곳 통일 (낙관적 업데이트 + 역할 가드)
- 마커 클릭 시 **바텀시트 정보 모달** + **길찾기 연동** (Capacitor 네이티브/웹 분기)
- **공통 useBottomSheetDrag 훅** 생성 — TripSwitcherModal 터치 스크롤 정상화 + RouteMapInfoModal 드래그 닫기

## Changed Files (8)
| 파일 | 변경 |
|------|------|
| src/components/trips/RouteMapView.tsx | 🆕 지도 보기 메인 컴포넌트 |
| src/components/trips/RouteMapInfoModal.tsx | 🆕 마커 클릭 바텀시트 모달 |
| src/hooks/useBottomSheetDrag.ts | 🆕 공통 BottomSheet 드래그 훅 |
| src/app/trips/detail/TripLayoutClient.tsx | 3탭 구조 확장, dynamic import |
| src/app/trips/detail/TripClient.tsx | handleToggleVisit 추가 |
| src/components/trips/PlanList.tsx | is_visited 토글 버튼 + 역할 가드 |
| src/components/trips/PlanDetailModal.tsx | 히어로 섹션 방문 토글 + 역할 가드 |
| src/components/trips/TripSwitcherModal.tsx | useBottomSheetDrag 적용, 스크롤 정상화 |

## Test plan
- [ ] 지도 탭 전환 → Google Maps 렌더링, 마커 표시, Polyline 연결
- [ ] 날짜 필터 칩 → 해당 날짜 마커만 표시 + Polyline 재계산
- [ ] 마커 클릭 → 바텀시트 정보 모달 (장소명, 시간, 메모)
- [ ] 바텀시트 상세보기 → PlanDetailModal 표시 (지도 탭에서)
- [ ] 바텀시트 길찾기 → Google Maps 앱/웹 열기
- [ ] 방문 토글 → 마커 색상 변경 (블루↔회색), 3곳 동기화
- [ ] TripSwitcher → 핸들바 드래그 닫기 + 리스트 터치 스크롤 정상
- [ ] RouteMapInfoModal → 핸들바 드래그 닫기
- [ ] TripSwitcher로 여행 전환 → 이전 마커/Polyline 잔존 없음
- [ ] 오프라인 → 지도 대신 안내 UI 표시
- [ ] pnpm build / pnpm build:mobile 성공

Resolves #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)