### PR TITLE
feat: implement CacheUtil.clear and cleanup legacy caches (#164)

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -297,12 +297,6 @@ export default function HomeClient() {
 
     const allTrips = trips || []
     processTrips(allTrips)
-    
-    try {
-      await CacheUtil.set('offline_home_all_trips', allTrips)
-    } catch (e) {
-      console.warn('Cache save failed', e)
-    }
   }, [supabase, processTrips])
 
   // 인증 상태 실시간 감지 (로그인 직후 세션 반영 대응)
@@ -337,15 +331,6 @@ export default function HomeClient() {
             setNickname(cachedProfile.nickname)
         } else {
             setNickname(localUser.email?.split('@')[0] || '여행자')
-        }
-        try {
-          // 캐시된 목록 즉시 적용
-          const cachedTrips = await CacheUtil.get<any[]>('offline_home_all_trips')
-          if (cachedTrips) {
-            processTrips(cachedTrips)
-          }
-        } catch (e) {
-          console.warn('Cache load failed', e)
         }
       }
       // 세션을 확인했든 못 했든 초기 로딩 해제 (화면 진입)

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,6 +12,7 @@ import BugReportModal from '@/components/profile/BugReportModal'
 import AccountLinking from '@/components/profile/AccountLinking'
 import DownloadedTripsModal from '@/components/profile/DownloadedTripsModal'
 import { AuthService } from '@/services/AuthService'
+import { CacheUtil } from '@/utils/cache'
 
 function ProfileContent() {
     const supabase = createClient()
@@ -228,11 +229,10 @@ function ProfileContent() {
     }
     
     const handleLogout = async () => {
-        const { error } = await supabase.auth.signOut()
-        if (!error) {
-            router.push('/')
-            router.refresh()
-        }
+        await supabase.auth.signOut()
+        await CacheUtil.clear()
+        router.push('/')
+        router.refresh()
     }
     
     if (loading) {

--- a/src/app/profile/withdrawal/page.tsx
+++ b/src/app/profile/withdrawal/page.tsx
@@ -6,6 +6,7 @@ import { css } from 'styled-system/css'
 import { ChevronLeft, AlertTriangle } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { CacheUtil } from '@/utils/cache'
 
 export default function WithdrawalPage() {
     const router = useRouter()
@@ -67,9 +68,7 @@ export default function WithdrawalPage() {
         await supabase.auth.signOut()
         
         // 3. Clear local storage cache
-        if (typeof window !== 'undefined') {
-            localStorage.clear()
-        }
+        await CacheUtil.clear()
 
         router.push('/')
     }

--- a/src/app/trips/checklist/ChecklistClient.tsx
+++ b/src/app/trips/checklist/ChecklistClient.tsx
@@ -417,13 +417,6 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                 return
             }
 
-            // 1. 캐시에서 로드 (깜빡임 방지)
-            const cachedItems = await CacheUtil.get<any[]>(`offline_checklist_items_${tripId}`)
-            if (cachedItems) {
-                setItems(cachedItems)
-                setIsLoading(false)
-            }
-
             // 2. 네트워크 확인
             const { isOfflineMode } = useNetworkStore.getState()
             if (!isOnline || isOfflineMode) {

--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -199,13 +199,6 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                 return
             }
 
-            // 1. 캐시에서 로드 (깜빡임 방지 / Fallback)
-            const cachedPlans = await CacheUtil.get<any[]>(`offline_plans_${tripId}`)
-            if (cachedPlans && plans.length === 0) {
-                setPlans(cachedPlans)
-                setIsLoading(false)
-            }
-
             // 2. 네트워크 확인
             const { isOfflineMode } = useNetworkStore.getState()
             if (!isOnline || isOfflineMode) {

--- a/src/app/trips/detail/TripLayoutClient.tsx
+++ b/src/app/trips/detail/TripLayoutClient.tsx
@@ -63,12 +63,6 @@ export default function TripLayoutClient() {
             if (!id) return;
             
             try {
-                // 1. 캐시에서 먼저 로드 (화면 깜빡임 방지용)
-                const cachedTrip = await CacheUtil.get<any>(`trip_${id}`)
-                if (cachedTrip) {
-                    setTrip(cachedTrip)
-                    setLoading(false)
-                }
 
                 // 2. 인증 세션 확인 (오프라인 대응)
                 const { data: { session } } = await supabase.auth.getSession()
@@ -96,7 +90,6 @@ export default function TripLayoutClient() {
                     router.replace('/404')
                 } else {
                     setTrip(data)
-                    await CacheUtil.set(`trip_${id}`, data) // 캐시 업데이트
                 }
             } catch (err) {
                 console.error('Failed to fetch trip:', err)

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -64,7 +64,7 @@ export default function Navbar() {
             if (networkUser) {
                 await CacheUtil.setAuthUser(networkUser)
             } else {
-                await CacheUtil.remove('auth_last_user')
+                await CacheUtil.clear()
             }
             setLoading(false)
         }
@@ -76,7 +76,7 @@ export default function Navbar() {
             if (currentUser) {
                 await CacheUtil.setAuthUser(currentUser)
             } else {
-                await CacheUtil.remove('auth_last_user')
+                await CacheUtil.clear()
             }
         })
 
@@ -90,7 +90,7 @@ export default function Navbar() {
 
     const handleSignOut = async () => {
         await supabase.auth.signOut()
-        await CacheUtil.remove('auth_last_user')
+        await CacheUtil.clear()
         router.push('/')
         router.refresh()
     }

--- a/src/components/trips/TripSwitcherModal.tsx
+++ b/src/components/trips/TripSwitcherModal.tsx
@@ -98,15 +98,6 @@ export default function TripSwitcherModal() {
             setLoading(true)
             const supabase = createClient()
             
-            // 1. 캐시 시도
-            try {
-                const cached = await CacheUtil.get<Trip[]>('offline_home_all_trips')
-                if (cached) {
-                    processTrips(cached)
-                }
-            } catch (e) {
-                console.warn('Cache load failed', e)
-            }
 
             // 2. 네트워크 페칭
             const { data: { user } } = await supabase.auth.getUser()
@@ -136,7 +127,6 @@ export default function TripSwitcherModal() {
             const { data: trips } = await query.order('start_date', { ascending: true })
             if (trips) {
                 processTrips(trips as Trip[])
-                await CacheUtil.set('offline_home_all_trips', trips)
             }
             setLoading(false)
         }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -48,5 +48,16 @@ export const CacheUtil = {
 
     async getProfile() {
         return await this.get<any>('auth_last_profile')
+    },
+
+    async clear() {
+        try {
+            await Preferences.clear()
+            if (typeof window !== 'undefined') {
+                localStorage.clear()
+            }
+        } catch (e) {
+            console.warn('Cache clearing failed', e)
+        }
     }
 }


### PR DESCRIPTION
캐싱 정책 전면 재수립(#160)의 네 번째 서브 태스크입니다.

**주요 작업 내용**:
* `CacheUtil.clear()` 구현: Capacitor `Preferences`와 웹 `localStorage`를 모두 초기화하여 사용자 전환 시 데이터 격리 보장.
* 로그아웃 및 회원 탈퇴 흐름에 전면 초기화 로직 통합.
* `HomeClient`, `TripDetail`, `Checklist`, `TripSwitcherModal` 등에서 목적이 불분명한 레거시 캐싱 로직(`offline_home_all_trips`, `trip_${id}` 등) 제거.
* 온라인 상태에서는 항상 최신 데이터를 페칭하고, 오프라인 시에는 명시적으로 다운로드된 번들만 사용하도록 표준화.

Closes #164