### PR TITLE
feat: 모바일 앱 구글 OAuth 세션 브릿지 구현

### DIFF
--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,0 +1,52 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export async function GET(request: Request) {
+    const { searchParams, origin } = new URL(request.url)
+    const platform = searchParams.get('platform')
+    const cookieStore = await cookies()
+
+    const supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+            cookies: {
+                getAll() {
+                    return cookieStore.getAll()
+                },
+                setAll(cookiesToSet) {
+                    cookiesToSet.forEach(({ name, value, options }) =>
+                        cookieStore.set(name, value, options)
+                    )
+                },
+            },
+        }
+    )
+
+    // 리다이렉트 경로 구성 (플랫폼 정보 포함)
+    const callbackUrl = new URL(`${origin}/auth/callback`)
+    if (platform) {
+        callbackUrl.searchParams.set('platform', platform)
+    }
+
+    // 서버에서 signInWithOAuth 호출 → PKCE verifier가 서버 쿠키에 안전하게 저장됨
+    const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+            redirectTo: callbackUrl.toString(),
+            queryParams: {
+                access_type: 'offline',
+                prompt: 'consent',
+            },
+        },
+    })
+
+    if (error || !data?.url) {
+        console.error('[Google OAuth] initiation error:', error?.message)
+        return NextResponse.redirect(`${origin}/auth/error?message=${encodeURIComponent(error?.message ?? 'google_oauth_error')}`)
+    }
+
+    // Google 인가 페이지로 리다이렉트 (PKCE verifier는 쿠키에 저장된 상태)
+    return NextResponse.redirect(data.url)
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,15 +1,21 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/utils/supabase/server'
 
