### PR TITLE
feat: 환율 데이터 서버 및 클라이언트 사이드 캐싱 구현 (#169)

### DIFF
--- a/src/app/api/exchange/route.ts
+++ b/src/app/api/exchange/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
         // Frankfurter API: 1 {from} = ? KRW
         const res = await fetch(
             `https://api.frankfurter.app/latest?from=${from}&to=KRW`,
-            { next: { revalidate: 3600 } } // 1시간 캐싱
+            { next: { revalidate: 86400 } } // 1일(24시간) 캐싱
         )
 
         if (!res.ok) {

--- a/src/services/ExternalApiService.ts
+++ b/src/services/ExternalApiService.ts
@@ -1,13 +1,40 @@
 import { apiService } from './ApiService';
 import { Capacitor } from '@capacitor/core';
+import { CacheUtil } from '@/utils/cache';
 
 /**
  * 환율 정보 서비스
  */
 export const ExchangeService = {
   getExchangeRate: async (fromCode: string) => {
-    const response = await apiService.get(`/api/exchange/`, { from: fromCode });
-    return response.data;
+    const cacheKey = `exchange_rate_${fromCode}`;
+    const CACHE_TTL = 24 * 60 * 60 * 1000; // 24시간
+
+    try {
+      // 1. 로컬 캐시 확인
+      const cached = await CacheUtil.get<{ rate: number; timestamp: number }>(cacheKey);
+      if (cached && (Date.now() - cached.timestamp < CACHE_TTL)) {
+        return { from: fromCode, to: 'KRW', rate: cached.rate };
+      }
+
+      // 2. 서버 호출
+      const response = await apiService.get(`/api/exchange/`, { from: fromCode });
+      const data = response.data;
+
+      if (data && data.rate) {
+        // 3. 캐시 업데이트
+        await CacheUtil.set(cacheKey, { rate: data.rate, timestamp: Date.now() });
+      }
+      return data;
+    } catch (error) {
+      console.warn('[ExchangeService] Failed to fetch, trying stale cache...', error);
+      // 4. 실패 시 (오프라인 등) 만료된 캐시라도 있다면 반환
+      const stale = await CacheUtil.get<{ rate: number; timestamp: number }>(cacheKey);
+      if (stale) {
+        return { from: fromCode, to: 'KRW', rate: stale.rate, isStale: true };
+      }
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
캐싱 정책 전면 재수립(#160)의 다섯 번째 서브 태스크입니다.

**주요 작업 내용**:
* **서버 사이드 최적화**: `api/exchange` 라우트의 캐시 `revalidate` 주기를 1시간에서 **24시간**으로 연장하여 외부 API 호출을 대폭 절감했습니다.
* **클라이언트 사이드 지속성 캐시**: `ExchangeService`가 `CacheUtil`을 통해 환율 데이터를 로컬에 저장하도록 구현했습니다.
* **오프라인 및 장애 대응**: 네트워크가 불안정하거나 오프라인인 경우에도 이전에 성공적으로 캐시된 데이터를 활용하여 환율 계산 기능을 유지합니다 (Stale Cache Fallback).

Closes #169