### PR TITLE
fix: 지도 탭 수정 연동 + 프로필 피드백 모달 전환

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import TermsModal from '../signup/TermsModal'
 import ProfileSkeleton from './ProfileSkeleton'
+import BugReportModal from '@/components/profile/BugReportModal'
 
 function ProfileContent() {
     const supabase = createClient()
@@ -20,6 +21,7 @@ function ProfileContent() {
     const [isSavingNickname, setIsSavingNickname] = useState(false)
     const [nicknameError, setNicknameError] = useState('')
     const [loading, setLoading] = useState(true)
+    const [isBugModalOpen, setIsBugModalOpen] = useState(false)
 
     const [currentPassword, setCurrentPassword] = useState('')
     const [newPassword, setNewPassword] = useState('')
@@ -545,8 +547,7 @@ function ProfileContent() {
                     {[
                         { href: '/templates', icon: '📦', label: '준비물 템플릿 관리', desc: '나만의 체크리스트를 미리 구성해 두세요' },
                         { href: '/profile/travel-log', icon: '📖', label: '여행 발자취 (Travel Log)', desc: '지금까지 다녀온 모든 여행의 기록입니다' },
-                        { href: '/feedback', icon: '💬', label: '건의 및 버그 제보', desc: '온여정을 더 좋게 만드는 소중한 의견을 주세요' },
-                    ].map((item, i) => (
+                    ].map((item) => (
                         <Link
                             key={item.href}
                             href={item.href}
@@ -575,7 +576,45 @@ function ProfileContent() {
                             <ChevronRight size={20} className={css({ color: '#CCC', transition: 'all 0.2s' })} />
                         </Link>
                     ))}
+                    {/* 건의 및 버그 제보 — 페이지 이동 대신 모달 */}
+                    <button
+                        onClick={() => setIsBugModalOpen(true)}
+                        className={css({
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            px: '24px',
+                            py: '20px',
+                            borderTop: '1px solid #F5F5F5',
+                            bg: 'transparent',
+                            border: 'none',
+                            cursor: 'pointer',
+                            w: '100%',
+                            textAlign: 'left',
+                            transition: 'all 0.25s ease',
+                            _hover: { bg: 'rgba(37, 99, 235, 0.04)', px: '28px' },
+                            _active: { bg: 'rgba(37, 99, 235, 0.08)' }
+                        })}
+                    >
+                        <div className={css({ display: 'flex', alignItems: 'center', gap: '16px' })}>
+                            <div className={css({ fontSize: '22px', w: '40px', h: '40px', display: 'flex', alignItems: 'center', justifyContent: 'center', bg: 'bg.softCotton', borderRadius: '12px' })}>
+                                💬
+                            </div>
+                            <div>
+                                <div className={css({ fontSize: '16px', fontWeight: '750', color: 'brand.secondary' })}>건의 및 버그 제보</div>
+                                <div className={css({ fontSize: '13px', color: 'brand.muted', mt: '2px', fontWeight: '600' })}>온여정을 더 좋게 만드는 소중한 의견을 주세요</div>
+                            </div>
+                        </div>
+                        <ChevronRight size={20} className={css({ color: '#CCC', transition: 'all 0.2s' })} />
+                    </button>
                 </div>
+
+                {/* 버그 제보 모달 */}
+                <BugReportModal
+                    isOpen={isBugModalOpen}
+                    onClose={() => setIsBugModalOpen(false)}
+                    user={user}
+                />
             </section>
 
             {/* 기타 지원 및 법률 히스토리 */}

--- a/src/components/trips/RouteMapView.tsx
+++ b/src/components/trips/RouteMapView.tsx
@@ -12,6 +12,7 @@ import { getCurrencyFromTimezone } from '@/utils/currency'
 import { ExchangeService } from '@/services/ExternalApiService'
 import RouteMapInfoModal from '@/components/trips/RouteMapInfoModal'
 import PlanDetailModal from '@/components/trips/PlanDetailModal'
+import NewPlanModal from '@/components/trips/NewPlanModal'
 
 const GOOGLE_MAPS_LIBRARIES: ('places')[] = ['places']
 
@@ -124,6 +125,8 @@ export default function RouteMapView({
     const [userRole, setUserRole] = useState<'owner' | 'editor' | 'viewer' | null>(null)
     const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null)
     const [detailPlan, setDetailPlan] = useState<Plan | null>(null)
+    const [editingPlan, setEditingPlan] = useState<any>(null)
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false)
     const [selectedDate, setSelectedDate] = useState<string>('all')
     const [dataLoaded, setDataLoaded] = useState(false)
     const [exchangeRates, setExchangeRates] = useState<Record<string, number>>({})
@@ -318,6 +321,29 @@ export default function RouteMapView({
         },
         []
     )
+
+    const handleEditPlan = useCallback(
+        async (plan: any) => {
+            const { data: urlsData } = await supabase.from('plan_urls').select('url').eq('plan_id', plan.id)
+            setEditingPlan({ ...plan, plan_urls: urlsData || [] })
+            setDetailPlan(null)
+            setIsEditModalOpen(true)
+        },
+        [supabase]
+    )
+
+    // plans 재패칭 (수정/삭제 후)
+    const refetchPlans = useCallback(async () => {
+        if (!tripId) return
+        const { data } = await supabase
+            .from('plans')
+            .select('*')
+            .eq('trip_id', tripId)
+            .order('start_datetime_local', { ascending: true })
+        if (data) {
+            setPlans(data.map((p: any) => ({ ...p, is_visited: p.is_visited ?? false })) as Plan[])
+        }
+    }, [tripId, supabase])
 
     const handleDeletePlan = useCallback(
         async (planId: string) => {
@@ -522,9 +548,22 @@ export default function RouteMapView({
                     timeDisplayMode="both"
                     userRole={userRole}
                     onClose={() => setDetailPlan(null)}
-                    onEdit={() => { /* 편집은 일정표 탭의 NewPlanModal 필요 — 모달 닫기만 */ setDetailPlan(null) }}
+                    onEdit={handleEditPlan}
                     onDelete={handleDeletePlan}
                     onToggleVisit={handleToggleVisit}
+                />
+            )}
+
+            {/* Edit plan modal */}
+            {tripId && (
+                <NewPlanModal
+                    tripId={tripId}
+                    isOpen={isEditModalOpen}
+                    onClose={() => { setIsEditModalOpen(false); setEditingPlan(null) }}
+                    onSuccess={refetchPlans}
+                    editData={editingPlan}
+                    tripStartDate={tripStartDate}
+                    tripEndDate={tripEndDate}
                 />
             )}
 


### PR DESCRIPTION
## Summary
- 지도 탭 상세보기에서 **일정 수정 버튼** 클릭 시 NewPlanModal이 열리도록 연동
- 프로필 페이지 **건의 및 버그 제보** 메뉴를 /feedback 페이지 이동 → BugReportModal 직접 호출로 변경

## Commits
1. `fix: 지도 탭 상세보기에서 일정 수정 연동` — RouteMapView에 NewPlanModal 렌더링 + handleEditPlan + refetchPlans
2. `fix: 프로필 건의 및 버그 제보 메뉴를 모달로 변경` — Link → button + BugReportModal

## Test plan
- [ ] 지도 탭 → 마커 클릭 → 상세보기 → 수정 버튼 → NewPlanModal 열림
- [ ] 수정 완료 → 지도 마커 자동 갱신
- [ ] 프로필 → 건의 및 버그 제보 클릭 → BugReportModal 표시 (페이지 이동 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)