### PR TITLE
feat: 명시적 여행 다운로드 및 오프라인 관리 UI 구현 (#162)

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,6 +10,7 @@ import TermsModal from '../signup/TermsModal'
 import ProfileSkeleton from './ProfileSkeleton'
 import BugReportModal from '@/components/profile/BugReportModal'
 import AccountLinking from '@/components/profile/AccountLinking'
+import DownloadedTripsModal from '@/components/profile/DownloadedTripsModal'
 import { AuthService } from '@/services/AuthService'
 
 function ProfileContent() {
@@ -24,6 +25,7 @@ function ProfileContent() {
     const [nicknameError, setNicknameError] = useState('')
     const [loading, setLoading] = useState(true)
     const [isBugModalOpen, setIsBugModalOpen] = useState(false)
+    const [isOfflineModalOpen, setIsOfflineModalOpen] = useState(false)
 
     const [currentPassword, setCurrentPassword] = useState('')
     const [newPassword, setNewPassword] = useState('')
@@ -604,6 +606,38 @@ function ProfileContent() {
                             <ChevronRight size={20} className={css({ color: '#CCC', transition: 'all 0.2s' })} />
                         </Link>
                     ))}
+
+                    {/* 오프라인 여행 관리 메뉴 */}
+                    <button
+                        onClick={() => setIsOfflineModalOpen(true)}
+                        className={css({
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            px: '24px',
+                            py: '20px',
+                            borderTop: '1px solid #F5F5F5',
+                            bg: 'transparent',
+                            border: 'none',
+                            cursor: 'pointer',
+                            w: '100%',
+                            textAlign: 'left',
+                            transition: 'all 0.25s ease',
+                            _hover: { bg: 'rgba(37, 99, 235, 0.04)', px: '28px' },
+                            _active: { bg: 'rgba(37, 99, 235, 0.08)' }
+                        })}
+                    >
+                        <div className={css({ display: 'flex', alignItems: 'center', gap: '16px' })}>
+                            <div className={css({ fontSize: '22px', w: '40px', h: '40px', display: 'flex', alignItems: 'center', justifyContent: 'center', bg: 'bg.softCotton', borderRadius: '12px' })}>
+                                📴
+                            </div>
+                            <div>
+                                <div className={css({ fontSize: '16px', fontWeight: '750', color: 'brand.secondary' })}>오프라인 여행 관리</div>
+                                <div className={css({ fontSize: '13px', color: 'brand.muted', mt: '2px', fontWeight: '600' })}>다운로드된 여행 목록을 관리하고 삭제할 수 있습니다</div>
+                            </div>
+                        </div>
+                        <ChevronRight size={20} className={css({ color: '#CCC', transition: 'all 0.2s' })} />
+                    </button>
                     {/* 건의 및 버그 제보 — 페이지 이동 대신 모달 */}
                     <button
                         onClick={() => setIsBugModalOpen(true)}
@@ -642,6 +676,11 @@ function ProfileContent() {
                     isOpen={isBugModalOpen}
                     onClose={() => setIsBugModalOpen(false)}
                     user={user}
+                />
+                
+                <DownloadedTripsModal
+                    isOpen={isOfflineModalOpen}
+                    onClose={() => setIsOfflineModalOpen(false)}
                 />
             </section>
 

--- a/src/app/trips/checklist/ChecklistClient.tsx
+++ b/src/app/trips/checklist/ChecklistClient.tsx
@@ -9,6 +9,7 @@ import { Plus, CheckSquare, Square, Trash2, Settings, ChevronDown, Check, ListTo
 import Link from 'next/link'
 import TemplateModal from '@/components/trips/TemplateModal'
 import { CacheUtil } from '@/utils/cache'
+import { DownloadService } from '@/services/DownloadService'
 import { useNetworkStore } from '@/stores/useNetworkStore'
 import { CATEGORIES } from '@/constants/checklist'
 import ChecklistSkeleton from './ChecklistSkeleton'
@@ -401,14 +402,18 @@ export default function ChecklistPage({ isActive = true }: { isActive?: boolean 
         if (!tripId) return
 
         try {
-            // 1. 캐시에서 로드 (깜빡임 방지)
-            const cachedItems = await CacheUtil.get<any[]>(`offline_checklist_items_${tripId}`)
-            if (cachedItems) {
-                setItems(cachedItems)
-                setIsLoading(false)
+            // 1. 오프라인이거나 캐시 로드가 필요한 경우 번들에서 로드
+            const bundle = await DownloadService.getBundle(tripId)
+            if (bundle) {
+                if (!isOnline || items.length === 0) {
+                    if (bundle.checklistItems) setItems(bundle.checklistItems)
+                    if (bundle.checklistChecks) setUserChecks(bundle.checklistChecks)
+                    if (!isOnline) {
+                        setIsLoading(false)
+                        return
+                    }
+                }
             }
-            const cachedChecks = await CacheUtil.get<any[]>(`offline_checklist_checks_${tripId}`)
-            if (cachedChecks) setUserChecks(cachedChecks)
 
             // 2. 네트워크 확인
             if (!isOnline) {
@@ -452,7 +457,12 @@ export default function ChecklistPage({ isActive = true }: { isActive?: boolean 
                 
                 if (itemsRes.data) {
                     setItems(itemsRes.data)
-                    await CacheUtil.set(`offline_checklist_items_${tripId}`, itemsRes.data)
+                    // 명시적 다운로드 정책에 따라 자동 저장은 제거
+                    
+                    // 이미 다운로드된 여행이라면 백그라운드에서 전체 데이터 동기화
+                    if (bundle) {
+                        DownloadService.downloadTrip(tripId!)
+                    }
                     
                     const itemIds = itemsRes.data.map((i: any) => i.id)
                     if (itemIds.length > 0) {
@@ -462,7 +472,7 @@ export default function ChecklistPage({ isActive = true }: { isActive?: boolean 
                             .in('item_id', itemIds)
                         if (checks) {
                             setUserChecks(checks)
-                            await CacheUtil.set(`offline_checklist_checks_${tripId}`, checks)
+                            // 명시적 다운로드 정책에 따라 자동 저장은 제거
                         }
                     }
 

--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -16,6 +16,8 @@ import { getCurrencyFromTimezone } from '@/utils/currency'
 import { ExchangeService } from '@/services/ExternalApiService'
 import { CacheUtil } from '@/utils/cache'
 import { NotificationService } from '@/services/NotificationService'
+import { DownloadService } from '@/services/DownloadService'
+import { Download, CloudDownload, CloudCheck, Loader2 } from 'lucide-react'
 import TripDetailSkeleton from './TripDetailSkeleton'
 const CustomTimeDropdown = ({ timeDisplayMode, setTimeDisplayMode }: any) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -90,6 +92,8 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
     const [timeDisplayMode, setTimeDisplayMode] = useState<'local' | 'kst' | 'both'>('local')
     const [userRole, setUserRole] = useState<'owner' | 'editor' | 'viewer' | null>(null)
     const { isOnline } = useNetworkStore()
+    const [isDownloaded, setIsDownloaded] = useState(false)
+    const [isDownloading, setIsDownloading] = useState(false)
 
     const [activeDropdown, setActiveDropdown] = useState<string | null>(null)
     const [editingPlan, setEditingPlan] = useState<any>(null)
@@ -174,22 +178,40 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
 
     const fetchTrip = useCallback(async () => {
         if (!tripId) return
+
+        // 오프라인이면 번들에서 시도
+        if (!isOnline) {
+            const bundle = await DownloadService.getBundle(tripId)
+            if (bundle?.trip) {
+                setTrip(bundle.trip)
+                return
+            }
+        }
+
         const { data } = await supabase.from('trips').select('*').eq('id', tripId).single()
         if (data) setTrip(data)
-    }, [tripId, supabase])
+    }, [tripId, supabase, isOnline])
 
     const fetchPlans = useCallback(async () => {
         if (!tripId) return
 
         try {
-            // 1. Load from cache first
-            const cachedPlans = await CacheUtil.get<any[]>(`offline_plans_${tripId}`)
-            if (cachedPlans) {
-                setPlans(cachedPlans)
-                setIsLoading(false)
+            // 1. 오프라인이거나 캐시 로드가 필요한 경우 번들에서 로드
+            const bundle = await DownloadService.getBundle(tripId)
+            if (bundle) {
+                setIsDownloaded(true)
+                if (!isOnline || plans.length === 0) {
+                    setPlans(bundle.plans)
+                    if (!isOnline) {
+                        setIsLoading(false)
+                        return
+                    }
+                }
+            } else {
+                setIsDownloaded(false)
             }
 
-            // 2. Network check
+            // 2. 네트워크 확인
             if (!isOnline) {
                 setIsLoading(false)
                 return
@@ -203,8 +225,13 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
 
             if (data && !error) {
                 setPlans(data)
-                await CacheUtil.set(`offline_plans_${tripId}`, data)
+                // 명시적 다운로드 정책에 따라 자동 저장은 제거하고 알림만 예약
                 NotificationService.scheduleOfflineReminders(data)
+                
+                // 이미 다운로드된 여행이라면 백그라운드에서 최신 데이터로 동기화
+                if (bundle) {
+                    DownloadService.downloadTrip(tripId)
+                }
             } else {
                 throw new Error("Failed to fetch")
             }
@@ -213,7 +240,7 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
         } finally {
             setIsLoading(false)
         }
-    }, [tripId, supabase, isOnline])
+    }, [tripId, supabase, isOnline, plans.length])
 
     const fetchUserRole = useCallback(async () => {
         if (!tripId) return
@@ -279,6 +306,21 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
     const handlePlanDetail = (plan: any) => {
         setSelectedPlanForDetail(plan)
         setIsDetailModalOpen(true)
+    }
+
+    const handleDownload = async () => {
+        if (!tripId || isDownloading) return
+        
+        setIsDownloading(true)
+        const success = await DownloadService.downloadTrip(tripId)
+        setIsDownloading(false)
+        
+        if (success) {
+            setIsDownloaded(true)
+            alert('여행 정보가 성공적으로 다운로드되었습니다. 오프라인에서도 확인할 수 있습니다!')
+        } else {
+            alert('다운로드에 실패했습니다. 네트워크 상태를 확인해 주세요.')
+        }
     }
 
     // 24시간 이내 가장 가까운 일정 계산
@@ -371,6 +413,31 @@ export default function TripPlansPage({ isActive = true }: { isActive?: boolean 
                             disabled={!isOnline}
                         >
                             <UserPlus size={16} /> <span>동행자</span>
+                        </button>
+
+                        <button
+                            onClick={handleDownload}
+                            className={css({
+                                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px',
+                                bg: isDownloaded ? 'rgba(46, 196, 182, 0.05)' : 'white',
+                                color: isDownloaded ? 'brand.primary' : 'brand.secondary',
+                                px: '12px', h: '42px',
+                                borderRadius: '16px', fontWeight: '700', fontSize: '13px',
+                                border: '1px solid', borderColor: isDownloaded ? 'brand.primary' : 'brand.border',
+                                whiteSpace: 'nowrap', transition: 'all 0.2s',
+                                _hover: { bg: 'bg.softCotton', borderColor: 'brand.primary' },
+                                _active: { transform: 'scale(0.92)' },
+                                flex: 1
+                            })}
+                        >
+                            {isDownloading ? (
+                                <Loader2 size={16} className={css({ animation: 'spin 1s linear infinite' })} />
+                            ) : isDownloaded ? (
+                                <CloudCheck size={16} />
+                            ) : (
+                                <CloudDownload size={16} />
+                            )}
+                            <span>{isDownloading ? '다운로드 중' : isDownloaded ? '다운로드됨' : '다운로드'}</span>
                         </button>
                         {userRole === 'owner' && (
                             <button

--- a/src/components/profile/DownloadedTripsModal.tsx
+++ b/src/components/profile/DownloadedTripsModal.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { css } from 'styled-system/css'
+import { Download, Trash2, X, MapPin, Calendar, ExternalLink, CloudCheck } from 'lucide-react'
+import { DownloadService, DownloadedTripMetadata } from '@/services/DownloadService'
+
+interface DownloadedTripsModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export default function DownloadedTripsModal({ isOpen, onClose }: DownloadedTripsModalProps) {
+    const [trips, setTrips] = useState<DownloadedTripMetadata[]>([])
+    const [isLoading, setIsLoading] = useState(true)
+
+    const fetchTrips = async () => {
+        setIsLoading(true)
+        const data = await DownloadService.getDownloadedTrips()
+        setTrips(data)
+        setIsLoading(false)
+    }
+
+    useEffect(() => {
+        if (isOpen) {
+            fetchTrips()
+        }
+    }, [isOpen])
+
+    const handleDelete = async (e: React.MouseEvent, id: string) => {
+        e.stopPropagation()
+        if (confirm('이 여행 데이터를 삭제하시겠습니까? 오프라인에서는 더 이상 볼 수 없게 됩니다.')) {
+            await DownloadService.removeDownloadedTrip(id)
+            fetchTrips()
+        }
+    }
+
+    if (!isOpen) return null
+
+    return (
+        <div className={css({
+            position: 'fixed', inset: 0, zIndex: 1000,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            p: { base: '16px', sm: '24px' }
+        })}>
+            <div 
+                className={css({ position: 'absolute', inset: 0, bg: 'rgba(0,0,0,0.4)', backdropFilter: 'blur(4px)' })} 
+                onClick={onClose} 
+            />
+            
+            <div className={css({
+                position: 'relative',
+                w: '100%', maxW: '500px',
+                bg: 'white', borderRadius: '32px',
+                boxShadow: '0 20px 40px rgba(0,0,0,0.2)',
+                display: 'flex', flexDirection: 'column',
+                maxH: '80vh', overflow: 'hidden',
+                animation: 'slideUp 0.3s ease-out'
+            })}>
+                {/* Header */}
+                <div className={css({
+                    p: '24px', borderBottom: '1px solid #F0F0F0',
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between'
+                })}>
+                    <div className={css({ display: 'flex', alignItems: 'center', gap: '12px' })}>
+                        <div className={css({ w: '40px', h: '40px', bg: 'rgba(37, 99, 235, 0.08)', borderRadius: '12px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'brand.primary' })}>
+                            <Download size={20} strokeWidth={2.5} />
+                        </div>
+                        <div>
+                            <h3 className={css({ fontSize: '18px', fontWeight: '850', color: '#2C3A47' })}>오프라인 여행 관리</h3>
+                            <p className={css({ fontSize: '13px', color: 'brand.muted', fontWeight: '600' })}>다운로드된 여행 목록</p>
+                        </div>
+                    </div>
+                    <button 
+                        onClick={onClose}
+                        className={css({ p: '8px', borderRadius: '12px', border: 'none', bg: 'bg.softCotton', color: 'brand.muted', cursor: 'pointer', _hover: { bg: '#FEE2E2', color: '#EF4444' } })}
+                    >
+                        <X size={20} />
+                    </button>
+                </div>
+
+                {/* Content */}
+                <div className={css({ flex: 1, overflowY: 'auto', p: '12px' })}>
+                    {isLoading ? (
+                        <div className={css({ p: '40px', textAlign: 'center', color: 'brand.muted' })}>불러오는 중...</div>
+                    ) : trips.length === 0 ? (
+                        <div className={css({ p: '60px 20px', textAlign: 'center' })}>
+                            <div className={css({ fontSize: '40px', mb: '16px' })}>📴</div>
+                            <p className={css({ fontSize: '16px', fontWeight: '700', color: 'brand.secondary' })}>다운로드된 여행이 없어요.</p>
+                            <p className={css({ fontSize: '13px', color: 'brand.muted', mt: '4px', fontWeight: '500' })}>여행 상세 페이지에서 다운로드할 수 있습니다.</p>
+                        </div>
+                    ) : (
+                        <div className={css({ display: 'flex', flexDirection: 'column', gap: '8px' })}>
+                            {trips.map(trip => (
+                                <div 
+                                    key={trip.id}
+                                    className={css({
+                                        p: '16px', borderRadius: '20px', border: '1px solid #F0F0F0',
+                                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                        transition: 'all 0.2s', _hover: { bg: '#FAFAFA' }
+                                    })}
+                                >
+                                    <div className={css({ display: 'flex', flexDirection: 'column', gap: '4px', flex: 1 })}>
+                                        <h4 className={css({ fontSize: '15px', fontWeight: '750', color: 'brand.secondary', display: 'flex', alignItems: 'center', gap: '6px' })}>
+                                            <CloudCheck size={14} className={css({ color: 'brand.primary' })} />
+                                            {trip.destination}
+                                        </h4>
+                                        <div className={css({ display: 'flex', alignItems: 'center', gap: '10px', color: 'brand.muted', fontSize: '12px', fontWeight: '600' })}>
+                                            <span className={css({ display: 'flex', alignItems: 'center', gap: '4px' })}>
+                                                <Calendar size={12} /> {trip.start_date} ~ {trip.end_date}
+                                            </span>
+                                        </div>
+                                        <span className={css({ fontSize: '11px', color: '#BBB', mt: '2px' })}>
+                                            다운로드: {new Date(trip.downloadedAt).toLocaleDateString()}
+                                        </span>
+                                    </div>
+                                    <button 
+                                        onClick={(e) => handleDelete(e, trip.id)}
+                                        className={css({ 
+                                            p: '10px', borderRadius: '12px', border: 'none', 
+                                            bg: 'rgba(244, 63, 94, 0.05)', color: '#F43F5E', 
+                                            cursor: 'pointer', transition: 'all 0.2s',
+                                            _hover: { bg: '#F43F5E', color: 'white' }
+                                        })}
+                                        title="삭제"
+                                    >
+                                        <Trash2 size={18} />
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                {/* Footer */}
+                <div className={css({ p: '16px', bg: '#F8F9FA', borderTop: '1px solid #F0F0F0' })}>
+                    <p className={css({ fontSize: '12px', color: 'brand.muted', textAlign: 'center', fontWeight: '500' })}>
+                        오프라인 데이터는 기기의 저장 공간을 사용합니다.<br/>더 이상 필요 없는 여행은 삭제해 주세요.
+                    </p>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -1,0 +1,153 @@
+import { createClient } from '@/utils/supabase/client'
+import { CacheUtil } from '@/utils/cache'
+
+export interface DownloadedTripMetadata {
+    id: string;
+    title: string;
+    destination: string;
+    start_date: string;
+    end_date: string;
+    downloadedAt: string;
+}
+
+export interface TripBundle {
+    trip: any;
+    plans: any[];
+    checklist: any | null;
+    checklistItems: any[];
+    checklistChecks: any[];
+    downloadedAt: string;
+}
+
+const REGISTRY_KEY = 'downloaded_trip_registry'
+const BUNDLE_PREFIX = 'trip_bundle_'
+
+export const DownloadService = {
+    /**
+     * 특정 여행의 모든 데이터를 가져와서 로컬에 저장합니다.
+     */
+    async downloadTrip(tripId: string): Promise<boolean> {
+        const supabase = createClient()
+        
+        try {
+            // 1. 여행 기본 정보
+            const { data: trip, error: tripErr } = await supabase
+                .from('trips')
+                .select('*')
+                .eq('id', tripId)
+                .single()
+            
+            if (tripErr || !trip) throw new Error('Trip not found')
+
+            // 2. 일정 정보 (Plan + PlanURLs)
+            const { data: plans, error: plansErr } = await supabase
+                .from('plans')
+                .select('*, plan_urls(*)')
+                .eq('trip_id', tripId)
+                .order('start_datetime_local', { ascending: true })
+            
+            if (plansErr) throw new Error('Plans fetch failed')
+
+            // 3. 체크리스트 정보
+            const { data: checklists } = await supabase
+                .from('checklists')
+                .select('*')
+                .eq('trip_id', tripId)
+                .limit(1)
+            
+            const checklist = checklists?.[0] || null
+            let checklistItems: any[] = []
+            let checklistChecks: any[] = []
+
+            if (checklist) {
+                const { data: items } = await supabase
+                    .from('checklist_items')
+                    .select('*')
+                    .eq('checklist_id', checklist.id)
+                
+                if (items) {
+                    checklistItems = items
+                    const itemIds = items.map(i => i.id)
+                    if (itemIds.length > 0) {
+                        const { data: checks } = await supabase
+                            .from('checklist_item_user_checks')
+                            .select('*')
+                            .in('item_id', itemIds)
+                        if (checks) checklistChecks = checks
+                    }
+                }
+            }
+
+            // 4. 번들 생성 및 저장
+            const bundle: TripBundle = {
+                trip,
+                plans: plans || [],
+                checklist,
+                checklistItems,
+                checklistChecks,
+                downloadedAt: new Date().toISOString()
+            }
+
+            await CacheUtil.set(`${BUNDLE_PREFIX}${tripId}`, bundle)
+
+            // 5. 레지스트리 업데이트
+            await this.addToRegistry({
+                id: trip.id,
+                title: trip.title,
+                destination: trip.destination,
+                start_date: trip.start_date,
+                end_date: trip.end_date,
+                downloadedAt: bundle.downloadedAt
+            })
+
+            return true
+        } catch (error) {
+            console.error('DownloadService.downloadTrip failed:', error)
+            return false
+        }
+    },
+
+    /**
+     * 로컬에 저장된 여행 데이터를 삭제합니다.
+     */
+    async removeDownloadedTrip(tripId: string): Promise<void> {
+        await CacheUtil.remove(`${BUNDLE_PREFIX}${tripId}`)
+        
+        const registry = await this.getDownloadedTrips()
+        const updatedRegistry = registry.filter(t => t.id !== tripId)
+        await CacheUtil.set(REGISTRY_KEY, updatedRegistry)
+    },
+
+    /**
+     * 다운로드된 여행 목록을 가져옵니다.
+     */
+    async getDownloadedTrips(): Promise<DownloadedTripMetadata[]> {
+        const registry = await CacheUtil.get<DownloadedTripMetadata[]>(REGISTRY_KEY)
+        return registry || []
+    },
+
+    /**
+     * 특정 여행이 다운로드되어 있는지 확인합니다.
+     */
+    async isDownloaded(tripId: string): Promise<boolean> {
+        const registry = await this.getDownloadedTrips()
+        return registry.some(t => t.id === tripId)
+    },
+
+    /**
+     * 레지스트리에 새 여행 정보를 추가합니다 (중복 방지).
+     */
+    async addToRegistry(metadata: DownloadedTripMetadata): Promise<void> {
+        const registry = await this.getDownloadedTrips()
+        const filtered = registry.filter(t => t.id !== metadata.id)
+        const updated = [metadata, ...filtered]
+        await CacheUtil.set(REGISTRY_KEY, updated)
+    },
+
+    /**
+     * 다운로드된 번들 데이터를 직접 가져옵니다.
+     */
+    async getBundle(tripId: string): Promise<TripBundle | null> {
+        return await CacheUtil.get<TripBundle>(`${BUNDLE_PREFIX}${tripId}`)
+    }
+}

--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -67,7 +67,7 @@ export const DownloadService = {
                 
                 if (items) {
                     checklistItems = items
-                    const itemIds = items.map(i => i.id)
+                    const itemIds = items.map((i: any) => i.id)
                     if (itemIds.length > 0) {
                         const { data: checks } = await supabase
                             .from('checklist_item_user_checks')


### PR DESCRIPTION
### 주요 구현 내용 (#162)

1. **DownloadService 도입**
   - 여행 상세 정보를 하나의 번들로 묶어 로컬 스토리지에 저장하는 기능 구현
   - 다운로드된 여행 레지스트리 관리 (목록 조회 및 삭제)

2. **여행 상세/체크리스트 연동**
   - 상단 액션바에 다운로드 버튼 추가
   - 오프라인 상태에서 번들 데이터 우선 로드
   - 온라인 시 이미 다운로드된 여행은 백그라운드 자동 동기화

3. **프로필 관리 UI**
   - '오프라인 여행 관리' 메뉴 및 모달 추가
   - 다운로드된 항목 확인 및 삭제 가능

### 테스트 완료 사항
- [x] 다운로드 버튼 클릭 시 번들 정상 생성 확인
- [x] 오프라인 모드 시 번들 데이터를 통한 화면 표시 확인
- [x] 프로필 페이지에서 삭제 시 스토리지 초기화 확인