### PR TITLE
feat: 오프라인 네비게이션 및 다운로드 UI 개선 (#177)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next"
 import BugReportFAB from '@/components/layout/BugReportFAB'
 import UpdateOverlay from '@/components/layout/UpdateOverlay'
 import GlobalModals from '@/components/layout/GlobalModals'
+import ToastContainer from '@/components/common/ToastContainer'
 
 export const metadata: Metadata = {
   title: '온여정 - 당신의 따뜻한 여행 동반자',
@@ -75,6 +76,7 @@ export default function RootLayout({
         )}
         <NativeAnalytics />
         <GlobalModals />
+        <ToastContainer />
       </body>
     </html>
   )

--- a/src/app/offline/trips/detail/page.tsx
+++ b/src/app/offline/trips/detail/page.tsx
@@ -39,7 +39,7 @@ function OfflineTripContent() {
                 }
             } else {
                 alert('해당 여행의 오프라인 데이터가 없습니다.')
-                router.replace('/')
+                router.replace('/offline')
             }
             setLoading(false)
         }

--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -407,30 +407,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                                     <UserPlus size={16} /> <span>동행자</span>
                                 </button>
 
-                                <button
-                                    onClick={handleDownload}
-                                    className={css({
-                                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px',
-                                        bg: isDownloaded ? 'rgba(46, 196, 182, 0.05)' : 'white',
-                                        color: isDownloaded ? 'brand.primary' : 'brand.ink',
-                                        px: '12px', h: '42px',
-                                        borderRadius: '8px', fontWeight: '700', fontSize: '13px',
-                                        border: '1px solid', borderColor: isDownloaded ? 'brand.primary' : 'brand.hairline',
-                                        whiteSpace: 'nowrap', transition: 'all 0.2s',
-                                        _hover: { bg: 'bg.softCotton', borderColor: 'brand.primary' },
-                                        _active: { transform: 'scale(0.92)' },
-                                        flex: 1
-                                    })}
-                                >
-                                    {isDownloading ? (
-                                        <Loader2 size={16} className={css({ animation: 'spin 1s linear infinite' })} />
-                                    ) : isDownloaded ? (
-                                        <CloudCheck size={16} />
-                                    ) : (
-                                        <CloudDownload size={16} />
-                                    )}
-                                    <span>{isDownloading ? '다운로드 중' : isDownloaded ? '다운로드됨' : '다운로드'}</span>
-                                </button>
+
 
                                 {userRole === 'owner' && (
                                     <button

--- a/src/components/common/OfflineBanner.tsx
+++ b/src/components/common/OfflineBanner.tsx
@@ -26,55 +26,5 @@ export default function OfflineBanner() {
         LifecycleService.initialize()
     }, [initializeNetworkListener])
 
-    if (!mounted || (isOnline && !isOfflineMode)) return null
-
-    return (
-        <div className={css({
-            bg: isOfflineMode ? 'brand.secondary' : 'brand.error',
-            color: 'white',
-            px: '20px',
-            py: '12px',
-            textAlign: 'center',
-            fontSize: '14px',
-            fontWeight: '700',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: '8px',
-            animation: 'fadeIn 0.3s ease-out',
-            zIndex: 1100,
-            position: 'relative',
-            boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
-        })}>
-            <div className={css({ display: 'flex', alignItems: 'center', gap: '8px' })}>
-                <WifiOff size={16} />
-                {isOfflineMode ? '현재 오프라인 모드로 동작 중입니다.' : '네트워크 연결이 끊어졌습니다.'}
-            </div>
-
-            {isOfflineMode && isOnline && (
-                <button
-                    onClick={() => {
-                        setOfflineMode(false)
-                        // 온라인 복귀 시 새로고침하여 최신 상태 반영
-                        window.location.reload() 
-                    }}
-                    className={css({
-                        mt: '4px',
-                        bg: 'brand.primary',
-                        color: 'white',
-                        border: 'none',
-                        px: '16px',
-                        py: '6px',
-                        borderRadius: '20px',
-                        fontSize: '12px',
-                        fontWeight: '800',
-                        cursor: 'pointer'
-                    })}
-                >
-                    온라인 모드로 복귀
-                </button>
-            )}
-        </div>
-    )
+    return null
 }

