### PR TITLE
fix: resolve cleartext network policy for android (#180)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">app.nexvoy.xyz</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Description
This PR resolves the "Cleartext HTTP traffic to app.nexvoy.xyz not permitted" error on Android devices.

### Changes
- **Added `network_security_config.xml`**: Explicitly allows (or manages) traffic to `app.nexvoy.xyz`.
- **Updated `AndroidManifest.xml`**: Linked the security configuration to the application.
- **Environment Update**: (Manual step performed locally) Switched `NEXT_PUBLIC_APP_URL` to HTTPS.

Closes #180