+const SUPABASE_FUNCTION_URL = process.env.NEXT_PUBLIC_SUPABASE_URL
+    ? `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/handle-kakao-oauth`
+    : ''
+
 export async function GET(request: Request) {
     const { searchParams, origin: defaultOrigin } = new URL(request.url)
-    
+
     // Determine the user-facing origin (handling reverse proxies/load balancers)
     const forwardedHost = request.headers.get('x-forwarded-host')
     const isLocalEnv = process.env.NODE_ENV === 'development'
     const origin = isLocalEnv ? defaultOrigin : (forwardedHost ? `https://${forwardedHost}` : defaultOrigin)
-    
+
     const code = searchParams.get('code')
+    const provider = searchParams.get('provider') // Google 등 직접 provider 명시
+    const state = searchParams.get('state')        // 카카오: state=provider=kakao 로 식별
     // if "next" is in param, use it as the redirect URL
     const next = searchParams.get('next') ?? '/'
 
@@ -20,17 +26,81 @@ export async function GET(request: Request) {
         return NextResponse.redirect(`${origin}/auth/error?message=${encodeURIComponent(error_description)}`)
     }
 
+    // ─── 카카오 OAuth 콜백 처리 ────────────────────────────────────────
+    // provider=kakao (직접 명시) 또는 state=provider=kakao (카카오 state 반환) 감지
+    const isKakaoCallback = provider === 'kakao' || state === 'provider=kakao'
+    if (isKakaoCallback && code) {
+        try {
+            // 카카오 개발자 콘솔에 등록된 redirect_uri와 동일해야 함 (state 없는 기본 경로)
+            const redirectUri = `${origin}/auth/callback`
+
+            const res = await fetch(SUPABASE_FUNCTION_URL, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '',
+                },
+                body: JSON.stringify({ code, redirect_uri: redirectUri }),
+            })
+
+            if (!res.ok) {
+                const errBody = await res.json().catch(() => ({}))
+                console.error('Kakao callback error:', errBody)
+                return NextResponse.redirect(
+                    `${origin}/auth/error?message=${encodeURIComponent(errBody?.error ?? '카카오 로그인에 실패했습니다.')}`
+                )
+            }
+
+            const { access_token, refresh_token } = await res.json()
+
+            // 서버에서 Supabase 세션 설정
+            const supabase = await createClient()
+            const { error: sessionError } = await supabase.auth.setSession({
+                access_token,
+                refresh_token,
+            })
+
+            if (sessionError) {
+                console.error('Kakao setSession error:', sessionError.message)
+                return NextResponse.redirect(
+                    `${origin}/auth/error?message=${encodeURIComponent(sessionError.message)}`
+                )
+            }
+
+            return NextResponse.redirect(`${origin}${next}`)
+        } catch (err) {
+            console.error('Kakao OAuth unexpected error:', err)
+            return NextResponse.redirect(`${origin}/auth/error?message=kakao_oauth_error`)
+        }
+    }
+
+    const platform = searchParams.get('platform')
+
+    // ─── 기존 이메일 인증 / Google OAuth 콜백 처리 ────────────────────
     if (code) {
         const supabase = await createClient()
         const { error } = await supabase.auth.exchangeCodeForSession(code)
-        
+
         if (!error) {
+            // 네이티브 플랫폼인 경우 딥링크로 세션 전달 (브릿지 방식)
+            if (platform === 'native') {
+                const { data: { session } } = await supabase.auth.getSession()
+                if (session) {
+                    const params = new URLSearchParams()
+                    params.set('access_token', session.access_token)
+                    params.set('refresh_token', session.refresh_token)
+                    
+                    // onvoy://auth/callback#access_token=...&refresh_token=...
+                    return NextResponse.redirect(`onvoy://auth/callback#${params.toString()}`)
+                }
+            }
+            
             return NextResponse.redirect(`${origin}${next}`)
         }
 
         // --- Handle Exchange Error ---
         console.error('Auth exchange error:', error.message)
-        
+
         // Check if we already have a session (in case of duplicate/pre-fetch requests)
         const { data: { session } } = await supabase.auth.getSession()
         if (session) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -16,6 +16,12 @@ export async function GET(request: Request) {
     const code = searchParams.get('code')
     const provider = searchParams.get('provider') // Google 등 직접 provider 명시
     const state = searchParams.get('state')        // 카카오: state=provider=kakao 로 식별
+    
+    // state 파라미터가 쿼리 스트링 형태인 경우 (예: provider=kakao&platform=native) 파싱
+    const stateParams = new URLSearchParams(state ?? '')
+    const platformFromState = stateParams.get('platform')
+    const providerFromState = stateParams.get('provider')
+
     // if "next" is in param, use it as the redirect URL
     const next = searchParams.get('next') ?? '/'
 
@@ -27,11 +33,11 @@ export async function GET(request: Request) {
     }
 
     // ─── 카카오 OAuth 콜백 처리 ────────────────────────────────────────
-    // provider=kakao (직접 명시) 또는 state=provider=kakao (카카오 state 반환) 감지
-    const isKakaoCallback = provider === 'kakao' || state === 'provider=kakao'
+    // provider=kakao (직접 명시) 또는 state가 provider=kakao 형태인 경우 감지
+    const isKakaoCallback = provider === 'kakao' || providerFromState === 'kakao' || state === 'provider=kakao'
     if (isKakaoCallback && code) {
         try {
-            // 카카오 개발자 콘솔에 등록된 redirect_uri와 동일해야 함 (state 없는 기본 경로)
+            // 카카오 개발자 콘솔에 등록된 redirect_uri와 동일해야 함
             const redirectUri = `${origin}/auth/callback`
 
             const res = await fetch(SUPABASE_FUNCTION_URL, {
@@ -67,6 +73,15 @@ export async function GET(request: Request) {
                 )
             }
 
+            // 네이티브 플랫폼인 경우 딥링크로 세션 전달 (카카오 대응 브릿지)
+            const platform = searchParams.get('platform') ?? platformFromState
+            if (platform === 'native') {
+                const params = new URLSearchParams()
+                params.set('access_token', access_token)
+                params.set('refresh_token', refresh_token)
+                return NextResponse.redirect(`onvoy://auth/callback#${params.toString()}`)
+            }
+
             return NextResponse.redirect(`${origin}${next}`)
         } catch (err) {
             console.error('Kakao OAuth unexpected error:', err)
@@ -74,7 +89,7 @@ export async function GET(request: Request) {
         }
     }
 
-    const platform = searchParams.get('platform')
+    const platform = searchParams.get('platform') ?? platformFromState
 
     // ─── 기존 이메일 인증 / Google OAuth 콜백 처리 ────────────────────
     if (code) {

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -8,10 +8,11 @@ const SUPABASE_FUNCTION_URL = process.env.NEXT_PUBLIC_SUPABASE_URL
 
 /**
  * OAuth 리다이렉트 URL을 플랫폼(Web/Capacitor)에 따라 자동 분기합니다.
+ * @param forceWeb true인 경우 네이티브 플랫폼이어도 웹 URL을 반환합니다. (카카오 등 커스텀 스킴 미지원 대응)
  */
-function getOAuthRedirectUrl(): string {
+function getOAuthRedirectUrl(forceWeb = false): string {
   const isNative = typeof window !== 'undefined' && Capacitor.isNativePlatform()
-  if (isNative) {
+  if (isNative && !forceWeb) {
     return 'onvoy://auth/callback'
   }
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? (
@@ -22,17 +23,27 @@ function getOAuthRedirectUrl(): string {
 
 /**
  * 카카오 OAuth 인가 코드 요청 URL을 생성합니다.
- * redirect_uri는 /auth/callback (웹) 또는 onvoy://auth/callback (네이티브)으로 분기됩니다.
+ * 카카오는 커스텀 스킴(onvoy://)을 허용하지 않으므로 앱에서도 웹 콜백 URL을 사용하고,
+ * state 파라미터를 통해 플랫폼 정보를 전달합니다.
  */
 function buildKakaoAuthUrl(): string {
+  const isNative = typeof window !== 'undefined' && Capacitor.isNativePlatform()
   const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID ?? ''
-  const redirectUri = getOAuthRedirectUrl()
+  
+  // 카카오는 웹 리다이렉트 URL만 허용함
+  const redirectUri = getOAuthRedirectUrl(true)
+  
+  const stateParams = new URLSearchParams()
+  stateParams.set('provider', 'kakao')
+  if (isNative) {
+    stateParams.set('platform', 'native')
+  }
+
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: 'code',
-    // state 파라미터: 카카오가 콜백 시 그대로 반환 → /auth/callback에서 provider 식별에 사용
-    state: 'provider=kakao',
+    state: stateParams.toString(),
   })
   return `${KAKAO_AUTH_URL}?${params.toString()}`
 }

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,0 +1,122 @@
+import { createClient } from '@/utils/supabase/client'
+import { Capacitor } from '@capacitor/core'
+
+const KAKAO_AUTH_URL = 'https://kauth.kakao.com/oauth/authorize'
+const SUPABASE_FUNCTION_URL = process.env.NEXT_PUBLIC_SUPABASE_URL
+  ? `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/handle-kakao-oauth`
+  : ''
+
+/**
+ * OAuth 리다이렉트 URL을 플랫폼(Web/Capacitor)에 따라 자동 분기합니다.
+ */
+function getOAuthRedirectUrl(): string {
+  const isNative = typeof window !== 'undefined' && Capacitor.isNativePlatform()
+  if (isNative) {
+    return 'onvoy://auth/callback'
+  }
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? (
+    typeof window !== 'undefined' ? window.location.origin : 'https://app.nexvoy.xyz'
+  )
+  return `${appUrl}/auth/callback`
+}
+
+/**
+ * 카카오 OAuth 인가 코드 요청 URL을 생성합니다.
+ * redirect_uri는 /auth/callback (웹) 또는 onvoy://auth/callback (네이티브)으로 분기됩니다.
+ */
+function buildKakaoAuthUrl(): string {
+  const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID ?? ''
+  const redirectUri = getOAuthRedirectUrl()
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    // state 파라미터: 카카오가 콜백 시 그대로 반환 → /auth/callback에서 provider 식별에 사용
+    state: 'provider=kakao',
+  })
+  return `${KAKAO_AUTH_URL}?${params.toString()}`
+}
+
+export const AuthService = {
+  /**
+   * Google OAuth 로그인을 시작합니다.
+   * 서버 API Route(/api/auth/google)로 리다이렉트하여
+   * PKCE verifier를 서버 쿠키에 안전하게 저장합니다.
+   */
+  async signInWithGoogle(): Promise<void> {
+    if (typeof window !== 'undefined') {
+      const isNative = Capacitor.isNativePlatform()
+      if (isNative) {
+        // 네이티브 앱에서는 외부 브라우저를 통해 서버 API Route로 접근해야 함
+        // NEXT_PUBLIC_APP_URL이 설정되어 있어야 하며, 없으면 현재 origin을 시도
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin
+        const authUrl = `${appUrl}/api/auth/google?platform=native`
+        window.location.href = authUrl
+      } else {
+        window.location.href = '/api/auth/google'
+      }
+    }
+  },
+
+  /**
+   * 카카오 OAuth 로그인을 시작합니다.
+   * 카카오 인가 URL로 브라우저를 이동시킵니다.
+   * 콜백 처리는 handleKakaoCallback()에서 수행합니다.
+   */
+  signInWithKakao(): void {
+    const kakaoUrl = buildKakaoAuthUrl()
+    if (typeof window !== 'undefined') {
+      window.location.href = kakaoUrl
+    }
+  },
+
+  /**
+   * 카카오 OAuth 콜백에서 인가 코드를 받아 Supabase 세션으로 교환합니다.
+   * Edge Function `handle-kakao-oauth`를 호출합니다.
+   */
+  async handleKakaoCallback(code: string): Promise<void> {
+    const supabase = createClient()
+    const redirectUri = getOAuthRedirectUrl()
+
+    const res = await fetch(SUPABASE_FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '',
+      },
+      body: JSON.stringify({ code, redirect_uri: redirectUri }),
+    })
+
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}))
+      console.error('[AuthService] Kakao callback error:', errBody)
+      throw new Error(errBody?.error ?? '카카오 로그인 처리 중 오류가 발생했습니다.')
+    }
+
+    const { access_token, refresh_token } = await res.json()
+
+    const { error } = await supabase.auth.setSession({
+      access_token,
+      refresh_token,
+    })
+
+    if (error) {
+      console.error('[AuthService] setSession error:', error.message)
+      throw new Error(error.message)
+    }
+  },
+
+  /**
+   * 소셜 로그인 에러 메시지를 사용자 친화적인 한국어로 변환합니다.
+   */
+  normalizeOAuthError(error: unknown): string {
+    if (error instanceof Error) {
+      const msg = error.message.toLowerCase()
+      if (msg.includes('popup_closed')) return '로그인 창이 닫혔습니다. 다시 시도해 주세요.'
+      if (msg.includes('access_denied')) return '로그인이 취소되었습니다.'
+      if (msg.includes('network')) return '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'
+      return error.message
+    }
+    return '알 수 없는 오류가 발생했습니다.'
+  },
+}