--- a/src/components/common/OfflinePromptModal.tsx
+++ b/src/components/common/OfflinePromptModal.tsx
@@ -27,16 +27,8 @@ export default function OfflinePromptModal() {
         setOfflineMode(true)
         setIsOpen(false)
         
-        // 현재 경로에 따라 오프라인 전용 페이지로 전환
-        if (pathname.includes('/trips/detail/')) {
-            const id = pathname.split('/').filter(Boolean).pop()
-            router.push(`/offline/trips/detail/?id=${id}&tab=plans`)
-        } else if (pathname.includes('/trips/checklist/')) {
-            const id = pathname.split('/').filter(Boolean).pop()
-            router.push(`/offline/trips/detail/?id=${id}&tab=checklist`)
-        } else {
-            router.push('/offline')
-        }
+        // 오프라인 모드 전환 시 항상 오프라인 홈으로 이동
+        router.push('/offline')
     }
 
     if (!isOpen) return null

--- a/src/components/common/ToastContainer.tsx
+++ b/src/components/common/ToastContainer.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useToastStore, ToastType } from '@/stores/useToastStore'
+import { motion, AnimatePresence } from 'framer-motion'
+import { css } from 'styled-system/css'
+import { CheckCircle2, AlertCircle, Info, Loader2, X } from 'lucide-react'
+
+const getToastIcon = (type: ToastType) => {
+    switch (type) {
+        case 'success': return <CheckCircle2 size={18} className={css({ color: 'green.500' })} />
+        case 'error': return <AlertCircle size={18} className={css({ color: 'red.500' })} />
+        case 'loading': return <Loader2 size={18} className={css({ color: 'brand.primary', animation: 'spin 1s linear infinite' })} />
+        default: return <Info size={18} className={css({ color: 'blue.500' })} />
+    }
+}
+
+const getToastStyles = (type: ToastType) => {
+    return css({
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+        bg: 'white',
+        color: 'brand.ink',
+        px: '16px',
+        py: '12px',
+        borderRadius: '12px',
+        boxShadow: '0 8px 30px rgba(0,0,0,0.12)',
+        border: '1px solid',
+        borderColor: 'brand.hairline',
+        minW: '280px',
+        maxW: '90vw',
+        pointerEvents: 'auto',
+    })
+}
+
+export default function ToastContainer() {
+    const { toasts, removeToast } = useToastStore()
+
+    return (
+        <div className={css({
+            position: 'fixed',
+            bottom: 'max(24px, env(safe-area-inset-bottom) + 16px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 9999,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '10px',
+            pointerEvents: 'none',
+        })}>
+            <AnimatePresence>
+                {toasts.map((toast) => (
+                    <motion.div
+                        key={toast.id}
+                        initial={{ opacity: 0, y: 20, scale: 0.9 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.9, transition: { duration: 0.2 } }}
+                        className={getToastStyles(toast.type)}
+                    >
+                        {getToastIcon(toast.type)}
+                        <span className={css({ 
+                            fontSize: '14px', 
+                            fontWeight: '500',
+                            flex: 1,
+                            lineHeight: '1.4'
+                        })}>
+                            {toast.message}
+                        </span>
+                        {toast.type !== 'loading' && (
+                            <button 
+                                onClick={() => removeToast(toast.id)}
+                                className={css({ 
+                                    p: '4px',
+                                    borderRadius: '50%',
+                                    _hover: { bg: 'bg.surfaceSoft' },
+                                    color: 'brand.muted',
+                                    cursor: 'pointer'
+                                })}
+                            >
+                                <X size={14} />
+                            </button>
+                        )}
+                    </motion.div>
+                ))}
+            </AnimatePresence>
+
+            <style jsx global>{`
+                @keyframes spin {
+                    from { transform: rotate(0deg); }
+                    to { transform: rotate(360deg); }
+                }
+            `}</style>
+        </div>
+    )
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import { useRouter, usePathname } from 'next/navigation'
 import { css } from 'styled-system/css'
 import { createClient } from '@/utils/supabase/client'
-import { LogOut, Home, User, BookOpen, LogIn, UserPlus, ListTodo, ChevronLeft, ChevronDown, MessageSquareText } from 'lucide-react'
+import { LogOut, Home, User, BookOpen, LogIn, UserPlus, ListTodo, ChevronLeft, ChevronDown, MessageSquareText, WifiOff } from 'lucide-react'
 import { useUIStore } from '@/stores/useUIStore'
 import { useNetworkStore } from '@/stores/useNetworkStore'
 import { CacheUtil } from '@/utils/cache'
@@ -51,7 +51,8 @@ export default function Navbar() {
         isVisible: isBugReportVisible 
     } = useBugReport()
 
-    const { isOnline } = useNetworkStore()
+    const { isOnline, isOfflineMode } = useNetworkStore()
+    const isOffline = !isOnline || isOfflineMode
 
     useEffect(() => {
         const fetchUser = async () => {
@@ -141,6 +142,23 @@ export default function Navbar() {
                         <Image src="/logo.png" alt="온여정 로고" width={28} height={28} priority />
                         <span>온여정</span>
                     </Link>
+                    {isOffline && (
+                        <div className={css({ 
+                            display: 'flex', 
+                            alignItems: 'center', 
+                            gap: '4px', 
+                            bg: isOfflineMode ? 'brand.secondary' : 'brand.error', 
+                            color: 'white', 
+                            px: '10px', 
+                            py: '4px', 
+                            borderRadius: '12px', 
+                            fontSize: '11px', 
+                            fontWeight: '700' 
+                        })}>
+                            <WifiOff size={12} />
+                            {isOfflineMode ? '오프라인 모드' : '연결 끊김'}
+                        </div>
+                    )}
                 </div>
 
                 {/* 오른쪽: 메뉴 */}
@@ -243,6 +261,24 @@ export default function Navbar() {
                         <h1 className={css({ fontSize: '17px', fontWeight: 'bold', color: 'brand.ink', letterSpacing: '-0.01em' })}>
                             {pageTitle}
                         </h1>
+                        {isOffline && (
+                            <div className={css({ 
+                                display: 'flex', 
+                                alignItems: 'center', 
+                                gap: '4px', 
+                                bg: isOfflineMode ? 'brand.secondary' : 'brand.error', 
+                                color: 'white', 
+                                px: '8px', 
+                                py: '3px', 
+                                borderRadius: '10px', 
+                                fontSize: '10px', 
+                                fontWeight: '700',
+                                ml: '4px'
+                            })}>
+                                <WifiOff size={10} />
+                                {isOfflineMode ? '오프라인' : '연결 끊김'}
+                            </div>
+                        )}
                     </div>
                 )}
 

--- a/src/components/trips/TripHeaderActions.tsx
+++ b/src/components/trips/TripHeaderActions.tsx
@@ -4,13 +4,14 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { css } from 'styled-system/css'
-import { Calendar, Users, Pencil, Trash2, Wallet, Loader2, Download, Check } from 'lucide-react'
+import { Calendar, Users, Pencil, Trash2, Wallet, Loader2, CloudDownload, CloudCheck } from 'lucide-react'
 import { getCurrencyFromTimezone, formatKRW } from '@/utils/currency'
 import { formatDate } from '@/utils/date'
 import { ExchangeService } from '@/services/ExternalApiService'
 import { DownloadService } from '@/services/DownloadService'
 import { Capacitor } from '@capacitor/core'
 import EditTripModal from './EditTripModal'
+import { useToastStore } from '@/stores/useToastStore'
 
 interface TripHeaderActionsProps {
     trip: {
@@ -29,6 +30,7 @@ interface TripHeaderActionsProps {
 export default function TripHeaderActions({ trip, onUpdate, isOffline = false }: TripHeaderActionsProps) {
     const router = useRouter()
     const supabase = createClient()
+    const toast = useToastStore()
 
     const [isOwner, setIsOwner] = useState(false)
     const [showEditModal, setShowEditModal] = useState(false)
@@ -61,12 +63,16 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
     const handleDownload = async () => {
         if (isDownloading) return
         setIsDownloading(true)
+        const loadingId = toast.loading('여행 정보를 다운로드하는 중입니다...')
         try {
             await DownloadService.downloadTrip(trip.id)
             setIsDownloaded(true)
+            toast.removeToast(loadingId)
+            toast.success('여행 정보가 성공적으로 다운로드되었습니다. 이제 오프라인에서도 확인할 수 있습니다!')
         } catch (error) {
             console.error('Download failed:', error)
-            alert('다운로드에 실패했습니다.')
+            toast.removeToast(loadingId)
+            toast.error('다운로드에 실패했습니다. 네트워크 상태를 확인해 주세요.')
         } finally {
             setIsDownloading(false)
         }
@@ -182,56 +188,59 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
                         {trip.destination} 여행
                     </h1>
 
-                    {isOwner && !isOffline && (
+                    {!isOffline && (
                         <div className={css({ display: 'flex', gap: '8px', flexShrink: 0 })}>
-                            {isNative && (
-                                <button
-                                    onClick={handleDownload}
-                                    disabled={isDownloading}
-                                    className={css({
-                                        display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                        p: '8px', bg: isDownloaded ? 'rgba(37, 99, 235, 0.1)' : 'white', 
-                                        color: isDownloaded ? 'brand.primary' : 'brand.muted', 
-                                        border: '1.5px solid', borderColor: isDownloaded ? 'brand.primary' : 'brand.border', 
-                                        borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s',
-                                        _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' },
-                                        _active: { transform: 'scale(0.92)' }
-                                    })}
-                                    title={isDownloaded ? "다운로드됨" : "오프라인 다운로드"}
-                                >
-                                    {isDownloading ? (
-                                        <Loader2 size={18} className={css({ animation: 'spin 1s linear infinite' })} />
-                                    ) : isDownloaded ? (
-                                        <Check size={18} />
-                                    ) : (
-                                        <Download size={18} />
-                                    )}
-                                </button>
+                            <button
+                                onClick={handleDownload}
+                                disabled={isDownloading}
+                                className={css({
+                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                    p: '8px', bg: isDownloaded ? 'rgba(46, 196, 182, 0.05)' : 'white', 
+                                    color: isDownloaded ? 'brand.primary' : 'brand.muted', 
+                                    border: '1.5px solid', borderColor: isDownloaded ? 'brand.primary' : 'brand.border', 
+                                    borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s',
+                                    _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' },
+                                    _active: { transform: 'scale(0.92)' }
+                                })}
+                                title={isDownloaded ? "다운로드됨" : "오프라인 다운로드"}
+                            >
+                                {isDownloading ? (
+                                    <Loader2 size={18} className={css({ animation: 'spin 1s linear infinite' })} />
+                                ) : isDownloaded ? (
+                                    <CloudCheck size={18} />
+                                ) : (
+                                    <CloudDownload size={18} />
+                                )}
+                            </button>
+
+                            {isOwner && (
+                                <>
+                                    <button
+                                        onClick={() => setShowEditModal(true)}
+                                        className={css({
+                                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                            p: '8px', bg: 'white', color: 'brand.muted', border: '1.5px solid', borderColor: 'brand.border', borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s', 
+                                            _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' }, 
+                                            _active: { transform: 'scale(0.92)' }
+                                        })}
+                                        title="여행 수정"
+                                    >
+                                        <Pencil size={18} />
+                                    </button>
+                                    <button
+                                        onClick={() => setShowDeleteConfirm(true)}
+                                        className={css({
+                                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                            p: '8px', bg: 'white', color: 'brand.muted', border: '1.5px solid', borderColor: 'brand.border', borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s', 
+                                            _hover: { bg: 'brand.errorLight', color: 'brand.error', borderColor: 'brand.error' }, 
+                                            _active: { transform: 'scale(0.92)' }
+                                        })}
+                                        title="여행 삭제"
+                                    >
+                                        <Trash2 size={18} />
+                                    </button>
+                                </>
                             )}
-                            <button
-                                onClick={() => setShowEditModal(true)}
-                                className={css({
-                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                    p: '8px', bg: 'white', color: 'brand.muted', border: '1.5px solid', borderColor: 'brand.border', borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s', 
-                                    _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' }, 
-                                    _active: { transform: 'scale(0.92)' }
-                                })}
-                                title="여행 수정"
-                            >
-                                <Pencil size={18} />
-                            </button>
-                            <button
-                                onClick={() => setShowDeleteConfirm(true)}
-                                className={css({
-                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                    p: '8px', bg: 'white', color: 'brand.muted', border: '1.5px solid', borderColor: 'brand.border', borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s', 
-                                    _hover: { bg: 'brand.errorLight', color: 'brand.error', borderColor: 'brand.error' }, 
-                                    _active: { transform: 'scale(0.92)' }
-                                })}
-                                title="여행 삭제"
-                            >
-                                <Trash2 size={18} />
-                            </button>
                         </div>
                     )}
                 </div>

--- a/src/hooks/useOTAUpdate.ts
+++ b/src/hooks/useOTAUpdate.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { CapacitorUpdater } from '@capgo/capacitor-updater';
 import { App } from '@capacitor/app';
 import { SplashScreen } from '@capacitor/splash-screen';
+import { Network } from '@capacitor/network';
 import { createClient } from '@/utils/supabase/client';
 
 const supabase = createClient();
@@ -16,7 +17,15 @@ export function useOTAUpdate() {
   useEffect(() => {
     const checkUpdate = async () => {
       try {
-        // 1. Notify that the current app is ready (prevent rollback)
+        // 1. Check network status - skip if offline
+        const networkStatus = await Network.getStatus();
+        if (!networkStatus.connected) {
+          console.log('Offline: Skipping OTA update check');
+          setStatus('idle');
+          return;
+        }
+
+        // 2. Notify that the current app is ready (prevent rollback)
         await CapacitorUpdater.notifyAppReady();
 
         setStatus('checking');

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+
+export type ToastType = 'success' | 'error' | 'info' | 'loading'
+
+interface Toast {
+    id: string
+    message: string
+    type: ToastType
+    duration?: number
+}
+
+interface ToastState {
+    toasts: Toast[]
+    addToast: (message: string, type?: ToastType, duration?: number) => string
+    removeToast: (id: string) => void
+    success: (message: string, duration?: number) => string
+    error: (message: string, duration?: number) => string
+    info: (message: string, duration?: number) => string
+    loading: (message: string) => string
+}
+
+export const useToastStore = create<ToastState>((set, get) => ({
+    toasts: [],
+    addToast: (message, type = 'info', duration = 3000) => {
+        const id = Math.random().toString(36).substring(2, 9)
+        const newToast = { id, message, type, duration }
+        
+        set((state) => ({ toasts: [...state.toasts, newToast] }))
+
+        if (type !== 'loading') {
+            setTimeout(() => {
+                get().removeToast(id)
+            }, duration)
+        }
+
+        return id
+    },
+    removeToast: (id) => {
+        set((state) => ({
+            toasts: state.toasts.filter((t) => t.id !== id)
+        }))
+    },
+    success: (message, duration) => get().addToast(message, 'success', duration),
+    error: (message, duration) => get().addToast(message, 'error', duration),
+    info: (message, duration) => get().addToast(message, 'info', duration),
+    loading: (message) => get().addToast(message, 'loading', 0),
+}))


### PR DESCRIPTION
## 작업 내용
오프라인 환경에서의 사용자 경험을 개선하고 중복된 다운로드 UI를 정리했습니다.

- **오프라인 네비게이션 수정**: 오프라인 전환 모달 클릭 시 즉시 오프라인 홈으로 이동하도록 수정하고, 상세 페이지 데이터 누락 시 리다이렉트 로직을 강화했습니다.
- **다운로드 UI 통합**: `TripHeaderActions`로 다운로드 버튼을 통합하고 아이콘을 업데이트했습니다.
- **Toast 알림 도입**: 다운로드 상태를 사용자에게 명확히 알리기 위해 Toast 시스템을 추가했습니다.
- **Navbar 상태 배지**: 기존의 거대한 배너 대신 작고 세련된 오프라인 상태 배지를 추가했습니다.
- **OTA 업데이트 최적화**: 오프라인 상태일 때 업데이트 체크를 즉시 건너뛰도록 개선했습니다.

## 관련 이슈
Resolves #177

## 검증 결과
- `pnpm build` 및 `pnpm build:mobile` 성공
- 모바일 환경에서의 오프라인 전환 및 리다이렉트 정상 작동 확인