### PR TITLE
fix: OTA 배포 안정성 개선

### DIFF
--- a/.github/workflows/ota-deploy.yml
+++ b/.github/workflows/ota-deploy.yml
@@ -44,6 +44,17 @@ jobs:
       - name: Build for Mobile (Standard Export)
         run: pnpm build:mobile
 
+      - name: Verify build output
+        run: |
+          echo "=== out/ directory check ==="
+          ls -la out/ | head -20
+          if [ ! -f out/index.html ]; then
+            echo "ERROR: out/index.html not found. Build may have failed."
+            exit 1
+          fi
+          echo "Build output size: $(du -sh out/ | cut -f1)"
+          echo "File count: $(find out/ -type f | wc -l)"
+
       - name: Deploy to Supabase
         run: node scripts/deploy-ota.mjs --channel=${{ github.event.inputs.channel }}
         env:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "NODE_OPTIONS='--dns-result-order=ipv4first' next dev",
     "build": "next build",
-    "build:mobile": "mv src/app/api src/app_api_tmp && mv src/app/auth src/app_auth_tmp && mv src/app/share src/app_share_tmp && BUILD_TARGET=mobile next build; mv src/app_api_tmp src/app/api; mv src/app_auth_tmp src/app/auth; mv src/app_share_tmp src/app/share",
+    "build:mobile": "mv src/app/api src/app_api_tmp && mv src/app/auth src/app_auth_tmp && mv src/app/share src/app_share_tmp && BUILD_TARGET=mobile next build; BS=$?; mv src/app_api_tmp src/app/api; mv src/app_auth_tmp src/app/auth; mv src/app_share_tmp src/app/share; exit $BS",
     "start": "NODE_OPTIONS='--dns-result-order=ipv4first' next start",
     "lint": "eslint",
     "prepare": "panda codegen"

--- a/scripts/deploy-ota.mjs
+++ b/scripts/deploy-ota.mjs
@@ -23,9 +23,34 @@ async function deploy() {
 
   console.log(`Starting OTA deployment for version ${VERSION}...${isDryRun ? ' (DRY RUN)' : ''}`);
 
+  // out/ 디렉토리 존재 및 내용 확인
+  const outDir = path.join(process.cwd(), 'out');
+  if (!fs.existsSync(outDir)) {
+    console.error('ERROR: "out/" directory does not exist. Run "pnpm build:mobile" first.');
+    process.exit(1);
+  }
+  const outFiles = fs.readdirSync(outDir);
+  if (outFiles.length === 0) {
+    console.error('ERROR: "out/" directory is empty. Build may have failed.');
+    process.exit(1);
+  }
+  if (!fs.existsSync(path.join(outDir, 'index.html'))) {
+    console.error('ERROR: "out/index.html" not found. Build output is invalid.');
+    process.exit(1);
+  }
+  console.log(`Found ${outFiles.length} entries in out/ directory.`);
+
   output.on('close', async () => {
-    console.log(`${archive.pointer()} total bytes`);
+    const totalBytes = archive.pointer();
+    console.log(`${totalBytes} total bytes`);
     console.log('Archive has been finalized.');
+
+    // ZIP 크기 검증 — 정상 빌드는 최소 수 MB
+    if (totalBytes < 10000) {
+      console.error(`ERROR: ZIP file is too small (${totalBytes} bytes). The 'out/' directory may be empty or the build failed.`);
+      fs.unlinkSync(zipPath);
+      process.exit(1);
+    }
 
     if (isDryRun) {
       console.log('Dry run: Skipping upload and database update.');

--- a/src/components/layout/UpdateOverlay.tsx
+++ b/src/components/layout/UpdateOverlay.tsx
@@ -1,11 +1,26 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useOTAUpdate, UpdateStatus } from '@/hooks/useOTAUpdate';
 import { css } from 'styled-system/css';
+import { Capacitor } from '@capacitor/core';
 
 const UpdateOverlay: React.FC = () => {
   const { status, progress, error } = useOTAUpdate();
+
+  const handleGoToStore = useCallback(() => {
+    const platform = Capacitor.getPlatform()
+    let storeUrl: string
+    if (platform === 'android') {
+      storeUrl = 'https://play.google.com/store/apps/details?id=xyz.nexvoy.app'
+    } else if (platform === 'ios') {
+      // iOS App Store URL (앱 등록 후 실제 ID로 교체 필요)
+      storeUrl = 'https://apps.apple.com/app/id0000000000'
+    } else {
+      storeUrl = 'https://app.nexvoy.xyz'
+    }
+    window.open(storeUrl, '_system')
+  }, []);
 
   if (status === 'idle') return null;
 
@@ -67,20 +82,21 @@ const UpdateOverlay: React.FC = () => {
             <p className={css({ mb: 6, color: '#64748b' })}>
               안정적인 서비스 이용을 위해 새 버전으로 업데이트가 필요합니다. 스토어에서 최신 앱을 확인해 주세요.
             </p>
-            <button 
-              onClick={() => window.open('https://nexvoy.app', '_blank')} // Replace with actual store link
+            <button
+              onClick={handleGoToStore}
               className={css({
                 w: '100%',
                 py: 3,
                 bg: '#172554',
                 color: 'white',
-                borderRadius: '12px',
+                borderRadius: '16px',
                 fontWeight: 'bold',
+                border: 'none',
                 cursor: 'pointer',
                 _hover: { bg: '#1e3a8a' }
               })}
             >
-              스토어로 이동하기
+              스토어에서 업데이트
             </button>
           </>
         )}


### PR DESCRIPTION
## Summary
- **UpdateOverlay**: mandatory_update 시 플랫폼별 앱스토어 URL + `_system`으로 외부 앱 열기 (Android: Play Store, iOS: App Store)
- **deploy-ota.mjs**: `out/` 디렉토리 존재/내용/index.html 검증 + ZIP 최소 크기(10KB) 검증
- **ota-deploy.yml**: 빌드 후 `out/` 검증 단계 추가 (파일 수, 크기 출력)
- **build:mobile**: `next build` 종료 코드 보존 (`BS=$?; ... exit $BS`) — 빌드 실패 시 CI 정상 중단

## Root Cause
GitHub Actions에서 `build:mobile` 실패 시 종료 코드가 0으로 반환되어, 빈 `out/` 디렉토리가 22바이트 ZIP으로 압축 → Supabase Storage에 업로드 → 앱에서 다운로드 오류 발생

## Test plan
- [ ] GitHub Actions에서 OTA 배포 재실행 → ZIP 크기 정상 (수 MB)
- [ ] mandatory_update 시 "스토어에서 업데이트" 클릭 → 앱스토어 열림 (WebView 내부가 아닌 외부)
- [ ] `pnpm build:mobile` 로컬 실행 → `node scripts/deploy-ota.mjs --dry-run` → 정상 ZIP 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)