--- a/src/services/LifecycleService.ts
+++ b/src/services/LifecycleService.ts
@@ -36,8 +36,36 @@ export const LifecycleService = {
                 });
 
                 // URL을 통해 앱이 열렸을 때 (딥링크 등도 포함)
-                App.addListener('appUrlOpen', (data: any) => {
+                App.addListener('appUrlOpen', async (data: any) => {
                     console.log(`[Lifecycle] App opened with URL: ${data.url}`);
+                    
+                    // ─── OAuth 세션 브릿지 처리 ─────────────────────────────
+                    if (data.url.includes('onvoy://auth/callback')) {
+                        try {
+                            const url = new URL(data.url.replace('#', '?')); // URLSearchParams가 fragment를 읽지 못하므로 변환
+                            const access_token = url.searchParams.get('access_token');
+                            const refresh_token = url.searchParams.get('refresh_token');
+                            
+                            if (access_token && refresh_token) {
+                                console.log('[Lifecycle] Auth tokens detected in deep link. Syncing session...');
+                                const supabase = createClient();
+                                const { error } = await supabase.auth.setSession({
+                                    access_token,
+                                    refresh_token
+                                });
+                                
+                                if (error) {
+                                    console.error('[Lifecycle] Sync session error:', error.message);
+                                } else {
+                                    console.log('[Lifecycle] Session synced successfully. Refreshing UI...');
+                                    window.dispatchEvent(new Event('focus')); // UI 갱신 유도
+                                }
+                            }
+                        } catch (err) {
+                            console.error('[Lifecycle] Error parsing deep link URL:', err);
+                        }
+                    }
+
                     this.handleResume('AppUrlOpen');
                 });
 
@@ -80,7 +108,7 @@ export const LifecycleService = {
             setTimeout(() => {
                 body.style.opacity = originalOpacity || '1';
                 console.log('[Lifecycle] UI Reflow finished');
-            }, 100);
+            }, 100); island
 
             // STEP 2: Supabase 세션 체크 (OS가 완전히 깨어날 수 있도록 500ms 지연)
             console.log('[Lifecycle] STEP 2: Delayed Session Recovery initiated');
@@ -98,7 +126,7 @@ export const LifecycleService = {
         try {
             console.log('[Lifecycle] refreshSession: Resetting Supabase client...');
             // 네이티브에서 싱글톤 클라이언트가 먹통이 되는 경우를 대비해 초기화
-            if (Capacitor.isNativePlatform()) {
+            if (Capaictor.isNativePlatform()) {
                 resetNativeClient();
             }
             

--- a/src/services/LifecycleService.ts
+++ b/src/services/LifecycleService.ts
@@ -108,7 +108,7 @@ export const LifecycleService = {
             setTimeout(() => {
                 body.style.opacity = originalOpacity || '1';
                 console.log('[Lifecycle] UI Reflow finished');
-            }, 100); island
+            }, 100);
 
             // STEP 2: Supabase 세션 체크 (OS가 완전히 깨어날 수 있도록 500ms 지연)
             console.log('[Lifecycle] STEP 2: Delayed Session Recovery initiated');
@@ -126,7 +126,7 @@ export const LifecycleService = {
         try {
             console.log('[Lifecycle] refreshSession: Resetting Supabase client...');
             // 네이티브에서 싱글톤 클라이언트가 먹통이 되는 경우를 대비해 초기화
-            if (Capaictor.isNativePlatform()) {
+            if (Capacitor.isNativePlatform()) {
                 resetNativeClient();
             }
             


### PR DESCRIPTION
## 개요
모바일 앱(Capacitor) 환경에서 구글 OAuth 로그인이 작동하지 않는 문제를 해결하기 위해 서버 사이드 세션 브릿지 로직을 구현했습니다.

## 주요 변경 사항
- **AuthService.ts**: 앱 환경에서 절대 경로를 사용하여 서버 API에 접근하도록 수정
- **google/route.ts**: 플랫폼 정보를 콜백 라우트로 전달
- **callback/route.ts**: 성공 시 앱의 딥링크(`onvoy://auth/callback`)로 세션 토큰을 포함하여 리다이렉트
- **LifecycleService.ts**: 앱에서 딥링크 수신 시 세션 토큰을 파싱하여 Supabase 세션 동기화

## 테스트 방법
1. 앱에서 구글 로그인을 시도합니다.
2. 외부 브라우저에서 로그인이 완료된 후 앱으로 돌아오는지 확인합니다.
3. 앱이 로그인된 상태로 정상적으로 전환되는지 확인합니다.