### PR TITLE
feat: Google 연동 추가 및 소셜 계정 연동 해제 기능 구현

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "xyz.nexvoy.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 34
-        versionName "0.6.4"
+        versionCode 36
+        versionName "0.6.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from 'next/server'
 export async function GET(request: Request) {
     const { searchParams, origin } = new URL(request.url)
     const platform = searchParams.get('platform')
+    const mode = searchParams.get('mode') // 'link' | null
     const cookieStore = await cookies()
 
     const supabase = createServerClient(
@@ -28,6 +29,11 @@ export async function GET(request: Request) {
     const callbackUrl = new URL(`${origin}/auth/callback`)
     if (platform) {
         callbackUrl.searchParams.set('platform', platform)
+    }
+    // 연동 모드: 콜백 완료 후 프로필 페이지로 복귀하도록 next 파라미터 설정
+    if (mode === 'link') {
+        callbackUrl.searchParams.set('mode', 'link')
+        callbackUrl.searchParams.set('provider', 'google')
     }
 
     // 서버에서 signInWithOAuth 호출 → PKCE verifier가 서버 쿠키에 안전하게 저장됨

--- a/src/app/api/auth/unlink-kakao/route.ts
+++ b/src/app/api/auth/unlink-kakao/route.ts
@@ -12,28 +12,8 @@ export async function POST() {
             return NextResponse.json({ error: '로그인이 필요합니다.' }, { status: 401 })
         }
 
-        // 2. Admin 클라이언트로 app_metadata.kakao_id 제거
-        const supabaseAdmin = createAdminClient(
-            process.env.NEXT_PUBLIC_SUPABASE_URL!,
-            process.env.SUPABASE_SERVICE_ROLE_KEY!,
-            { auth: { autoRefreshToken: false, persistSession: false } }
-        )
-
-        // app_metadata에서 kakao_id 제거
-        const { error: metaError } = await supabaseAdmin.auth.admin.updateUserById(user.id, {
-            app_metadata: {
-                ...user.app_metadata,
-                kakao_id: null,
-            },
-        })
-
-        if (metaError) {
-            console.error('[unlink-kakao] app_metadata update error:', metaError.message)
-            return NextResponse.json({ error: '연동 해제 중 오류가 발생했습니다.' }, { status: 500 })
-        }
-
-        // 3. profiles 테이블의 kakao_id 컬럼 null 처리
-        const { error: profileError } = await supabaseAdmin
+        // 2. profiles 테이블의 kakao_id 컬럼 null 처리 (RLS: 본인만 수정 가능)
+        const { error: profileError } = await supabase
             .from('profiles')
             .update({ kakao_id: null, updated_at: new Date().toISOString() })
             .eq('id', user.id)
@@ -43,9 +23,31 @@ export async function POST() {
             return NextResponse.json({ error: '프로필 업데이트 중 오류가 발생했습니다.' }, { status: 500 })
         }
 
+        // 3. (선택) app_metadata.kakao_id 제거 — Service Role Key가 있을 때만 수행
+        const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+        if (serviceRoleKey) {
+            try {
+                const supabaseAdmin = createAdminClient(
+                    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+                    serviceRoleKey,
+                    { auth: { autoRefreshToken: false, persistSession: false } }
+                )
+                const updatedMeta = { ...user.app_metadata }
+                delete updatedMeta.kakao_id
+
+                await supabaseAdmin.auth.admin.updateUserById(user.id, {
+                    app_metadata: updatedMeta,
+                })
+            } catch (metaErr: any) {
+                // app_metadata 업데이트 실패는 치명적이지 않으므로 warn만 기록
+                console.warn('[unlink-kakao] app_metadata update skipped:', metaErr?.message)
+            }
+        }
+
         return NextResponse.json({ success: true })
     } catch (err: any) {
         console.error('[unlink-kakao] unexpected error:', err)
         return NextResponse.json({ error: err.message ?? '알 수 없는 오류가 발생했습니다.' }, { status: 500 })
     }
 }
+

--- a/src/app/api/auth/unlink-kakao/route.ts
+++ b/src/app/api/auth/unlink-kakao/route.ts
@@ -4,7 +4,7 @@ import { createClient as createAdminClient } from '@supabase/supabase-js'
 
 export async function POST() {
     try {
-        // 1. 서버 측 Supabase 클라이언트로 현재 세션 검증
+        // 1. 서버 클라이언트로 현재 세션 검증
         const supabase = await createClient()
         const { data: { user }, error: authError } = await supabase.auth.getUser()
 
@@ -12,36 +12,37 @@ export async function POST() {
             return NextResponse.json({ error: '로그인이 필요합니다.' }, { status: 401 })
         }
 
-        // 2. profiles 테이블의 kakao_id 컬럼 null 처리 (RLS: 본인만 수정 가능)
-        const { error: profileError } = await supabase
+        // 2. Admin 클라이언트 (Service Role Key)
+        const supabaseAdmin = createAdminClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE_KEY!,
+            { auth: { autoRefreshToken: false, persistSession: false } }
+        )
+
+        // 3. app_metadata에서 kakao_id 제거 + provider 'email'로 복원
+        //    카카오 연동 시 provider가 'kakao'로 덮어씌워지므로 원복 필요
+        const updatedMeta = { ...user.app_metadata }
+        delete updatedMeta.kakao_id
+        if (updatedMeta.provider === 'kakao') {
+            updatedMeta.provider = 'email'
+        }
+
+        const { error: metaError } = await supabaseAdmin.auth.admin.updateUserById(user.id, {
+            app_metadata: updatedMeta,
+        })
+        if (metaError) {
+            console.error('[unlink-kakao] app_metadata update error:', metaError.message)
+            return NextResponse.json({ error: '연동 해제 중 오류가 발생했습니다.' }, { status: 500 })
+        }
+
+        // 4. profiles 테이블 kakao_id null 처리
+        const { error: profileError } = await supabaseAdmin
             .from('profiles')
             .update({ kakao_id: null, updated_at: new Date().toISOString() })
             .eq('id', user.id)
-
         if (profileError) {
             console.error('[unlink-kakao] profiles update error:', profileError.message)
             return NextResponse.json({ error: '프로필 업데이트 중 오류가 발생했습니다.' }, { status: 500 })
-        }
-
-        // 3. (선택) app_metadata.kakao_id 제거 — Service Role Key가 있을 때만 수행
-        const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-        if (serviceRoleKey) {
-            try {
-                const supabaseAdmin = createAdminClient(
-                    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-                    serviceRoleKey,
-                    { auth: { autoRefreshToken: false, persistSession: false } }
-                )
-                const updatedMeta = { ...user.app_metadata }
-                delete updatedMeta.kakao_id
-
-                await supabaseAdmin.auth.admin.updateUserById(user.id, {
-                    app_metadata: updatedMeta,
-                })
-            } catch (metaErr: any) {
-                // app_metadata 업데이트 실패는 치명적이지 않으므로 warn만 기록
-                console.warn('[unlink-kakao] app_metadata update skipped:', metaErr?.message)
-            }
         }
 
         return NextResponse.json({ success: true })
@@ -50,4 +51,3 @@ export async function POST() {
         return NextResponse.json({ error: err.message ?? '알 수 없는 오류가 발생했습니다.' }, { status: 500 })
     }
 }
-

--- a/src/app/api/auth/unlink-kakao/route.ts
+++ b/src/app/api/auth/unlink-kakao/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import { createClient as createAdminClient } from '@supabase/supabase-js'
+
+export async function POST() {
+    try {
+        // 1. 서버 측 Supabase 클라이언트로 현재 세션 검증
+        const supabase = await createClient()
+        const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+        if (authError || !user) {
+            return NextResponse.json({ error: '로그인이 필요합니다.' }, { status: 401 })
+        }
+
+        // 2. Admin 클라이언트로 app_metadata.kakao_id 제거
+        const supabaseAdmin = createAdminClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE_KEY!,
+            { auth: { autoRefreshToken: false, persistSession: false } }
+        )
+
+        // app_metadata에서 kakao_id 제거
+        const { error: metaError } = await supabaseAdmin.auth.admin.updateUserById(user.id, {
+            app_metadata: {
+                ...user.app_metadata,
+                kakao_id: null,
+            },
+        })
+
+        if (metaError) {
+            console.error('[unlink-kakao] app_metadata update error:', metaError.message)
+            return NextResponse.json({ error: '연동 해제 중 오류가 발생했습니다.' }, { status: 500 })
+        }
+
+        // 3. profiles 테이블의 kakao_id 컬럼 null 처리
+        const { error: profileError } = await supabaseAdmin
+            .from('profiles')
+            .update({ kakao_id: null, updated_at: new Date().toISOString() })
+            .eq('id', user.id)
+
+        if (profileError) {
+            console.error('[unlink-kakao] profiles update error:', profileError.message)
+            return NextResponse.json({ error: '프로필 업데이트 중 오류가 발생했습니다.' }, { status: 500 })
+        }
+
+        return NextResponse.json({ success: true })
+    } catch (err: any) {
+        console.error('[unlink-kakao] unexpected error:', err)
+        return NextResponse.json({ error: err.message ?? '알 수 없는 오류가 발생했습니다.' }, { status: 500 })
+    }
+}

--- a/src/app/api/auth/unlink-kakao/route.ts
+++ b/src/app/api/auth/unlink-kakao/route.ts
@@ -19,16 +19,23 @@ export async function POST() {
             { auth: { autoRefreshToken: false, persistSession: false } }
         )
 
-        // 3. app_metadata에서 kakao_id 제거 + provider 'email'로 복원
+        // 3. app_metadata 및 user_metadata에서 kakao_id 제거 (null 명시 필요)
+        //    * Supabase는 메타데이터 업데이트 시 병합(merge)을 수행하므로, 필드를 지우려면 반드시 null을 전달해야 합니다.
         //    카카오 연동 시 provider가 'kakao'로 덮어씌워지므로 원복 필요
-        const updatedMeta = { ...user.app_metadata }
-        delete updatedMeta.kakao_id
-        if (updatedMeta.provider === 'kakao') {
-            updatedMeta.provider = 'email'
+        const appMetadataUpdate = {
+            ...user.app_metadata,
+            kakao_id: null,
+            provider: user.app_metadata.provider === 'kakao' ? 'email' : user.app_metadata.provider
+        }
+
+        const userMetadataUpdate = {
+            ...user.user_metadata,
+            kakao_id: null
         }
 
         const { error: metaError } = await supabaseAdmin.auth.admin.updateUserById(user.id, {
-            app_metadata: updatedMeta,
+            app_metadata: appMetadataUpdate,
+            user_metadata: userMetadataUpdate
         })
         if (metaError) {
             console.error('[unlink-kakao] app_metadata update error:', metaError.message)

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -16,6 +16,7 @@ export async function GET(request: Request) {
     const code = searchParams.get('code')
     const provider = searchParams.get('provider') // Google 등 직접 provider 명시
     const state = searchParams.get('state')        // 카카오: state=provider=kakao 로 식별
+    const modeParam = searchParams.get('mode')     // 'link' | null (Google 연동 모드)
     
     // state 파라미터가 쿼리 스트링 형태인 경우 (예: provider=kakao&platform=native) 파싱
     const stateParams = new URLSearchParams(state ?? '')
@@ -142,6 +143,12 @@ export async function GET(request: Request) {
         const { error } = await supabase.auth.exchangeCodeForSession(code)
 
         if (!error) {
+            // Google 연동 모드: 코드 교환 성공 후 프로필 페이지로 복귀
+            const isGoogleLinkMode = (provider === 'google' || providerFromState === 'google') && (modeParam === 'link' || modeFromState === 'link')
+            if (isGoogleLinkMode) {
+                return NextResponse.redirect(`${origin}/profile?linked=google`)
+            }
+
             // 네이티브 플랫폼인 경우 딥링크로 세션 전달 (브릿지 방식)
             if (platform === 'native') {
                 const { data: { session } } = await supabase.auth.getSession()

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -149,6 +149,9 @@ function ProfileContent() {
             alert('카카오 계정 연동이 완료되었습니다! 🎉')
             // URL 파라미터 제거
             window.history.replaceState({}, '', window.location.pathname)
+        } else if (linked === 'google') {
+            alert('구글 계정 연동이 완료되었습니다! 🎉')
+            window.history.replaceState({}, '', window.location.pathname)
         } else if (error === 'conflict') {
             alert('이미 다른 계정에 연동된 카카오 계정입니다. 해당 계정에서 탈퇴하거나 연동 해제 후 다시 시도해 주세요.')
             window.history.replaceState({}, '', window.location.pathname)
@@ -432,16 +435,23 @@ function ProfileContent() {
                 </div>
             </section>
 
-            {/* 계정 연동 설정 */}
-            <section className={css({ bg: 'white', borderRadius: '32px', p: { base: '24px', sm: '32px' }, boxShadow: '0 8px 30px rgba(0,0,0,0.03)', border: '1px solid #F0F0F0' })}>
-                <h2 className={css({ fontSize: '18px', fontWeight: '850', mb: '24px', color: '#2C3A47', display: 'flex', alignItems: 'center', gap: '10px', letterSpacing: '-0.02em' })}>
-                    <div className={css({ w: '36px', h: '36px', bg: 'rgba(37, 99, 235, 0.08)', borderRadius: '12px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'brand.primary' })}>
-                        <ShieldCheck size={18} strokeWidth={2.5} />
-                    </div>
-                    계정 연동 설정
-                </h2>
-                <AccountLinking user={user} />
-            </section>
+            {/* 계정 연동 설정 — 이메일 가입 계정에서만 노출 */}
+            {(() => {
+                const primaryProvider = user?.app_metadata?.provider ?? 'email'
+                const isSocialSignup = primaryProvider === 'google' || primaryProvider === 'kakao'
+                if (isSocialSignup) return null
+                return (
+                    <section className={css({ bg: 'white', borderRadius: '32px', p: { base: '24px', sm: '32px' }, boxShadow: '0 8px 30px rgba(0,0,0,0.03)', border: '1px solid #F0F0F0' })}>
+                        <h2 className={css({ fontSize: '18px', fontWeight: '850', mb: '24px', color: '#2C3A47', display: 'flex', alignItems: 'center', gap: '10px', letterSpacing: '-0.02em' })}>
+                            <div className={css({ w: '36px', h: '36px', bg: 'rgba(37, 99, 235, 0.08)', borderRadius: '12px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'brand.primary' })}>
+                                <ShieldCheck size={18} strokeWidth={2.5} />
+                            </div>
+                            계정 연동 설정
+                        </h2>
+                        <AccountLinking user={user} />
+                    </section>
+                )
+            })()}
 
             {/* 계정 보안 설정 */}
             <section className={css({ bg: 'white', borderRadius: '32px', p: { base: '24px', sm: '32px' }, boxShadow: '0 8px 30px rgba(0,0,0,0.03)', border: '1px solid #F0F0F0' })}>

--- a/src/components/common/UnlinkConfirmModal.tsx
+++ b/src/components/common/UnlinkConfirmModal.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { css } from 'styled-system/css'
+import { AlertTriangle, Loader2, X } from 'lucide-react'
+
+interface UnlinkConfirmModalProps {
+  isOpen: boolean
+  provider: 'google' | 'kakao'
+  onConfirm: () => void
+  onCancel: () => void
+  isLoading?: boolean
+}
+
+const PROVIDER_INFO = {
+  google: {
+    label: '구글',
+    color: '#4285F4',
+    bg: 'rgba(66, 133, 244, 0.08)',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05" />
+        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+      </svg>
+    ),
+  },
+  kakao: {
+    label: '카카오',
+    color: '#191919',
+    bg: 'rgba(254, 229, 0, 0.15)',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path fillRule="evenodd" clipRule="evenodd" d="M12 3C6.48 3 2 6.48 2 10.8c0 2.73 1.6 5.13 4.02 6.6L5.1 21l4.46-2.95c.79.13 1.61.2 2.44.2 5.52 0 10-3.48 10-7.8C22 6.48 17.52 3 12 3z" fill="#371D1E" />
+      </svg>
+    ),
+  },
+}
+
+export default function UnlinkConfirmModal({
+  isOpen,
+  provider,
+  onConfirm,
+  onCancel,
+  isLoading = false,
+}: UnlinkConfirmModalProps) {
+  if (!isOpen) return null
+
+  const info = PROVIDER_INFO[provider]
+
+  return (
+    <div
+      className={css({
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        px: '20px',
+      })}
+    >
+      {/* 오버레이 */}
+      <div
+        onClick={!isLoading ? onCancel : undefined}
+        className={css({
+          position: 'absolute',
+          inset: 0,
+          bg: 'rgba(0, 0, 0, 0.45)',
+          backdropFilter: 'blur(4px)',
+          animation: 'fadeIn 0.2s ease',
+        })}
+      />
+
+      {/* 모달 카드 */}
+      <div
+        className={css({
+          position: 'relative',
+          bg: 'white',
+          borderRadius: '28px',
+          p: '32px 28px 28px',
+          w: '100%',
+          maxW: '360px',
+          boxShadow: '0 24px 60px rgba(0,0,0,0.15)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '20px',
+          animation: 'slideUp 0.25s cubic-bezier(0.2, 0, 0, 1)',
+        })}
+      >
+        {/* 닫기 버튼 */}
+        <button
+          onClick={!isLoading ? onCancel : undefined}
+          disabled={isLoading}
+          className={css({
+            position: 'absolute',
+            top: '16px',
+            right: '16px',
+            w: '32px',
+            h: '32px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bg: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            color: '#BBB',
+            borderRadius: '10px',
+            transition: 'all 0.2s',
+            _hover: { bg: '#F5F5F5', color: '#666' },
+            _disabled: { opacity: 0.4, cursor: 'not-allowed' },
+          })}
+        >
+          <X size={18} />
+        </button>
+
+        {/* 아이콘 + 제목 */}
+        <div className={css({ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '16px', textAlign: 'center' })}>
+          <div
+            className={css({
+              w: '60px',
+              h: '60px',
+              borderRadius: '20px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            })}
+            style={{ background: info.bg }}
+          >
+            {info.icon}
+          </div>
+
+          <div>
+            <h2 className={css({ fontSize: '18px', fontWeight: '850', color: '#2C3A47', letterSpacing: '-0.02em', mb: '8px' })}>
+              {info.label} 연동을 해제할까요?
+            </h2>
+            <p className={css({ fontSize: '14px', color: '#828D99', fontWeight: '600', lineHeight: '1.6' })}>
+              연동을 해제해도 이메일과 비밀번호로
+              <br />
+              계속 로그인할 수 있어요.
+            </p>
+          </div>
+        </div>
+
+        {/* 경고 배지 */}
+        <div
+          className={css({
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '8px',
+            p: '14px 16px',
+            bg: 'rgba(245, 158, 11, 0.08)',
+            borderRadius: '14px',
+            border: '1px solid rgba(245, 158, 11, 0.2)',
+          })}
+        >
+          <AlertTriangle size={15} color="#F59E0B" style={{ flexShrink: 0, marginTop: 1 }} />
+          <p className={css({ fontSize: '13px', color: '#92400E', fontWeight: '600', lineHeight: '1.5' })}>
+            해제 후 {info.label} 계정으로 로그인하려면 다시 연동해야 합니다.
+          </p>
+        </div>
+
+        {/* 버튼 영역 */}
+        <div className={css({ display: 'flex', gap: '10px' })}>
+          <button
+            onClick={!isLoading ? onCancel : undefined}
+            disabled={isLoading}
+            className={css({
+              flex: 1,
+              py: '14px',
+              bg: '#F5F5F5',
+              color: '#828D99',
+              borderRadius: '16px',
+              border: 'none',
+              cursor: 'pointer',
+              fontWeight: '750',
+              fontSize: '15px',
+              transition: 'all 0.2s',
+              _hover: { bg: '#EBEBEB' },
+              _active: { transform: 'scale(0.97)' },
+              _disabled: { opacity: 0.4, cursor: 'not-allowed' },
+            })}
+          >
+            취소
+          </button>
+          <button
+            onClick={!isLoading ? onConfirm : undefined}
+            disabled={isLoading}
+            className={css({
+              flex: 1,
+              py: '14px',
+              bg: '#EF4444',
+              color: 'white',
+              borderRadius: '16px',
+              border: 'none',
+              cursor: 'pointer',
+              fontWeight: '800',
+              fontSize: '15px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '6px',
+              transition: 'all 0.2s',
+              boxShadow: '0 4px 12px rgba(239, 68, 68, 0.25)',
+              _hover: { bg: '#DC2626', boxShadow: '0 6px 16px rgba(239, 68, 68, 0.3)', transform: 'translateY(-1px)' },
+              _active: { transform: 'scale(0.97)' },
+              _disabled: { opacity: 0.6, cursor: 'not-allowed', boxShadow: 'none', transform: 'none' },
+            })}
+          >
+            {isLoading ? (
+              <Loader2 size={16} className={css({ animation: 'spin 1s linear infinite' })} />
+            ) : null}
+            {isLoading ? '해제 중...' : '연동 해제'}
+          </button>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes fadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes slideUp {
+          from { opacity: 0; transform: translateY(20px) scale(0.97); }
+          to { opacity: 1; transform: translateY(0) scale(1); }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/components/profile/AccountLinking.tsx
+++ b/src/components/profile/AccountLinking.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { css } from 'styled-system/css'
 import { MessageCircle, CheckCircle2, ChevronRight, Loader2, Link2Off } from 'lucide-react'
 import { AuthService } from '@/services/AuthService'
+import { createClient } from '@/utils/supabase/client'
 import UnlinkConfirmModal from '@/components/common/UnlinkConfirmModal'
 
 interface AccountLinkingProps {
@@ -79,7 +80,9 @@ export default function AccountLinking({ user }: AccountLinkingProps) {
         await AuthService.unlinkKakaoAccount()
       }
       setUnlinkTarget(null)
-      // 연동 상태 갱신을 위해 페이지 새로고침
+      // app_metadata 변경이 클라이언트 JWT에 반영되도록 세션 강제 갱신
+      const supabase = createClient()
+      await supabase.auth.refreshSession()
       router.refresh()
       window.location.reload()
     } catch (err: any) {

--- a/src/components/profile/AccountLinking.tsx
+++ b/src/components/profile/AccountLinking.tsx
@@ -149,6 +149,10 @@ export default function AccountLinking({ user }: AccountLinkingProps) {
                 해제
               </button>
             </div>
+          ) : isKakaoLinked ? (
+            <div className={css({ fontSize: '13px', color: 'brand.muted', fontWeight: '600', px: '8px' })}>
+              카카오 해제 후 연동 가능
+            </div>
           ) : (
             <button
               onClick={handleLinkGoogle}
@@ -222,6 +226,10 @@ export default function AccountLinking({ user }: AccountLinkingProps) {
                 <Link2Off size={13} />
                 해제
               </button>
+            </div>
+          ) : isGoogleLinked ? (
+            <div className={css({ fontSize: '13px', color: 'brand.muted', fontWeight: '600', px: '8px' })}>
+              구글 해제 후 연동 가능
             </div>
           ) : (
             <button

--- a/src/components/profile/AccountLinking.tsx
+++ b/src/components/profile/AccountLinking.tsx
@@ -1,140 +1,264 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { css } from 'styled-system/css'
-import { MessageCircle, CheckCircle2, ChevronRight, AlertCircle, Loader2 } from 'lucide-react'
+import { MessageCircle, CheckCircle2, ChevronRight, Loader2, Link2Off } from 'lucide-react'
 import { AuthService } from '@/services/AuthService'
+import UnlinkConfirmModal from '@/components/common/UnlinkConfirmModal'
 
 interface AccountLinkingProps {
   user: any
 }
 
-export default function AccountLinking({ user }: AccountLinkingProps) {
-  const [loading, setLoading] = useState(false)
+// Google 공식 SVG 아이콘
+const GoogleIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05" />
+    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+  </svg>
+)
 
-  // 연동 상태 확인 (identities 또는 app_metadata 활용)
+export default function AccountLinking({ user }: AccountLinkingProps) {
+  const router = useRouter()
+  const [linkingGoogle, setLinkingGoogle] = useState(false)
+  const [linkingKakao, setLinkingKakao] = useState(false)
+  const [isUnlinking, setIsUnlinking] = useState(false)
+  const [unlinkTarget, setUnlinkTarget] = useState<'google' | 'kakao' | null>(null)
+  const [unlinkError, setUnlinkError] = useState('')
+
+  // 연동 상태 확인
   const identities = user?.identities || []
   const appMetadata = user?.app_metadata || {}
 
   const isKakaoLinked = identities.some((id: any) => id.provider === 'kakao') || !!appMetadata.kakao_id
-  const isGoogleLinked = identities.some((id: any) => id.provider === 'google') || !!appMetadata.google_id
-  
-  // 사용자의 주 로그인 방식 (이메일인지 확인)
-  const isEmailUser = user?.app_metadata?.provider === 'email' || (!isKakaoLinked && !isGoogleLinked)
+  const isGoogleLinked = identities.some((id: any) => id.provider === 'google')
 
-  const handleLinkKakao = async () => {
-    if (loading || isKakaoLinked) return
-    setLoading(true)
+  // 최초 가입 방식 판단: google/kakao로 가입한 경우 섹션 전체 숨김
+  const primaryProvider = appMetadata.provider ?? 'email'
+  const isSocialSignup = primaryProvider === 'google' || primaryProvider === 'kakao'
+
+  // 소셜 계정(구글/카카오)으로 가입한 경우 이 섹션을 표시하지 않음
+  if (isSocialSignup) return null
+
+  const handleLinkGoogle = () => {
+    if (linkingGoogle || isGoogleLinked) return
+    setLinkingGoogle(true)
     try {
-      AuthService.linkKakaoAccount()
+      AuthService.linkGoogleAccount()
+      // 리다이렉트 발생 → 로딩 상태 유지
     } catch (error) {
-      console.error('Failed to initiate Kakao linking:', error)
-      setLoading(false)
+      console.error('Failed to initiate Google linking:', error)
+      setLinkingGoogle(false)
     }
   }
 
-  // 구글이나 카카오로 이미 연동된 상태라면 버튼을 노출하지 않거나 상태만 표시 (사용자 요청: "구글 또는 카카오로 연동되어 있지 않은 상태에서만")
-  // 하지만 이미 카카오로 연동된 경우에는 '연동됨' 상태를 보여주는 것이 좋음.
-  const canLink = isEmailUser && !isGoogleLinked && !isKakaoLinked
+  const handleLinkKakao = () => {
+    if (linkingKakao || isKakaoLinked) return
+    setLinkingKakao(true)
+    try {
+      AuthService.linkKakaoAccount()
+      // 리다이렉트 발생 → 로딩 상태 유지
+    } catch (error) {
+      console.error('Failed to initiate Kakao linking:', error)
+      setLinkingKakao(false)
+    }
+  }
+
+  const handleUnlinkConfirm = async () => {
+    if (!unlinkTarget) return
+    setIsUnlinking(true)
+    setUnlinkError('')
+
+    try {
+      if (unlinkTarget === 'google') {
+        await AuthService.unlinkGoogleAccount()
+      } else {
+        await AuthService.unlinkKakaoAccount()
+      }
+      setUnlinkTarget(null)
+      // 연동 상태 갱신을 위해 페이지 새로고침
+      router.refresh()
+      window.location.reload()
+    } catch (err: any) {
+      console.error('Unlink failed:', err)
+      setUnlinkError(err.message ?? '연동 해제 중 오류가 발생했습니다. 다시 시도해 주세요.')
+      setIsUnlinking(false)
+    }
+  }
 
   return (
-    <div className={css({ 
-      display: 'flex', 
-      flexDirection: 'column', 
-      gap: '12px',
-      mb: '12px'
-    })}>
-      <div className={css({
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        p: '20px',
-        bg: 'bg.softCotton',
-        borderRadius: '20px',
-        border: '1px solid #F0F0F0',
-        transition: 'all 0.2s',
-        _hover: canLink ? { borderColor: 'brand.primary', bg: 'white', boxShadow: '0 4px 12px rgba(0,0,0,0.05)' } : {}
-      })}>
-        <div className={css({ display: 'flex', alignItems: 'center', gap: '14px' })}>
-          <div className={css({ 
-            w: '44px', 
-            h: '44px', 
-            bg: '#FEE500', 
-            borderRadius: '14px', 
-            display: 'flex', 
-            alignItems: 'center', 
-            justifyContent: 'center',
-            color: '#191919',
-            boxShadow: '0 4px 10px rgba(254, 229, 0, 0.2)'
-          })}>
-            <MessageCircle size={22} fill="currentColor" />
+    <>
+      <div className={css({ display: 'flex', flexDirection: 'column', gap: '12px' })}>
+
+        {/* ── Google 연동 row ── */}
+        <div className={css({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          p: '20px',
+          bg: 'bg.softCotton',
+          borderRadius: '20px',
+          border: '1px solid #F0F0F0',
+          transition: 'all 0.2s',
+          _hover: !isGoogleLinked ? { borderColor: 'brand.primary', bg: 'white', boxShadow: '0 4px 12px rgba(0,0,0,0.05)' } : {},
+        })}>
+          <div className={css({ display: 'flex', alignItems: 'center', gap: '14px' })}>
+            <div className={css({
+              w: '44px', h: '44px',
+              bg: 'white',
+              borderRadius: '14px',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+              border: '1px solid #F0F0F0',
+            })}>
+              <GoogleIcon />
+            </div>
+            <div>
+              <div className={css({ fontSize: '15px', fontWeight: '800', color: 'brand.secondary' })}>구글 계정 연동</div>
+              <p className={css({ fontSize: '13px', color: 'brand.muted', mt: '2px', fontWeight: '600' })}>
+                {isGoogleLinked ? '구글 계정과 연결되어 있습니다.' : '구글 로그인 기능을 활성화합니다.'}
+              </p>
+            </div>
           </div>
-          <div>
-            <div className={css({ fontSize: '15px', fontWeight: '800', color: 'brand.secondary' })}>카카오 계정 연동</div>
-            <p className={css({ fontSize: '13px', color: 'brand.muted', mt: '2px', fontWeight: '600' })}>
-              {isKakaoLinked ? '이미 카카오 계정과 연결되어 있습니다.' : '카카오 로그인 기능을 활성화합니다.'}
-            </p>
-          </div>
+
+          {isGoogleLinked ? (
+            <div className={css({ display: 'flex', alignItems: 'center', gap: '8px' })}>
+              <div className={css({ display: 'flex', alignItems: 'center', gap: '6px', color: 'brand.success', fontWeight: '800', fontSize: '14px', bg: 'rgba(34, 197, 94, 0.08)', px: '12px', py: '6px', borderRadius: '10px' })}>
+                <CheckCircle2 size={16} />
+                연동됨
+              </div>
+              <button
+                onClick={() => { setUnlinkError(''); setUnlinkTarget('google') }}
+                className={css({
+                  display: 'flex', alignItems: 'center', gap: '4px',
+                  bg: 'rgba(239, 68, 68, 0.06)', color: '#EF4444',
+                  px: '10px', py: '6px', borderRadius: '10px',
+                  fontSize: '13px', fontWeight: '750', border: 'none', cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  _hover: { bg: 'rgba(239, 68, 68, 0.12)' },
+                  _active: { transform: 'scale(0.95)' },
+                })}
+              >
+                <Link2Off size={13} />
+                해제
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleLinkGoogle}
+              disabled={linkingGoogle}
+              className={css({
+                display: 'flex', alignItems: 'center', gap: '4px',
+                bg: 'brand.primary', color: 'white',
+                px: '14px', py: '8px', borderRadius: '12px',
+                fontSize: '14px', fontWeight: '800', border: 'none', cursor: 'pointer',
+                transition: 'all 0.2s',
+                _hover: { bg: '#1D4ED8', transform: 'translateX(2px)' },
+                _active: { transform: 'scale(0.95)' },
+                _disabled: { opacity: 0.6, cursor: 'not-allowed' },
+              })}
+            >
+              {linkingGoogle ? <Loader2 size={16} className={css({ animation: 'spin 1s linear infinite' })} /> : '연동하기'}
+              {!linkingGoogle && <ChevronRight size={16} />}
+            </button>
+          )}
         </div>
 
-        {isKakaoLinked ? (
-          <div className={css({ display: 'flex', alignItems: 'center', gap: '6px', color: 'brand.success', fontWeight: '800', fontSize: '14px', bg: 'rgba(34, 197, 94, 0.08)', px: '12px', py: '6px', borderRadius: '10px' })}>
-            <CheckCircle2 size={16} />
-            연동됨
-          </div>
-        ) : canLink ? (
-          <button
-            onClick={handleLinkKakao}
-            disabled={loading}
-            className={css({
-              display: 'flex',
-              alignItems: 'center',
-              gap: '4px',
-              bg: 'brand.primary',
-              color: 'white',
-              px: '14px',
-              py: '8px',
-              borderRadius: '12px',
-              fontSize: '14px',
-              fontWeight: '800',
-              border: 'none',
-              cursor: 'pointer',
-              transition: 'all 0.2s',
-              _hover: { bg: '#1D4ED8', transform: 'translateX(2px)' },
-              _active: { transform: 'scale(0.95)' },
-              _disabled: { opacity: 0.6, cursor: 'not-allowed' }
-            })}
-          >
-            {loading ? <Loader2 size={16} className={css({ animation: 'spin 1s linear infinite' })} /> : '연동하기'}
-            {!loading && <ChevronRight size={16} />}
-          </button>
-        ) : isGoogleLinked ? (
-            <div className={css({ display: 'flex', alignItems: 'center', gap: '6px', color: 'brand.muted', fontWeight: '700', fontSize: '13px', opacity: 0.7 })}>
-                <AlertCircle size={14} />
-                구글 계정 연동 중
+        {/* ── 카카오 연동 row ── */}
+        <div className={css({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          p: '20px',
+          bg: 'bg.softCotton',
+          borderRadius: '20px',
+          border: '1px solid #F0F0F0',
+          transition: 'all 0.2s',
+          _hover: !isKakaoLinked ? { borderColor: 'brand.primary', bg: 'white', boxShadow: '0 4px 12px rgba(0,0,0,0.05)' } : {},
+        })}>
+          <div className={css({ display: 'flex', alignItems: 'center', gap: '14px' })}>
+            <div className={css({
+              w: '44px', h: '44px',
+              bg: '#FEE500',
+              borderRadius: '14px',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: '#191919',
+              boxShadow: '0 4px 10px rgba(254, 229, 0, 0.2)',
+            })}>
+              <MessageCircle size={22} fill="currentColor" />
             </div>
-        ) : (
-          <div className={css({ fontSize: '13px', color: 'brand.muted', fontWeight: '600', opacity: 0.6 })}>
-            연동 불가
+            <div>
+              <div className={css({ fontSize: '15px', fontWeight: '800', color: 'brand.secondary' })}>카카오 계정 연동</div>
+              <p className={css({ fontSize: '13px', color: 'brand.muted', mt: '2px', fontWeight: '600' })}>
+                {isKakaoLinked ? '카카오 계정과 연결되어 있습니다.' : '카카오 로그인 기능을 활성화합니다.'}
+              </p>
+            </div>
           </div>
+
+          {isKakaoLinked ? (
+            <div className={css({ display: 'flex', alignItems: 'center', gap: '8px' })}>
+              <div className={css({ display: 'flex', alignItems: 'center', gap: '6px', color: 'brand.success', fontWeight: '800', fontSize: '14px', bg: 'rgba(34, 197, 94, 0.08)', px: '12px', py: '6px', borderRadius: '10px' })}>
+                <CheckCircle2 size={16} />
+                연동됨
+              </div>
+              <button
+                onClick={() => { setUnlinkError(''); setUnlinkTarget('kakao') }}
+                className={css({
+                  display: 'flex', alignItems: 'center', gap: '4px',
+                  bg: 'rgba(239, 68, 68, 0.06)', color: '#EF4444',
+                  px: '10px', py: '6px', borderRadius: '10px',
+                  fontSize: '13px', fontWeight: '750', border: 'none', cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  _hover: { bg: 'rgba(239, 68, 68, 0.12)' },
+                  _active: { transform: 'scale(0.95)' },
+                })}
+              >
+                <Link2Off size={13} />
+                해제
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleLinkKakao}
+              disabled={linkingKakao}
+              className={css({
+                display: 'flex', alignItems: 'center', gap: '4px',
+                bg: 'brand.primary', color: 'white',
+                px: '14px', py: '8px', borderRadius: '12px',
+                fontSize: '14px', fontWeight: '800', border: 'none', cursor: 'pointer',
+                transition: 'all 0.2s',
+                _hover: { bg: '#1D4ED8', transform: 'translateX(2px)' },
+                _active: { transform: 'scale(0.95)' },
+                _disabled: { opacity: 0.6, cursor: 'not-allowed' },
+              })}
+            >
+              {linkingKakao ? <Loader2 size={16} className={css({ animation: 'spin 1s linear infinite' })} /> : '연동하기'}
+              {!linkingKakao && <ChevronRight size={16} />}
+            </button>
+          )}
+        </div>
+
+        {/* 연동 해제 에러 메시지 */}
+        {unlinkError && (
+          <p className={css({ fontSize: '13px', color: '#EF4444', fontWeight: '700', px: '4px', display: 'flex', alignItems: 'center', gap: '6px' })}>
+            ⚠️ {unlinkError}
+          </p>
         )}
       </div>
 
-      {!isKakaoLinked && !canLink && (
-        <div className={css({ 
-          fontSize: '12px', 
-          color: 'brand.muted', 
-          px: '12px', 
-          fontWeight: '600',
-          display: 'flex',
-          alignItems: 'flex-start',
-          gap: '6px',
-          lineHeight: '1.5'
-        })}>
-          <AlertCircle size={14} className={css({ flexShrink: 0, mt: '1px' })} />
-          구글 또는 카카오로 이미 소셜 연동된 계정은 추가 연동이 제한됩니다.
-        </div>
+      {/* 연동 해제 확인 모달 */}
+      {unlinkTarget && (
+        <UnlinkConfirmModal
+          isOpen={!!unlinkTarget}
+          provider={unlinkTarget}
+          onConfirm={handleUnlinkConfirm}
+          onCancel={() => { if (!isUnlinking) { setUnlinkTarget(null); setUnlinkError('') } }}
+          isLoading={isUnlinking}
+        />
       )}
-    </div>
+    </>
   )
 }

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -90,6 +90,50 @@ export const AuthService = {
   },
 
   /**
+   * 로그인된 상태에서 구글 계정 연동을 시작합니다.
+   * /api/auth/google?mode=link 로 리다이렉트하여 PKCE 흐름을 서버에서 처리합니다.
+   */
+  linkGoogleAccount(): void {
+    if (typeof window !== 'undefined') {
+      const isNative = Capacitor.isNativePlatform()
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin
+      const base = isNative ? appUrl : ''
+      window.location.href = `${base}/api/auth/google?mode=link`
+    }
+  },
+
+  /**
+   * 구글 계정 연동을 해제합니다.
+   * Supabase native unlinkIdentity API를 사용합니다.
+   */
+  async unlinkGoogleAccount(): Promise<void> {
+    const supabase = createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) throw new Error('로그인이 필요합니다.')
+
+    const googleIdentity = user.identities?.find((id: any) => id.provider === 'google')
+    if (!googleIdentity) throw new Error('연동된 구글 계정이 없습니다.')
+
+    const { error } = await supabase.auth.unlinkIdentity(googleIdentity)
+    if (error) throw new Error(error.message)
+  },
+
+  /**
+   * 카카오 계정 연동을 해제합니다.
+   * 커스텀 API Route(/api/auth/unlink-kakao)를 호출하여 서버 측에서 처리합니다.
+   */
+  async unlinkKakaoAccount(): Promise<void> {
+    const res = await fetch('/api/auth/unlink-kakao', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new Error(body?.error ?? '카카오 연동 해제 중 오류가 발생했습니다.')
+    }
+  },
+
+  /**
    * 카카오 OAuth 콜백에서 인가 코드를 받아 Supabase 세션으로 교환합니다.
    * Edge Function `handle-kakao-oauth`를 호출합니다.
    */

--- a/supabase/functions/handle-kakao-oauth/config.toml
+++ b/supabase/functions/handle-kakao-oauth/config.toml
@@ -1,0 +1,2 @@
+[functions.handle-kakao-oauth]
+verify_jwt = false

--- a/supabase/functions/handle-kakao-oauth/index.ts
+++ b/supabase/functions/handle-kakao-oauth/index.ts
@@ -76,7 +76,7 @@ Deno.serve(async (req: Request) => {
       userId = currentUser.id;
       finalEmail = currentUser.email;
       await supabaseAdmin.auth.admin.updateUserById(userId, { 
-        app_metadata: { kakao_id: kakaoId, provider: 'kakao' }, 
+        app_metadata: { ...currentUser.app_metadata, kakao_id: kakaoId }, 
         user_metadata: { ...currentUser.user_metadata, kakao_id: kakaoId } 
       });
     } else {


### PR DESCRIPTION
Resolves #157

## 변경 사항

### 🆕 신규 컴포넌트
- **`UnlinkConfirmModal.tsx`** — 커스텀 연동 해제 확인 모달 (`src/components/common/`)
  - provider(google/kakao)별 아이콘, 색상 자동 분기
  - 경고 배지 + 취소/해제 버튼 포함
  - PC 웹과 모바일 앱 모두에서 일관된 UX 제공
- **`api/auth/unlink-kakao/route.ts`** — 카카오 연동 해제 서버 API
  - 세션 검증 → `profiles.kakao_id` + `auth.users.app_metadata.kakao_id` null 처리

### ✏️ 수정 파일
| 파일 | 내용 |
|---|---|
| `AccountLinking.tsx` | 구글 연동 row 추가, 연동 해제 버튼, 소셜 가입자 섹션 숨김 |
| `AuthService.ts` | `linkGoogleAccount`, `unlinkGoogleAccount`, `unlinkKakaoAccount` 추가 |
| `api/auth/google/route.ts` | `mode=link` 파라미터 지원 (구글 연동 모드) |
| `auth/callback/route.ts` | Google 연동 모드 콜백 분기 처리 추가 |
| `profile/page.tsx` | `linked=google` URL 파라미터 처리 추가, 소셜 가입 계정 섹션 wrapper 숨김 |

## 동작 조건

| 가입 방식 | 계정 연동 섹션 |
|---|---|
| 이메일 + 미연동 | ✅ 구글/카카오 연동하기 |
| 이메일 + 구글 연동됨 | ✅ 구글 연동됨+해제 / 카카오 연동하기 |
| 이메일 + 카카오 연동됨 | ✅ 구글 연동하기 / 카카오 연동됨+해제 |
| 구글로 가입 | ❌ 섹션 없음 |
| 카카오로 가입 | ❌ 섹션 없음 |

## 빌드 결과
- ✅ `pnpm build` — 성공
- ✅ `pnpm build:mobile` — 성공