### PR TITLE
feat: Google Place 사진 Supabase Storage 영구 저장 및 on-demand 복구 (#184)

### DIFF
--- a/docs/adrs/ADR-006-google-place-photo-permanent-storage.md
+++ b/docs/adrs/ADR-006-google-place-photo-permanent-storage.md
@@ -1,0 +1,56 @@
+# ADR-006: Google Place Photo 영구 저장 및 On-demand 복구
+
+- 상태: 제안됨
+- 결정일: 2026-05-27
+- 결정자: ysjee141
+- 관련 이슈: #184
+
+## 컨텍스트
+
+Google Maps Places Photo API의 CDN URL은 만료되어 일정 시간 후 403을 반환한다.
+OnVoy는 현재 해당 URL을 `plans.image_url`에 그대로 저장하고 있어 일정 목록/상세에서 이미지가 깨지는 문제가 발생한다.
+오프라인 캐시(`DownloadService`) 또한 만료 URL을 그대로 캐싱하여 오프라인에서도 깨진 이미지가 표시될 수 있다.
+
+Google Maps Platform 약관 §3.2.3 (a)는 콘텐츠의 영구 캐싱을 제한하지만,
+1인 운영 서비스의 사용자 경험 및 운영 부담을 고려하여 정책적 리스크를 감수하는 결정을 내린다.
+
+## 결정
+
+1. **영구 저장**: 서버가 Google Photo 바이너리를 다운로드하여 Supabase Storage `place-photos` 버킷에 업로드하고, 그 publicUrl을 `plans.image_url`에 저장한다.
+2. **photo_reference 보존**: `plans.photo_reference TEXT` 컬럼을 추가하여 재발급/복구의 키로 사용한다.
+3. **하이브리드 비동기 처리**: `plans` INSERT는 즉시 완료(`image_url=null`)되고, 이미지 다운로드/업로드/UPDATE는 백그라운드에서 처리한다.
+4. **On-demand 복구**: 클라이언트는 `<img onError>`에서 만료/누락을 감지하여 `photo_reference`로 서버에 복구를 요청한다. 동일 plan에 대한 중복 호출은 클라이언트에서 dedup한다(모듈 스코프 `Set` + 5분 cooldown `Map`, 410 응답 시 24시간 cooldown).
+5. **Storage 경로/권한**:
+   - 경로: `place-photos/{user_id}/{trip_id}/{plan_id}_{placeIdHash8}.jpg`
+   - 버킷: public, SELECT는 누구나
+   - RLS: INSERT/UPDATE/DELETE는 본인 폴더(`user_id == auth.uid()`)에 한정
+6. **Plan 삭제 시 정리**: plan DELETE 흐름에서 동일 폴더의 Storage 객체를 best-effort로 제거한다.
+
+## 대안 비교
+
+- **CDN URL 직접 저장(현행)**: 만료 시 이미지 깨짐. 채택하지 않음.
+- **표시 시점 매번 Places API 재요청**: 쿼터/요금/지연 부담. 채택하지 않음.
+- **동기 INSERT(저장 완료까지 대기)**: 사용자 대기 시간 증가로 UX 저하. 채택하지 않음.
+- **일괄 백필 마이그레이션**: 다수의 만료 토큰으로 효율 낮음. 채택하지 않음.
+- **선택안(채택)**: 영구 저장 + 하이브리드 비동기 + on-demand 복구.
+
+## 결과
+
+### 긍정
+- 일정 이미지 안정성 확보
+- 신규 일정 생성 UX 즉시 완료 유지
+- 레거시 데이터 점진적 자동 복구
+- Storage 사용 패턴 표준화의 첫 사례 마련 (trip 커버, profile 아바타 등 후속 기능 재사용 가능)
+
+### 부정/감수
+- Google Maps Platform 약관 §3.2.3 (a) 캐싱 제한에 대한 위반 가능성 (감수)
+- Storage 저장 비용 발생 (현 규모 무시 가능)
+- Attribution(저작자 표시) 의무 검토 필요 — 본 ADR에서는 보류, 후속 TODO
+
+## 후속 TODO
+
+- Attribution(`html_attributions`) 표시 정책 검토 및 별도 ADR/이슈로 처리
+- 주기 갱신 잡(예: 30~60일 주기) 도입 검토
+- Zustand `usePlansStore` 도입으로 콜백 prop chain 축소
+- Supabase `Database` 자동 생성 타입 재생성
+- `NEXT_PUBLIC_APP_URL` 미설정 가드 (모바일 빌드)

--- a/src/app/api/places/photo/route.ts
+++ b/src/app/api/places/photo/route.ts
@@ -21,17 +21,21 @@ export async function GET(request: Request) {
         const detailsData = await detailsRes.json()
 
         if (detailsData.status !== 'OK' || !detailsData.result?.photos?.length) {
-            return NextResponse.json({ url: null })
+            return NextResponse.json({ url: null, photoReference: null })
         }
 
-        const photoRef = detailsData.result.photos[0].photo_reference
+        const photoRef: string = detailsData.result.photos[0].photo_reference
 
-        // 2. Places Photo URL로 리다이렉트를 따라가 영구 CDN URL 획득
+        // 2. Places Photo URL로 리다이렉트를 따라가 영구 CDN URL 획득 (미리보기용)
         const photoApiUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=${maxwidth}&photo_reference=${photoRef}&key=${apiKey}`
         const photoRes = await fetch(photoApiUrl, { redirect: 'manual', next: { revalidate: 3600 } })
         const finalUrl = photoRes.headers.get('location')
 
-        return NextResponse.json({ url: finalUrl || photoApiUrl })
+        // photoReference는 클라이언트가 plans INSERT 시 함께 저장해야 함 (영구 저장 키)
+        return NextResponse.json({
+            url: finalUrl || photoApiUrl,
+            photoReference: photoRef,
+        })
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         console.error('[places/photo] Error:', message)

--- a/src/app/api/places/photo/store/route.ts
+++ b/src/app/api/places/photo/store/route.ts
@@ -1,0 +1,238 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import { createHash } from 'crypto'
+
+interface StoreRequestBody {
+    planId?: string
+    tripId?: string
+    placeId?: string
+    photoReference?: string | null
+}
+
+const PHOTO_MAX_WIDTH = 800
+const STORAGE_BUCKET = 'place-photos'
+const STORAGE_CONTENT_TYPE = 'image/jpeg'
+
+/**
+ * Google Places Details API로부터 photo_reference를 조회한다.
+ * - 레거시 plan(photo_reference 컬럼이 null인 데이터) 자동 복구 fallback에 사용.
+ * - 실패/photos 없음/non-OK status는 모두 null 반환 → 호출 측에서 410 처리.
+ */
+async function fetchPhotoReferenceByPlaceId(
+    placeId: string,
+    apiKey: string
+): Promise<string | null> {
+    const detailsUrl =
+        `https://maps.googleapis.com/maps/api/place/details/json` +
+        `?place_id=${encodeURIComponent(placeId)}` +
+        `&fields=photos` +
+        `&language=ko` +
+        `&key=${apiKey}`
+
+    try {
+        const res = await fetch(detailsUrl)
+        if (!res.ok) {
+            console.error(
+                `[photo/store] Places Details HTTP ${res.status} for placeId lookup`
+            )
+            return null
+        }
+        const json = (await res.json()) as {
+            status?: string
+            result?: { photos?: Array<{ photo_reference?: string }> }
+        }
+        if (json.status !== 'OK') {
+            console.warn(`[photo/store] Places Details status=${json.status}`)
+            return null
+        }
+        const photoRef = json.result?.photos?.[0]?.photo_reference
+        if (!photoRef) {
+            return null
+        }
+        return photoRef
+    } catch (err) {
+        const message = err instanceof Error ? err.message : 'fetch failed'
+        console.error('[photo/store] Places Details fetch failed:', message)
+        return null
+    }
+}
+
+function placeIdHash8(placeId: string): string {
+    return createHash('sha256').update(placeId).digest('hex').slice(0, 8)
+}
+
+function buildStoragePath(userId: string, tripId: string, planId: string, placeId: string): string {
+    return `${userId}/${tripId}/${planId}_${placeIdHash8(placeId)}.jpg`
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        // 1) 요청 본문 파싱
+        let body: StoreRequestBody
+        try {
+            body = (await request.json()) as StoreRequestBody
+        } catch {
+            return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+        }
+
+        const { planId, tripId, placeId } = body
+        // photoReference는 optional. 누락 시 placeId 기반 fallback으로 조회.
+        let photoReference: string | null | undefined = body.photoReference
+        if (!planId || !tripId || !placeId) {
+            return NextResponse.json(
+                { error: 'Missing required fields: planId, tripId, placeId' },
+                { status: 400 }
+            )
+        }
+
+        // 2) 인증 확인
+        const supabase = await createClient()
+        const {
+            data: { user },
+            error: authError,
+        } = await supabase.auth.getUser()
+
+        if (authError || !user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        // 3) 멤버십 검증
+        //    plan이 존재하며 동일 trip_id에 속하고, 현재 사용자가 owner/editor 권한을 가진다.
+        //    RLS만 의존하지 않고 service 레이어에서 명시 검증.
+        const { data: planRow, error: planLookupError } = await supabase
+            .from('plans')
+            .select('id, trip_id')
+            .eq('id', planId)
+            .maybeSingle()
+
+        if (planLookupError) {
+            console.error('[places/photo/store] plan lookup failed:', planLookupError.message)
+            return NextResponse.json({ error: 'Plan lookup failed' }, { status: 500 })
+        }
+        if (!planRow) {
+            return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+        }
+        if (planRow.trip_id !== tripId) {
+            return NextResponse.json({ error: 'Trip mismatch' }, { status: 400 })
+        }
+
+        // 소유자 또는 멤버(편집자) 권한 검증.
+        // 두 보조 함수를 RPC 호출하여 OR 조건을 평가한다.
+        const [ownerResp, editorResp] = await Promise.all([
+            supabase.rpc('check_is_trip_owner', { _trip_id: tripId, _user_id: user.id }),
+            supabase.rpc('check_is_trip_editor', { _trip_id: tripId, _user_id: user.id }),
+        ])
+        if (ownerResp.error) {
+            console.error('[places/photo/store] check_is_trip_owner failed:', ownerResp.error.message)
+        }
+        if (editorResp.error) {
+            console.error('[places/photo/store] check_is_trip_editor failed:', editorResp.error.message)
+        }
+        const isOwner = ownerResp.data === true
+        const isEditor = editorResp.data === true
+        if (!isOwner && !isEditor) {
+            return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+        }
+
+        // 4) Google Maps API Key (서버 보유)
+        //    Places Photo API는 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY를 사용하지만,
+        //    가능하면 서버 전용 키를 분리해서 도메인 제약을 우회한다.
+        const apiKey =
+            process.env.GOOGLE_PLACES_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+        if (!apiKey) {
+            return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+        }
+
+        // 4-b) photoReference fallback
+        //      레거시 plan(photo_reference=null) 자동 복구: placeId로 Places Details API 호출하여
+        //      photo_reference를 재조회한다. 조회 실패 시 410으로 반환하여 클라이언트는 만료 처리.
+        if (!photoReference) {
+            console.info('[photo/store] photoReference fallback via placeId', { planId })
+            const recovered = await fetchPhotoReferenceByPlaceId(placeId, apiKey)
+            if (!recovered) {
+                return NextResponse.json(
+                    { error: 'Photo reference unavailable' },
+                    { status: 410 }
+                )
+            }
+            photoReference = recovered
+        }
+
+        // 5) Google Photo CDN fetch
+        //    Places Photo API는 302 리다이렉트 → 실제 CDN. fetch는 자동 follow.
+        const photoApiUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=${PHOTO_MAX_WIDTH}&photo_reference=${encodeURIComponent(
+            photoReference
+        )}&key=${apiKey}`
+
+        let photoRes: Response
+        try {
+            photoRes = await fetch(photoApiUrl, { redirect: 'follow' })
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'fetch failed'
+            console.error('[places/photo/store] Google Photo fetch failed:', message)
+            return NextResponse.json({ error: 'Photo fetch failed' }, { status: 502 })
+        }
+
+        // 403/410은 토큰 만료/거부 — 클라이언트가 photo_reference 무효화 처리해야 함
+        if (photoRes.status === 403 || photoRes.status === 410) {
+            console.warn(
+                `[places/photo/store] Google Photo expired (status=${photoRes.status}) for plan=${planId}`
+            )
+            return NextResponse.json({ error: 'Photo reference expired' }, { status: 410 })
+        }
+        if (!photoRes.ok) {
+            console.error(
+                `[places/photo/store] Google Photo fetch returned ${photoRes.status} for plan=${planId}`
+            )
+            return NextResponse.json({ error: 'Photo fetch failed' }, { status: 502 })
+        }
+
+        const photoArrayBuffer = await photoRes.arrayBuffer()
+        if (!photoArrayBuffer.byteLength) {
+            return NextResponse.json({ error: 'Empty photo response' }, { status: 502 })
+        }
+        const photoBuffer = Buffer.from(photoArrayBuffer)
+
+        // 6) Supabase Storage upload
+        const storagePath = buildStoragePath(user.id, tripId, planId, placeId)
+        const { error: uploadError } = await supabase.storage
+            .from(STORAGE_BUCKET)
+            .upload(storagePath, photoBuffer, {
+                contentType: STORAGE_CONTENT_TYPE,
+                upsert: true,
+                cacheControl: '31536000',
+            })
+        if (uploadError) {
+            console.error('[places/photo/store] Storage upload failed:', uploadError.message)
+            return NextResponse.json({ error: 'Storage upload failed' }, { status: 500 })
+        }
+
+        // 7) publicUrl 획득
+        const { data: publicUrlData } = supabase.storage
+            .from(STORAGE_BUCKET)
+            .getPublicUrl(storagePath)
+        const publicUrl = publicUrlData?.publicUrl
+        if (!publicUrl) {
+            console.error('[places/photo/store] getPublicUrl returned empty for', storagePath)
+            return NextResponse.json({ error: 'Public URL generation failed' }, { status: 500 })
+        }
+
+        // 8) plans UPDATE { image_url, photo_reference }
+        //    RLS 정책에 의해 권한이 있는 경우만 통과.
+        const { error: updateError } = await supabase
+            .from('plans')
+            .update({ image_url: publicUrl, photo_reference: photoReference })
+            .eq('id', planId)
+
+        if (updateError) {
+            console.error('[places/photo/store] plans UPDATE failed:', updateError.message)
+            return NextResponse.json({ error: 'Plan update failed' }, { status: 500 })
+        }
+
+        return NextResponse.json({ imageUrl: publicUrl }, { status: 200 })
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        console.error('[places/photo/store] Unhandled error:', message)
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    }
+}

--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -17,6 +17,7 @@ import { ExchangeService } from '@/services/ExternalApiService'
 import { CacheUtil } from '@/utils/cache'
 import { NotificationService } from '@/services/NotificationService'
 import { DownloadService } from '@/services/DownloadService'
+import { PlanPhotoStorageService } from '@/services/PlanPhotoStorageService'
 import { Download, CloudDownload, CloudCheck, Loader2 } from 'lucide-react'
 import TripDetailSkeleton from './TripDetailSkeleton'
 const CustomTimeDropdown = ({ timeDisplayMode, setTimeDisplayMode }: any) => {
@@ -250,6 +251,15 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
     const handleDeletePlan = async (planId: string) => {
         if (!confirm('이 일정을 삭제하시겠습니까? (연결된 정보도 함께 삭제됩니다)')) return
 
+        // Storage cleanup은 best-effort: 실패해도 plan DELETE는 계속 진행
+        if (tripId) {
+            try {
+                await PlanPhotoStorageService.cleanupPlanPhotos({ tripId, planId })
+            } catch (cleanupErr) {
+                console.warn('[TripClient] cleanupPlanPhotos failed (ignored)', cleanupErr)
+            }
+        }
+
         const { error } = await supabase.from('plans').delete().eq('id', planId)
         if (error) {
             alert('삭제에 실패했습니다.')
@@ -258,6 +268,16 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             fetchPlans() // 목록 리프레시
         }
     }
+
+    /** 백그라운드/on-demand 업로드 성공 시 plans 리스트 image_url 동기화 */
+    const handlePlanImageRecovered = useCallback((planId: string, newImageUrl: string) => {
+        setPlans(prev => prev.map(p => (
+            p.id === planId ? { ...p, image_url: newImageUrl } : p
+        )))
+        setSelectedPlanForDetail((cur: any) => (
+            cur && cur.id === planId ? { ...cur, image_url: newImageUrl } : cur
+        ))
+    }, [])
 
     const handleEditPlan = async (plan: any) => {
         // 편집을 위해, 해당 Plan에 연결된 url들도 같이 가져옵니다
@@ -475,6 +495,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                     onDelete={handleDeletePlan}
                     onDetail={handlePlanDetail}
                     onToggleVisit={handleToggleVisit}
+                    onPlanImageRecovered={handlePlanImageRecovered}
                 />
             )}
 
@@ -490,6 +511,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                     onEdit={handleEditPlan}
                     onDelete={handleDeletePlan}
                     onToggleVisit={handleToggleVisit}
+                    onPlanImageRecovered={handlePlanImageRecovered}
                 />
             )}
 
@@ -502,6 +524,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                     editData={editingPlan}
                     tripStartDate={trip?.start_date}
                     tripEndDate={trip?.end_date}
+                    onPlanImageUpdated={handlePlanImageRecovered}
                 />
             )}
             {tripId && (

--- a/src/components/common/PlanImage.tsx
+++ b/src/components/common/PlanImage.tsx
@@ -1,0 +1,455 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { ImageIcon } from 'lucide-react'
+import { css } from 'styled-system/css'
+import { useImageRecovery } from '@/hooks/useImageRecovery'
+import { canStoreNow } from '@/services/PlacePhotoService'
+
+/**
+ * PlanImage — Google Place Photo 영구 저장 컴포넌트
+ *
+ * 상태 머신 (6개):
+ *  - idle-empty        : image_url=null, photo_reference 있음, 신규(<5초). shimmer
+ *  - idle-placeholder  : image_url=null, 5초 경과 또는 photo_reference=null. static placeholder
+ *  - loading-img       : image_url 있음, onLoad/onError 대기. 빈 배경
+ *  - loading-recovery  : image_url 있음, onError 후 복구 API 호출 중. shimmer
+ *  - loaded            : 이미지 표시 (페이드인 1회)
+ *  - error-final       : 복구 실패 / 쿨다운 차단. static placeholder
+ *
+ * UX 설계 문서: _workspace/01b_ux_design.md
+ */
+
+type PlanImageState =
+    | 'idle-empty'
+    | 'idle-placeholder'
+    | 'loading-img'
+    | 'loading-recovery'
+    | 'loaded'
+    | 'error-final'
+
+export interface PlanImageProps {
+    planId: string
+    tripId: string
+    placeId?: string | null
+    imageUrl?: string | null
+    photoReference?: string | null
+    /** ISO 8601 문자열. 신규 생성 5초 이내인지 판정 */
+    createdAt?: string | null
+    variant: 'thumbnail' | 'hero'
+    /** plan.title 기반 (예: "{title} 장소 사진") */
+    alt: string
+    onRecovered?: (newUrl: string) => void
+    onRecoveryFailed?: () => void
+    /** 오프라인 모드 등에서 강제 비활성화 */
+    disableRecovery?: boolean
+    className?: string
+}
+
+const IDLE_EMPTY_TIMEOUT_MS = 5_000
+const SHIMMER_MIN_DURATION_MS = 400
+const FADE_IN_THUMBNAIL_MS = 240
+const FADE_IN_HERO_MS = 320
+
+const VARIANT_RADIUS: Record<PlanImageProps['variant'], string> = {
+    thumbnail: '12px',
+    hero: '0px',
+}
+
+const VARIANT_ICON_SIZE: Record<PlanImageProps['variant'], number> = {
+    thumbnail: 20,
+    hero: 32,
+}
+
+/** `prefers-reduced-motion: reduce` 감지 */
+function usePrefersReducedMotion(): boolean {
+    const [reduced, setReduced] = useState(false)
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.matchMedia) return
+        try {
+            const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+            setReduced(mq.matches)
+            const handler = (event: MediaQueryListEvent) => setReduced(event.matches)
+            if (typeof mq.addEventListener === 'function') {
+                mq.addEventListener('change', handler)
+                return () => mq.removeEventListener('change', handler)
+            }
+            // Safari legacy fallback
+            mq.addListener(handler)
+            return () => mq.removeListener(handler)
+        } catch (error) {
+            console.warn('[PlanImage] prefers-reduced-motion 감지 실패', error)
+            return undefined
+        }
+    }, [])
+
+    return reduced
+}
+
+/** createdAt 기준으로 신규(5초 이내) 여부와 남은 시간(ms) 계산 */
+function getNewnessInfo(createdAt: string | null | undefined): { isNew: boolean; remainingMs: number } {
+    if (!createdAt) return { isNew: false, remainingMs: 0 }
+    const created = new Date(createdAt).getTime()
+    if (Number.isNaN(created)) return { isNew: false, remainingMs: 0 }
+    const elapsed = Date.now() - created
+    if (elapsed >= IDLE_EMPTY_TIMEOUT_MS) return { isNew: false, remainingMs: 0 }
+    return { isNew: true, remainingMs: IDLE_EMPTY_TIMEOUT_MS - elapsed }
+}
+
+export function PlanImage(props: PlanImageProps) {
+    const {
+        planId,
+        tripId,
+        placeId,
+        imageUrl,
+        photoReference,
+        createdAt,
+        variant,
+        alt,
+        onRecovered,
+        onRecoveryFailed,
+        disableRecovery = false,
+        className,
+    } = props
+
+    const reducedMotion = usePrefersReducedMotion()
+    const { recover } = useImageRecovery()
+
+    /** 현재 렌더링 중인 URL (복구 후 갱신 시 변경) */
+    const [activeUrl, setActiveUrl] = useState<string | null>(imageUrl ?? null)
+    /** 신규 생성 5초 타임아웃 경과 여부 */
+    const [isNewnessExpired, setIsNewnessExpired] = useState<boolean>(() => {
+        return !getNewnessInfo(createdAt).isNew
+    })
+    /** 복구 시도 진행 중 여부 */
+    const [isRecovering, setIsRecovering] = useState(false)
+    /** 복구 시도 종료(성공/실패) 후 final 처리 여부 */
+    const [recoveryFailed, setRecoveryFailed] = useState(false)
+    /** 이미지 onLoad/onError 도달 여부 */
+    const [imgLoaded, setImgLoaded] = useState(false)
+    /** 자발 복구 요청 플래그 (image_url=null 케이스에서 shimmer 표시용) */
+    const [recoveryRequested, setRecoveryRequested] = useState(false)
+    /** 깜박임 방지: shimmer 표시 시작 시각 */
+    const recoveryStartedAtRef = useRef<number | null>(null)
+    /** 마운트 사이클 내 자발 트리거 1회 가드 */
+    const autoTriggerAttemptedRef = useRef(false)
+
+    /** 외부에서 imageUrl이 갱신되면 activeUrl 동기화 + 상태 리셋 */
+    useEffect(() => {
+        if (imageUrl === activeUrl) return
+        setActiveUrl(imageUrl ?? null)
+        setImgLoaded(false)
+        setRecoveryFailed(false)
+        setIsRecovering(false)
+        setRecoveryRequested(false)
+        recoveryStartedAtRef.current = null
+        autoTriggerAttemptedRef.current = false
+    }, [imageUrl, activeUrl])
+
+    /** createdAt 기반 idle-empty 타임아웃 처리 */
+    useEffect(() => {
+        const { isNew, remainingMs } = getNewnessInfo(createdAt)
+        if (!isNew) {
+            setIsNewnessExpired(true)
+            return
+        }
+        setIsNewnessExpired(false)
+        const timer = setTimeout(() => setIsNewnessExpired(true), remainingMs)
+        return () => clearTimeout(timer)
+    }, [createdAt])
+
+    /** 현재 상태 계산 (single source of truth) */
+    const state: PlanImageState = useMemo(() => {
+        if (recoveryFailed) return 'error-final'
+        if (isRecovering) return 'loading-recovery'
+        if (activeUrl) {
+            return imgLoaded ? 'loaded' : 'loading-img'
+        }
+        // image_url 없음 분기
+        if (disableRecovery) return 'idle-placeholder'
+        // 자발 복구가 예약/진행 중인 경우 → shimmer
+        if (recoveryRequested) return 'idle-empty'
+        if (!photoReference && !placeId) return 'idle-placeholder'
+        if (!photoReference) {
+            // photoReference는 없지만 placeId가 있어 서버 fallback 가능 — 신규 5초 동안만 shimmer
+            return isNewnessExpired ? 'idle-placeholder' : 'idle-empty'
+        }
+        if (isNewnessExpired) return 'idle-placeholder'
+        return 'idle-empty'
+    }, [activeUrl, imgLoaded, isRecovering, recoveryFailed, photoReference, placeId, disableRecovery, isNewnessExpired, recoveryRequested])
+
+    /** 이미지 onError → 복구 시도 트리거 */
+    const handleImgError = useCallback(async () => {
+        if (disableRecovery || !placeId) {
+            setRecoveryFailed(true)
+            onRecoveryFailed?.()
+            return
+        }
+        setIsRecovering(true)
+        recoveryStartedAtRef.current = Date.now()
+        try {
+            const result = await recover({ planId, tripId, placeId, photoReference })
+            // shimmer 최소 표시 시간 보장 (깜박임 방지)
+            const startedAt = recoveryStartedAtRef.current ?? Date.now()
+            const elapsed = Date.now() - startedAt
+            const wait = Math.max(0, SHIMMER_MIN_DURATION_MS - elapsed)
+            if (wait > 0) {
+                await new Promise<void>((resolve) => setTimeout(resolve, wait))
+            }
+            if (result?.imageUrl) {
+                setActiveUrl(result.imageUrl)
+                setImgLoaded(false)
+                setRecoveryFailed(false)
+                onRecovered?.(result.imageUrl)
+            } else {
+                setRecoveryFailed(true)
+                onRecoveryFailed?.()
+            }
+        } catch (error) {
+            // Zero Noise: 토스트 없이 콘솔 로그만
+            console.error('[PlanImage] recovery error', error)
+            setRecoveryFailed(true)
+            onRecoveryFailed?.()
+        } finally {
+            setIsRecovering(false)
+            recoveryStartedAtRef.current = null
+        }
+    }, [planId, tripId, placeId, photoReference, disableRecovery, recover, onRecovered, onRecoveryFailed])
+
+    /**
+     * image_url=null 자발 복구 트리거
+     * - 마운트 시점에 image_url=null && placeId 존재 시 자동으로 recover 호출
+     * - 단발성 보장 (autoTriggerAttemptedRef)
+     * - PlacePhotoService.canStoreNow + in-flight dedup으로 중복 차단
+     */
+    useEffect(() => {
+        if (disableRecovery) return
+        if (activeUrl) return
+        if (!placeId) return
+        if (!planId || !tripId) return
+        if (isRecovering || recoveryFailed) return
+        if (autoTriggerAttemptedRef.current) return
+        if (!canStoreNow(planId)) return
+
+        autoTriggerAttemptedRef.current = true
+
+        let cancelled = false
+        const run = async () => {
+            setIsRecovering(true)
+            setRecoveryRequested(true)
+            recoveryStartedAtRef.current = Date.now()
+            try {
+                const result = await recover({ planId, tripId, placeId, photoReference })
+                if (cancelled) return
+                const startedAt = recoveryStartedAtRef.current ?? Date.now()
+                const elapsed = Date.now() - startedAt
+                const wait = Math.max(0, SHIMMER_MIN_DURATION_MS - elapsed)
+                if (wait > 0) {
+                    await new Promise<void>((resolve) => setTimeout(resolve, wait))
+                }
+                if (cancelled) return
+                if (result?.imageUrl) {
+                    setActiveUrl(result.imageUrl)
+                    setImgLoaded(false)
+                    setRecoveryFailed(false)
+                    onRecovered?.(result.imageUrl)
+                } else {
+                    // 실패 시: photoReference 없으면 placeholder로 회귀(소프트), 있으면 error-final
+                    if (photoReference) {
+                        setRecoveryFailed(true)
+                        onRecoveryFailed?.()
+                    } else {
+                        setRecoveryRequested(false)
+                        onRecoveryFailed?.()
+                    }
+                }
+            } catch (error) {
+                console.error('[PlanImage] auto recovery error', error)
+                if (cancelled) return
+                setRecoveryFailed(true)
+                onRecoveryFailed?.()
+            } finally {
+                if (!cancelled) {
+                    setIsRecovering(false)
+                    recoveryStartedAtRef.current = null
+                }
+            }
+        }
+
+        void run()
+
+        return () => {
+            cancelled = true
+        }
+    }, [
+        activeUrl,
+        placeId,
+        planId,
+        tripId,
+        photoReference,
+        disableRecovery,
+        isRecovering,
+        recoveryFailed,
+        recover,
+        onRecovered,
+        onRecoveryFailed,
+    ])
+
+    /** 페이드인 duration (variant + reduced-motion 반영) */
+    const fadeInMs = reducedMotion ? 0 : variant === 'hero' ? FADE_IN_HERO_MS : FADE_IN_THUMBNAIL_MS
+
+    /** variant별 동적 스타일 (인라인 — Panda 정적 추출 보장) */
+    const containerInlineStyle = useMemo<React.CSSProperties>(
+        () => ({
+            borderRadius: VARIANT_RADIUS[variant],
+        }),
+        [variant],
+    )
+
+    /** loaded 상태일 때의 backgroundImage 동적 값 (인라인 처리) */
+    const loadedBackgroundStyle = useMemo<React.CSSProperties | undefined>(() => {
+        if (!activeUrl) return undefined
+        return { backgroundImage: `url("${activeUrl}")` }
+    }, [activeUrl])
+
+    return (
+        <div
+            className={[
+                css({
+                    position: 'relative',
+                    w: '100%',
+                    h: '100%',
+                    overflow: 'hidden',
+                    bg: 'bg.surfaceSoft',
+                }),
+                className,
+            ]
+                .filter(Boolean)
+                .join(' ')}
+            style={containerInlineStyle}
+            role={state === 'loaded' ? undefined : 'img'}
+            aria-label={state === 'loaded' ? undefined : getAriaLabel(state, alt)}
+            aria-busy={state === 'idle-empty' || state === 'loading-recovery' || state === 'loading-img'}
+        >
+            {/* 숨겨진 <img>로 로드/에러 감지 (loaded 상태에서만 backgroundImage 사용) */}
+            {activeUrl && !imgLoaded && !recoveryFailed && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                    key={activeUrl}
+                    src={activeUrl}
+                    alt=""
+                    aria-hidden="true"
+                    onLoad={() => setImgLoaded(true)}
+                    onError={handleImgError}
+                    className={css({
+                        position: 'absolute',
+                        width: '1px',
+                        height: '1px',
+                        opacity: 0,
+                        pointerEvents: 'none',
+                    })}
+                />
+            )}
+
+            <AnimatePresence mode="wait">
+                {(state === 'idle-empty' || state === 'loading-recovery') && (
+                    <motion.div
+                        key="shimmer"
+                        initial={reducedMotion ? false : { opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={reducedMotion ? undefined : { opacity: 0 }}
+                        transition={{ duration: reducedMotion ? 0 : 0.12, ease: 'easeOut' }}
+                        className={css({
+                            position: 'absolute',
+                            inset: 0,
+                            background:
+                                'linear-gradient(90deg, token(colors.bg.surfaceSoft) 25%, token(colors.brand.hairline) 50%, token(colors.bg.surfaceSoft) 75%)',
+                            backgroundSize: '200% 100%',
+                            animation: 'shimmer 2s infinite linear',
+                        })}
+                        style={reducedMotion ? { animation: 'none' } : undefined}
+                    />
+                )}
+
+                {(state === 'idle-placeholder' || state === 'error-final') && (
+                    <motion.div
+                        key="placeholder"
+                        initial={reducedMotion ? false : { opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={reducedMotion ? undefined : { opacity: 0 }}
+                        transition={{ duration: reducedMotion ? 0 : 0.16, ease: 'easeOut' }}
+                        className={css({
+                            position: 'absolute',
+                            inset: 0,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            bg: 'bg.surfaceSoft',
+                        })}
+                    >
+                        <ImageIcon
+                            size={VARIANT_ICON_SIZE[variant]}
+                            aria-hidden="true"
+                            className={css({ color: 'brand.muted' })}
+                        />
+                    </motion.div>
+                )}
+
+                {state === 'loaded' && activeUrl && (
+                    <motion.div
+                        key={`loaded-${activeUrl}`}
+                        initial={reducedMotion ? false : { opacity: 0, scale: 1.02 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={reducedMotion ? undefined : { opacity: 0 }}
+                        transition={{ duration: fadeInMs / 1000, ease: 'easeOut' }}
+                        className={css({
+                            position: 'absolute',
+                            inset: 0,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
+                            backgroundRepeat: 'no-repeat',
+                        })}
+                        style={loadedBackgroundStyle}
+                        role="img"
+                        aria-label={alt}
+                    />
+                )}
+
+                {state === 'loading-img' && (
+                    <motion.div
+                        key="loading-img"
+                        initial={false}
+                        animate={{ opacity: 1 }}
+                        exit={reducedMotion ? undefined : { opacity: 0 }}
+                        transition={{ duration: reducedMotion ? 0 : 0.12, ease: 'easeOut' }}
+                        className={css({
+                            position: 'absolute',
+                            inset: 0,
+                            bg: 'bg.surfaceSoft',
+                        })}
+                    />
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}
+
+function getAriaLabel(state: PlanImageState, alt: string): string {
+    switch (state) {
+        case 'idle-empty':
+            return '이미지 불러오는 중'
+        case 'loading-recovery':
+            return '이미지 복구 중'
+        case 'loading-img':
+            return '이미지 표시 준비 중'
+        case 'idle-placeholder':
+        case 'error-final':
+            return '장소 사진 없음'
+        default:
+            return alt
+    }
+}
+
+export default PlanImage

--- a/src/components/trips/NewPlanModal.tsx
+++ b/src/components/trips/NewPlanModal.tsx
@@ -6,8 +6,16 @@ import { css } from 'styled-system/css'
 import { X, MapPin, Clock, Calendar, Check, Search, ChevronRight, Loader2, Camera, Navigation, Map, Info, Compass, Bell } from 'lucide-react'
 import { useLoadScript, Autocomplete } from '@react-google-maps/api'
 import { LocationService, PlacePhotoService } from '@/services/ExternalApiService'
+import { uploadInBackground as uploadPlacePhotoInBackground } from '@/services/PlacePhotoService'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useScrollLock } from '@/hooks/useScrollLock'
+import type { Plan } from './PlanList'
+
+/**
+ * 편집 모드에서 NewPlanModal로 전달되는 plan 스냅샷.
+ * Plan의 부분 집합 + 옵셔널한 id를 허용한다.
+ */
+type EditDraft = Partial<Plan> & { id?: string }
 
 const libraries: ("places")[] = ["places"]
 
@@ -18,7 +26,12 @@ interface NewPlanModalProps {
     tripId: string
     tripStartDate?: string
     tripEndDate?: string
-    editData?: any
+    editData?: EditDraft
+    /**
+     * 백그라운드 업로드 완료 시 호출. (planId, newImageUrl).
+     * 부모가 plans 리스트의 해당 항목 image_url을 패치할 때 사용.
+     */
+    onPlanImageUpdated?: (planId: string, imageUrl: string) => void
 }
 
 // ── 핵심 타입 정의 ──
@@ -27,20 +40,24 @@ interface PlaceOption {
     address: string
     lat: number
     lng: number
+    /** 미리보기 URL (DB에 저장하지 않음) */
     photo?: string
+    /** Google photo_reference (영구 저장 키) */
+    photoReference?: string | null
     rating?: number
     type?: string
     googlePlaceId?: string
 }
 
-export default function NewPlanModal({ 
-    isOpen, 
-    onClose, 
-    onSuccess, 
-    tripId, 
-    tripStartDate = '', 
-    tripEndDate = '', 
-    editData 
+export default function NewPlanModal({
+    isOpen,
+    onClose,
+    onSuccess,
+    tripId,
+    tripStartDate = '',
+    tripEndDate = '',
+    editData,
+    onPlanImageUpdated,
 }: NewPlanModalProps) {
     const supabase = createClient()
     const [step, setStep] = useState(1) // 1: 장소검색, 2: 상세입력
@@ -118,6 +135,7 @@ export default function NewPlanModal({
                 lat: editData.location_lat || 0,
                 lng: editData.location_lng || 0,
                 photo: editData.image_url || undefined,
+                photoReference: editData.photo_reference ?? null,
                 googlePlaceId: editData.google_place_id || undefined,
             })
             
@@ -167,18 +185,23 @@ export default function NewPlanModal({
                 lat: place.geometry.location.lat(),
                 lng: place.geometry.location.lng(),
                 photo: undefined,
+                photoReference: null,
                 rating: place.rating,
                 type: place.types?.[0],
                 googlePlaceId: placeId
             })
             setStep(2)
 
-            // 서버사이드 API로 영구 사진 URL 비동기 조회
+            // 서버사이드 API로 미리보기 URL + photoReference(영구 저장 키) 동시 조회
             if (placeId) {
-                PlacePhotoService.getPhotoUrl(placeId).then(url => {
-                    if (url) {
-                        setSelectedPlace(prev => prev ? { ...prev, photo: url } : prev)
-                    }
+                PlacePhotoService.getPhoto(placeId).then(({ url, photoReference }) => {
+                    setSelectedPlace(prev => prev ? {
+                        ...prev,
+                        photo: url || prev.photo,
+                        photoReference: photoReference ?? prev.photoReference ?? null,
+                    } : prev)
+                }).catch(error => {
+                    console.warn('[NewPlanModal] photo metadata fetch failed', error)
                 })
             }
         }
@@ -199,17 +222,22 @@ export default function NewPlanModal({
                 lat: place.geometry.location.lat(),
                 lng: place.geometry.location.lng(),
                 photo: undefined,
+                photoReference: null,
                 rating: place.rating,
                 type: place.types?.[0],
                 googlePlaceId: placeId
             })
 
-            // 서버사이드 API로 영구 사진 URL 비동기 조회
+            // 서버사이드 API로 미리보기 URL + photoReference 조회
             if (placeId) {
-                PlacePhotoService.getPhotoUrl(placeId).then(url => {
-                    if (url) {
-                        setSelectedPlace(prev => prev ? { ...prev, photo: url } : prev)
-                    }
+                PlacePhotoService.getPhoto(placeId).then(({ url, photoReference }) => {
+                    setSelectedPlace(prev => prev ? {
+                        ...prev,
+                        photo: url || prev.photo,
+                        photoReference: photoReference ?? prev.photoReference ?? null,
+                    } : prev)
+                }).catch(error => {
+                    console.warn('[NewPlanModal] photo metadata fetch failed', error)
                 })
             }
         }
@@ -223,6 +251,7 @@ export default function NewPlanModal({
             lat: 0,
             lng: 0,
             photo: undefined,
+            photoReference: null,
             googlePlaceId: undefined
         })
         setStep(2)
@@ -258,7 +287,10 @@ export default function NewPlanModal({
             const locationToSave = customTitle.trim() ? selectedPlace.name : selectedPlace.address;
             const addressToSave = selectedPlace.address;
 
-            const planData = {
+            // 신규 흐름: image_url은 백그라운드 업로드 완료 시점에 채워짐.
+            // INSERT 시점에는 photo_reference(영구 저장 키)만 저장한다.
+            // 단, edit 모드에서 기존 image_url이 이미 Storage URL(영구)인 경우 보존한다.
+            const planData: Record<string, unknown> = {
                 trip_id: tripId,
                 title: titleToSave,
                 location: locationToSave,
@@ -266,7 +298,8 @@ export default function NewPlanModal({
                 location_lat: selectedPlace.lat || 0,
                 location_lng: selectedPlace.lng || 0,
                 google_place_id: selectedPlace.googlePlaceId,
-                image_url: selectedPlace.photo,
+                image_url: editData?.id ? editData.image_url ?? null : null,
+                photo_reference: selectedPlace.photoReference ?? null,
                 start_datetime_local: startStr,
                 end_datetime_local: endStr,
                 cost: cost ? parseFloat(cost) : 0,
@@ -275,19 +308,70 @@ export default function NewPlanModal({
                 timezone_string: tzData.timeZoneId || 'Asia/Seoul'
             }
 
-            let result;
+            let savedPlanId: string | null = null
             if (editData?.id) {
-                result = await supabase.from('plans').update(planData).eq('id', editData.id)
+                const result = await supabase
+                    .from('plans')
+                    .update(planData)
+                    .eq('id', editData.id)
+                    .select('id')
+                    .single()
+                if (result.error) throw result.error
+                savedPlanId = (result.data as { id?: string } | null)?.id ?? editData.id
             } else {
-                result = await supabase.from('plans').insert(planData)
+                const result = await supabase
+                    .from('plans')
+                    .insert(planData)
+                    .select('id')
+                    .single()
+                if (result.error) throw result.error
+                savedPlanId = (result.data as { id?: string } | null)?.id ?? null
             }
 
-            if (result.error) throw result.error
+            // 백그라운드 업로드 (fire-and-forget). photo_reference + placeId 모두 있을 때만 시도.
+            // 모달 close 이전에 시작해야 try/catch/finally가 의도대로 동작한다.
+            if (
+                savedPlanId &&
+                selectedPlace.photoReference &&
+                selectedPlace.googlePlaceId
+            ) {
+                try {
+                    uploadPlacePhotoInBackground(
+                        {
+                            planId: savedPlanId,
+                            tripId,
+                            placeId: selectedPlace.googlePlaceId,
+                            photoReference: selectedPlace.photoReference,
+                        },
+                        (imageUrl) => {
+                            // Zustand store가 plan-level에 없어, 부모에게 콜백으로 통지
+                            try {
+                                onPlanImageUpdated?.(savedPlanId as string, imageUrl)
+                            } catch (cbErr) {
+                                console.warn(
+                                    '[NewPlanModal] onPlanImageUpdated callback failed',
+                                    cbErr,
+                                )
+                            }
+                        },
+                    )
+                } catch (bgErr) {
+                    // Zero Noise: 백그라운드 업로드 실패는 토스트 없이 콘솔만
+                    console.warn('[NewPlanModal] background upload start failed', bgErr)
+                }
+            }
 
+            // 모든 sync 호출이 정상 종료된 뒤 모달을 닫는다.
+            // 이렇게 해야 INSERT/UPDATE 직후 발생할 수 있는 예외도 catch 블록에 도달하여
+            // 사용자에게 에러 메시지를 노출할 수 있다.
             onSuccess()
             onClose()
-        } catch (err: any) {
-            setError(err.message || '일정을 저장하는 중 오류가 발생했습니다.')
+        } catch (err: unknown) {
+            const message =
+                err instanceof Error
+                    ? err.message
+                    : '일정을 저장하는 중 오류가 발생했습니다.'
+            setError(message)
         } finally {
             setLoading(false)
         }

--- a/src/components/trips/PlanDetailModal.tsx
+++ b/src/components/trips/PlanDetailModal.tsx
@@ -12,6 +12,7 @@ import { useNetworkStore } from '@/stores/useNetworkStore'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useScrollLock } from '@/hooks/useScrollLock'
 import UrlPreviewCard from '@/components/common/UrlPreviewCard'
+import PlanImage from '@/components/common/PlanImage'
 // ── Main Modal ──
 interface PlanDetailModalProps {
     plan: any
@@ -24,11 +25,14 @@ interface PlanDetailModalProps {
     onEdit: (plan: any) => void
     onDelete: (id: string) => void
     onToggleVisit: (planId: string, isVisited: boolean) => void
+    /** PlanImage 복구 성공 시 호출. 부모(TripClient/RouteMapView) plans 동기화. */
+    onPlanImageRecovered?: (planId: string, newImageUrl: string) => void
 }
 
 export default function PlanDetailModal({
     plan, exchangeRates, formatLocalTime, formatKstTime, timeDisplayMode,
     userRole, onClose, onEdit, onDelete, onToggleVisit,
+    onPlanImageRecovered,
 }: PlanDetailModalProps) {
     const [tab, setTab] = useState<'info' | 'refs'>('info')
     const [mapError, setMapError] = useState(false)
@@ -123,24 +127,38 @@ export default function PlanDetailModal({
                 })}
             >
                 {/* ── 헤더 & 히어로 섹션 ── */}
-                <div className={css({ 
-                    position: 'relative', 
-                    h: plan.image_url ? { base: '240px', sm: '260px' } : { base: '140px', sm: '160px' },
+                <div className={css({
+                    position: 'relative',
+                    h: (plan.image_url || plan.photo_reference)
+                        ? { base: '240px', sm: '260px' }
+                        : { base: '140px', sm: '160px' },
                     flexShrink: 0,
                     overflow: 'hidden',
-                    bg: 'brand.primary',
+                    bg: 'bg.surfaceSoft',
                 })}>
-                    {plan.image_url && (
+                    {(plan.image_url || plan.photo_reference) && (
                         <>
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img 
-                                src={plan.image_url} 
-                                alt={plan.title} 
-                                className={css({ w: '100%', h: '100%', objectFit: 'cover' })} 
+                            <PlanImage
+                                planId={plan.id}
+                                tripId={plan.trip_id}
+                                placeId={plan.google_place_id}
+                                imageUrl={plan.image_url}
+                                photoReference={plan.photo_reference}
+                                createdAt={plan.created_at}
+                                variant="hero"
+                                alt={plan.title}
+                                onRecovered={(newUrl) => {
+                                    try {
+                                        onPlanImageRecovered?.(plan.id, newUrl)
+                                    } catch (err) {
+                                        console.warn('[PlanDetailModal] onPlanImageRecovered failed', err)
+                                    }
+                                }}
                             />
-                            <div className={css({ 
-                                position: 'absolute', inset: 0, 
-                                background: 'linear-gradient(to bottom, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0) 50%, rgba(0,0,0,0.7) 100%)' 
+                            <div className={css({
+                                position: 'absolute', inset: 0,
+                                background: 'linear-gradient(to bottom, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0) 50%, rgba(0,0,0,0.7) 100%)',
+                                pointerEvents: 'none',
                             })} />
                         </>
                     )}

--- a/src/components/trips/PlanList.tsx
+++ b/src/components/trips/PlanList.tsx
@@ -3,14 +3,18 @@
 import { css } from 'styled-system/css'
 import { Clock, CheckCircle2, Circle, Trash2, Edit3, Wallet, Bell, MapPin, FileText, Link2 } from 'lucide-react'
 import { getCurrencyFromTimezone, formatCurrency } from '@/utils/currency'
+import PlanImage from '@/components/common/PlanImage'
 
-interface Plan {
+export interface Plan {
     id: string
+    trip_id: string
     title: string
     location: string
     address: string
     lat: number
     lng: number
+    location_lat?: number
+    location_lng?: number
     visit_date?: string
     visit_time?: string
     start_datetime_local: string
@@ -18,14 +22,18 @@ interface Plan {
     alarm_minutes_before?: number
     cost: number
     memo: string
-    image_url: string
+    image_url: string | null
+    photo_reference?: string | null
+    google_place_id?: string | null
+    created_at?: string | null
     is_completed: boolean
     is_visited: boolean
     timezone_string: string
+    plan_urls?: Array<{ id?: string; url: string; title?: string | null }>
 }
 
 interface PlanListProps {
-    plans: any[]
+    plans: Plan[]
     exchangeRates: Record<string, number>
     activeDropdown: string | null
     setActiveDropdown: (id: string | null) => void
@@ -33,10 +41,12 @@ interface PlanListProps {
     timeDisplayMode: 'local' | 'kst' | 'both'
     formatLocalTime: (date: string) => string
     formatKstTime: (date: string, tz: string) => string
-    onEdit: (plan: any) => void
+    onEdit: (plan: Plan) => void
     onDelete: (id: string) => void
-    onDetail: (plan: any) => void
+    onDetail: (plan: Plan) => void
     onToggleVisit: (planId: string, isVisited: boolean) => void
+    /** PlanImage 복구 성공 시 호출. 부모가 plans 리스트 image_url을 동기화. */
+    onPlanImageRecovered?: (planId: string, newImageUrl: string) => void
 }
 
 export default function PlanList({
@@ -51,7 +61,8 @@ export default function PlanList({
     onEdit,
     onDelete,
     onDetail,
-    onToggleVisit
+    onToggleVisit,
+    onPlanImageRecovered,
 }: PlanListProps) {
     if (!plans || plans.length === 0) {
         return (
@@ -64,7 +75,7 @@ export default function PlanList({
     }
 
     // 날짜별 그룹화 (start_datetime_local 기준)
-    const groupedPlans = plans.reduce((groups: Record<string, any[]>, plan) => {
+    const groupedPlans = plans.reduce<Record<string, Plan[]>>((groups, plan) => {
         const date = plan.start_datetime_local.split('T')[0]
         if (!groups[date]) groups[date] = []
         groups[date].push(plan)
@@ -126,6 +137,7 @@ export default function PlanList({
                                     onDelete={onDelete}
                                     onDetail={onDetail}
                                     onToggleVisit={onToggleVisit}
+                                    onPlanImageRecovered={onPlanImageRecovered}
                                 />
                             </div>
                         ))}
@@ -146,18 +158,20 @@ function PlanCard({
     onEdit,
     onDelete,
     onDetail,
-    onToggleVisit
+    onToggleVisit,
+    onPlanImageRecovered,
 }: {
-    plan: any
+    plan: Plan
     exchangeRates: Record<string, number>
     userRole: 'owner' | 'editor' | 'viewer' | null
     timeDisplayMode: 'local' | 'kst' | 'both'
     formatLocalTime: (date: string) => string
     formatKstTime: (date: string, tz: string) => string
-    onEdit: (plan: any) => void
+    onEdit: (plan: Plan) => void
     onDelete: (id: string) => void
-    onDetail: (plan: any) => void
+    onDetail: (plan: Plan) => void
     onToggleVisit: (planId: string, isVisited: boolean) => void
+    onPlanImageRecovered?: (planId: string, newImageUrl: string) => void
 }) {
     const currency = getCurrencyFromTimezone(plan.timezone_string || 'Asia/Seoul')
     const rate = exchangeRates[currency.code]
@@ -177,17 +191,33 @@ function PlanCard({
                 _hover: { boxShadow: 'airbnbHover', borderColor: 'transparent', transform: 'translateY(-2px)' },
             })}
         >
-            {/* 왼쪽: 라운드 썸네일 */}
-            {plan.image_url && (
-                <div
-                    className={css({
-                        w: '68px', flexShrink: 0, borderRadius: '12px',
-                        backgroundSize: 'cover', backgroundPosition: 'center',
-                        alignSelf: 'stretch',
-                    })}
-                    style={{ backgroundImage: `url("${plan.image_url}")` }}
+            {/* 왼쪽: 라운드 썸네일 (PlanImage가 6개 상태 모두 처리) */}
+            <div
+                className={css({
+                    w: '68px',
+                    flexShrink: 0,
+                    alignSelf: 'stretch',
+                    minH: '68px',
+                })}
+            >
+                <PlanImage
+                    planId={plan.id}
+                    tripId={plan.trip_id}
+                    placeId={plan.google_place_id}
+                    imageUrl={plan.image_url}
+                    photoReference={plan.photo_reference}
+                    createdAt={plan.created_at}
+                    variant="thumbnail"
+                    alt={`${plan.title} 장소 사진`}
+                    onRecovered={(newUrl) => {
+                        try {
+                            onPlanImageRecovered?.(plan.id, newUrl)
+                        } catch (err) {
+                            console.warn('[PlanList] onPlanImageRecovered failed', err)
+                        }
+                    }}
                 />
-            )}
+            </div>
 
             {/* 오른쪽: 콘텐츠 */}
             <div className={css({ flex: 1, minW: 0, display: 'flex', flexDirection: 'column', gap: '6px' })}>
@@ -198,7 +228,7 @@ function PlanCard({
                         overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minW: 0,
                         textDecoration: plan.is_visited ? 'line-through' : 'none',
                     })}>{plan.title}</h4>
-                    {plan.alarm_minutes_before > 0 && (
+                    {(plan.alarm_minutes_before ?? 0) > 0 && (
                         <Bell size={13} className={css({ color: 'orange.500', flexShrink: 0 })} fill="currentColor" />
                     )}
                     {hasMemo && <FileText size={13} className={css({ color: 'brand.muted', flexShrink: 0 })} />}

--- a/src/components/trips/RouteMapView.tsx
+++ b/src/components/trips/RouteMapView.tsx
@@ -10,6 +10,7 @@ import { useNetworkStore } from '@/stores/useNetworkStore'
 import { collaboration } from '@/utils/collaboration'
 import { getCurrencyFromTimezone } from '@/utils/currency'
 import { ExchangeService } from '@/services/ExternalApiService'
+import { PlanPhotoStorageService } from '@/services/PlanPhotoStorageService'
 import RouteMapInfoModal from '@/components/trips/RouteMapInfoModal'
 import PlanDetailModal from '@/components/trips/PlanDetailModal'
 import NewPlanModal from '@/components/trips/NewPlanModal'
@@ -25,6 +26,7 @@ const MAP_CONTAINER_STYLE = { width: '100%', height: '100%' }
 
 interface Plan {
     id: string
+    trip_id?: string
     title: string
     location?: string
     address?: string
@@ -36,6 +38,9 @@ interface Plan {
     location_lng?: number
     google_place_id?: string
     timezone_string?: string
+    image_url?: string | null
+    photo_reference?: string | null
+    created_at?: string | null
 }
 
 interface RouteMapViewProps {
@@ -364,14 +369,32 @@ export default function RouteMapView({
     const handleDeletePlan = useCallback(
         async (planId: string) => {
             if (!confirm('이 일정을 삭제하시겠습니까?')) return
+            if (tripId) {
+                // best-effort: Storage cleanup 실패해도 plan DELETE는 계속 진행
+                try {
+                    await PlanPhotoStorageService.cleanupPlanPhotos({ tripId, planId })
+                } catch (cleanupErr) {
+                    console.warn('[RouteMapView] cleanupPlanPhotos failed (ignored)', cleanupErr)
+                }
+            }
             const { error } = await supabase.from('plans').delete().eq('id', planId)
             if (!error) {
                 setPlans(prev => prev.filter(p => p.id !== planId))
                 setDetailPlan(null)
             }
         },
-        [supabase]
+        [supabase, tripId]
     )
+
+    /** 백그라운드/on-demand 업로드 성공 시 plans 동기화 */
+    const handlePlanImageRecovered = useCallback((planId: string, newImageUrl: string) => {
+        setPlans(prev => prev.map(p => (
+            p.id === planId ? ({ ...p, image_url: newImageUrl } as Plan) : p
+        )))
+        setDetailPlan(cur => (
+            cur && cur.id === planId ? ({ ...cur, image_url: newImageUrl } as Plan) : cur
+        ))
+    }, [])
 
     // Offline fallback
     if (!isOnline) {
@@ -567,6 +590,7 @@ export default function RouteMapView({
                     onEdit={handleEditPlan}
                     onDelete={handleDeletePlan}
                     onToggleVisit={handleToggleVisit}
+                    onPlanImageRecovered={handlePlanImageRecovered}
                 />
             )}
 
@@ -580,6 +604,7 @@ export default function RouteMapView({
                     editData={editingPlan}
                     tripStartDate={tripStartDate}
                     tripEndDate={tripEndDate}
+                    onPlanImageUpdated={handlePlanImageRecovered}
                 />
             )}
 

--- a/src/hooks/useImageRecovery.ts
+++ b/src/hooks/useImageRecovery.ts
@@ -1,0 +1,88 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import { storePhoto, isStoring } from '@/services/PlacePhotoService'
+
+/**
+ * 이미지 복구 훅 — Google Place Photo 영구 저장 진입점.
+ *
+ * 책임:
+ *  - PlanImage(onError) 트리거 시 `POST /api/places/photo/store` 호출
+ *  - 모듈 스코프(PlacePhotoService)에 위임하여 in-flight dedup + cooldown 적용
+ *  - 성공 시 imageUrl 반환. 실패는 null 반환 (Zero Noise)
+ *  - 410 (photo_reference 만료) 시에도 null 반환 — 호출자(PlanImage)는
+ *    `error-final`로 자동 귀결됨
+ *
+ * 비고:
+ *  - Zustand store 갱신은 본 훅에서 직접 수행하지 않는다.
+ *    PlanImage의 onRecovered 콜백에서 호출자가 처리한다 (UX 설계 9.x 참조).
+ */
+
+export interface RecoverParams {
+    planId: string
+    tripId: string
+    placeId?: string | null
+    photoReference?: string | null
+}
+
+export interface RecoverResult {
+    imageUrl: string
+}
+
+export interface UseImageRecoveryReturn {
+    recover: (params: RecoverParams) => Promise<RecoverResult | null>
+    isRecovering: boolean
+    isRecoveringFor: (planId: string) => boolean
+}
+
+export function useImageRecovery(): UseImageRecoveryReturn {
+    const [isRecovering, setIsRecovering] = useState(false)
+    const inFlightRef = useRef<boolean>(false)
+
+    const recover = useCallback(
+        async (params: RecoverParams): Promise<RecoverResult | null> => {
+            const { planId, tripId, placeId, photoReference } = params
+
+            // 필수 필드 검증 — photoReference는 서버 fallback이 처리하므로 optional
+            if (!planId || !tripId || !placeId) {
+                return null
+            }
+
+            // 동일 훅 인스턴스 dedup (PlanImage가 한 카드에서 onError가 빠르게 두 번 발생할 수 있음)
+            if (inFlightRef.current) return null
+
+            inFlightRef.current = true
+            setIsRecovering(true)
+            try {
+                const result = await storePhoto({
+                    planId,
+                    tripId,
+                    placeId,
+                    photoReference,
+                })
+
+                if (result.ok) {
+                    return { imageUrl: result.imageUrl }
+                }
+                // 실패 — 모든 사유에 대해 null 반환. cooldown은 모듈 스코프가 관리.
+                return null
+            } catch (error) {
+                // 예외는 service에서 잡지만, 방어적으로 처리
+                console.error('[useImageRecovery] unexpected error', error)
+                return null
+            } finally {
+                inFlightRef.current = false
+                setIsRecovering(false)
+            }
+        },
+        [],
+    )
+
+    const isRecoveringFor = useCallback((planId: string) => {
+        return isStoring(planId)
+    }, [])
+
+    return { recover, isRecovering, isRecoveringFor }
+}
+
+export default useImageRecovery

--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -41,12 +41,16 @@ export const DownloadService = {
             if (tripErr || !trip) throw new Error('Trip not found')
 
             // 2. 일정 정보 (Plan + PlanURLs)
+            //    NOTE: plans.image_url 은 영구 저장 전환(이슈 #184) 이후 Supabase Storage publicUrl만 들어간다.
+            //          만료 가능한 Google CDN URL 은 더 이상 image_url 에 저장되지 않으므로 캐시 안전.
+            //          단, photo_reference 만 있고 백그라운드 업로드가 미완료인 plan 은 image_url=null로 캐시되며
+            //          오프라인에서는 PlanImage 가 placeholder로 표시된다 (정상 동작).
             const { data: plans, error: plansErr } = await supabase
                 .from('plans')
                 .select('*, plan_urls(*)')
                 .eq('trip_id', tripId)
                 .order('start_datetime_local', { ascending: true })
-            
+
             if (plansErr) throw new Error('Plans fetch failed')
 
             // 3. 체크리스트 정보

--- a/src/services/ExternalApiService.ts
+++ b/src/services/ExternalApiService.ts
@@ -66,18 +66,35 @@ export const LocationService = {
 
 /**
  * Google Places 사진 서비스
+ *
+ * `getPhoto`: 미리보기 URL과 영구 저장에 필요한 `photoReference`를 동시에 반환.
  */
+export interface PlacePhotoResponse {
+  url: string | null;
+  photoReference: string | null;
+}
+
 export const PlacePhotoService = {
-  getPhotoUrl: async (placeId: string, maxwidth = 400): Promise<string | null> => {
+  /**
+   * 미리보기 URL + photoReference 동시 조회.
+   * NewPlanModal이 plans INSERT 시 `photo_reference` 컬럼에 저장하기 위한 용도.
+   */
+  getPhoto: async (
+    placeId: string,
+    maxwidth = 400,
+  ): Promise<PlacePhotoResponse> => {
     try {
-      const response = await apiService.get<{ url: string | null }>('/api/places/photo/', {
+      const response = await apiService.get<PlacePhotoResponse>('/api/places/photo/', {
         placeId,
         maxwidth: String(maxwidth),
       });
-      return response.data.url || null;
+      return {
+        url: response.data?.url ?? null,
+        photoReference: response.data?.photoReference ?? null,
+      };
     } catch (error) {
-      console.error('[PlacePhotoService] Failed to fetch photo URL:', error);
-      return null;
+      console.error('[PlacePhotoService] Failed to fetch photo metadata:', error);
+      return { url: null, photoReference: null };
     }
   }
 };

--- a/src/services/PlacePhotoService.ts
+++ b/src/services/PlacePhotoService.ts
@@ -1,0 +1,216 @@
+import { Capacitor, CapacitorHttp } from '@capacitor/core'
+
+/**
+ * PlacePhotoService
+ * - Google Place Photo의 영구 저장(Supabase Storage) 흐름 진입점.
+ * - 모듈 스코프에서 in-flight dedup과 cooldown을 관리하여 동일 plan에 대한
+ *   중복 호출을 차단한다.
+ *
+ * 주의:
+ *  - 직접 `POST /api/places/photo/store` 호출 (인증 쿠키 동반).
+ *  - 모바일(Capacitor) 환경에서는 CapacitorHttp 사용 (절대 경로).
+ *  - 실패는 silent (콘솔 로그만). 호출자(훅/모달)는 onRecovered 콜백을 통해
+ *    성공 시 상태를 갱신한다.
+ */
+
+export interface StorePhotoParams {
+    planId: string
+    tripId: string
+    placeId?: string | null
+    photoReference?: string | null
+}
+
+export interface StorePhotoResult {
+    /** Storage publicUrl (성공 시) */
+    imageUrl: string
+}
+
+/** 410 응답 시 사용. photo_reference 만료 */
+const PHOTO_REFERENCE_EXPIRED_COOLDOWN_MS = 24 * 60 * 60 * 1000 // 24h
+/** 그 외 5xx/네트워크 실패 시 사용 */
+const TRANSIENT_FAILURE_COOLDOWN_MS = 5 * 60 * 1000 // 5분
+
+const inFlight: Set<string> = new Set()
+const lastFailedAt: Map<string, { at: number; cooldownMs: number }> = new Map()
+
+function isCoolingDown(planId: string): boolean {
+    const entry = lastFailedAt.get(planId)
+    if (!entry) return false
+    if (Date.now() - entry.at >= entry.cooldownMs) {
+        lastFailedAt.delete(planId)
+        return false
+    }
+    return true
+}
+
+function getStoreUrl(): string {
+    const base = process.env.NEXT_PUBLIC_APP_URL || ''
+    if (Capacitor.isNativePlatform()) {
+        // Native: 절대 경로 필요
+        return `${base}/api/places/photo/store`
+    }
+    return '/api/places/photo/store'
+}
+
+/** in-flight + cooldown 체크 (사이드 이펙트 없음) */
+export function canStoreNow(planId: string): boolean {
+    if (!planId) return false
+    if (inFlight.has(planId)) return false
+    if (isCoolingDown(planId)) return false
+    return true
+}
+
+/** 진행 중 여부 (UI 표시용) */
+export function isStoring(planId: string): boolean {
+    return !!planId && inFlight.has(planId)
+}
+
+/**
+ * `POST /api/places/photo/store` 호출.
+ * - 성공: { imageUrl }
+ * - 410: photo_reference 만료 → 장기 cooldown 기록 후 'expired' 반환
+ * - 그 외 실패: 단기 cooldown 기록 후 'transient' 반환
+ *
+ * 호출자가 await 가능. 백그라운드 호출 측에서는 `void` 처리하여 fire-and-forget.
+ */
+export async function storePhoto(
+    params: StorePhotoParams,
+): Promise<
+    | { ok: true; imageUrl: string }
+    | { ok: false; reason: 'invalid' | 'cooldown' | 'expired' | 'transient' }
+> {
+    const { planId, tripId, placeId, photoReference } = params
+
+    // photoReference는 optional — 서버가 placeId로 Places Details fallback 수행
+    if (!planId || !tripId || !placeId) {
+        return { ok: false, reason: 'invalid' }
+    }
+    if (inFlight.has(planId)) {
+        return { ok: false, reason: 'cooldown' }
+    }
+    if (isCoolingDown(planId)) {
+        return { ok: false, reason: 'cooldown' }
+    }
+
+    inFlight.add(planId)
+    try {
+        const url = getStoreUrl()
+        const normalizedPhotoReference = photoReference ?? null
+        const body = JSON.stringify({
+            planId,
+            tripId,
+            placeId,
+            photoReference: normalizedPhotoReference,
+        })
+
+        let status = 0
+        let payload: StorePhotoResult | { error?: string } = {}
+
+        if (Capacitor.isNativePlatform()) {
+            try {
+                const res = await CapacitorHttp.request({
+                    url,
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    data: {
+                        planId,
+                        tripId,
+                        placeId,
+                        photoReference: normalizedPhotoReference,
+                    },
+                    connectTimeout: 15000,
+                    readTimeout: 15000,
+                })
+                status = res.status
+                payload = (res.data as StorePhotoResult) ?? {}
+            } catch (err) {
+                console.warn('[PlacePhotoService] native request failed', err)
+                lastFailedAt.set(planId, {
+                    at: Date.now(),
+                    cooldownMs: TRANSIENT_FAILURE_COOLDOWN_MS,
+                })
+                return { ok: false, reason: 'transient' }
+            }
+        } else {
+            try {
+                const controller = new AbortController()
+                const timer = setTimeout(() => controller.abort(), 15000)
+                let res: Response
+                try {
+                    res = await fetch(url, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body,
+                        credentials: 'same-origin',
+                        signal: controller.signal,
+                    })
+                } finally {
+                    clearTimeout(timer)
+                }
+                status = res.status
+                payload = await res.json().catch(() => ({}))
+            } catch (err) {
+                console.warn('[PlacePhotoService] fetch failed', err)
+                lastFailedAt.set(planId, {
+                    at: Date.now(),
+                    cooldownMs: TRANSIENT_FAILURE_COOLDOWN_MS,
+                })
+                return { ok: false, reason: 'transient' }
+            }
+        }
+
+        if (status === 200 && (payload as StorePhotoResult).imageUrl) {
+            return { ok: true, imageUrl: (payload as StorePhotoResult).imageUrl }
+        }
+
+        if (status === 410) {
+            lastFailedAt.set(planId, {
+                at: Date.now(),
+                cooldownMs: PHOTO_REFERENCE_EXPIRED_COOLDOWN_MS,
+            })
+            return { ok: false, reason: 'expired' }
+        }
+
+        lastFailedAt.set(planId, {
+            at: Date.now(),
+            cooldownMs: TRANSIENT_FAILURE_COOLDOWN_MS,
+        })
+        return { ok: false, reason: 'transient' }
+    } finally {
+        inFlight.delete(planId)
+    }
+}
+
+/**
+ * 백그라운드 업로드 (fire-and-forget).
+ * - await 하지 않음. 호출자는 즉시 다음 동작으로 진행 가능.
+ * - 성공 시 `onSuccess` 콜백을 통해 imageUrl 전달.
+ * - 실패는 silent (콘솔 로그만).
+ */
+export function uploadInBackground(
+    params: StorePhotoParams,
+    onSuccess?: (imageUrl: string) => void,
+): void {
+    if (!canStoreNow(params.planId)) return
+    storePhoto(params)
+        .then(result => {
+            if (result.ok && onSuccess) {
+                try {
+                    onSuccess(result.imageUrl)
+                } catch (err) {
+                    console.warn('[PlacePhotoService] onSuccess callback failed', err)
+                }
+            }
+        })
+        .catch(err => {
+            // Zero Noise: 토스트 없이 콘솔 로그만
+            console.warn('[PlacePhotoService] background upload failed', err)
+        })
+}
+
+export const PlacePhotoStoreService = {
+    storePhoto,
+    uploadInBackground,
+    canStoreNow,
+    isStoring,
+}

--- a/src/services/PlanPhotoStorageService.ts
+++ b/src/services/PlanPhotoStorageService.ts
@@ -1,0 +1,103 @@
+import { createClient } from '@/utils/supabase/client'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * PlanPhotoStorageService
+ * - place-photos 버킷 내 plan 관련 객체의 cleanup을 담당.
+ * - plan 삭제 흐름에서 best-effort로 호출하며, 실패해도 plan 삭제 자체는 진행한다.
+ *
+ * 경로 규칙: place-photos/{user_id}/{trip_id}/{plan_id}_{placeIdHash8}.jpg
+ *
+ * 권한: RLS에 의해 본인 폴더(user_id == auth.uid()) 객체만 삭제 가능.
+ */
+class PlanPhotoStorageServiceImpl {
+    private static instance: PlanPhotoStorageServiceImpl
+    private readonly bucket = 'place-photos'
+
+    private constructor() {}
+
+    static getInstance(): PlanPhotoStorageServiceImpl {
+        if (!PlanPhotoStorageServiceImpl.instance) {
+            PlanPhotoStorageServiceImpl.instance = new PlanPhotoStorageServiceImpl()
+        }
+        return PlanPhotoStorageServiceImpl.instance
+    }
+
+    /**
+     * plan 삭제 전후로 호출. {user_id}/{trip_id}/ 폴더에서 {plan_id}_ 로 시작하는 객체를 일괄 삭제.
+     *
+     * @param params.tripId  trip id (경로 구성에 필요)
+     * @param params.planId  plan id (파일명 접두어)
+     * @returns 삭제된 객체 수 (실패 시 0)
+     *
+     * 실패는 best-effort: 절대 throw 하지 않음. 호출 측 plan DELETE는 계속 진행.
+     */
+    async cleanupPlanPhotos(params: { tripId: string; planId: string }): Promise<number> {
+        const { tripId, planId } = params
+        if (!tripId || !planId) {
+            return 0
+        }
+
+        try {
+            const supabase: SupabaseClient = createClient()
+
+            // 1) 현재 사용자 식별
+            const {
+                data: { user },
+                error: authError,
+            } = await supabase.auth.getUser()
+            if (authError || !user) {
+                console.warn('[PlanPhotoStorageService] cleanup skipped: unauthenticated')
+                return 0
+            }
+
+            const folder = `${user.id}/${tripId}`
+
+            // 2) 폴더 내 객체 목록 조회
+            const { data: list, error: listError } = await supabase.storage
+                .from(this.bucket)
+                .list(folder, { limit: 100 })
+
+            if (listError) {
+                console.warn(
+                    '[PlanPhotoStorageService] list failed:',
+                    listError.message
+                )
+                return 0
+            }
+            if (!list || list.length === 0) {
+                return 0
+            }
+
+            // 3) {plan_id}_ 로 시작하는 객체만 필터
+            const targets = list
+                .filter(obj => obj?.name?.startsWith(`${planId}_`))
+                .map(obj => `${folder}/${obj.name}`)
+
+            if (targets.length === 0) {
+                return 0
+            }
+
+            // 4) 삭제 (RLS에 의해 본인 폴더만 삭제 가능)
+            const { data: removed, error: removeError } = await supabase.storage
+                .from(this.bucket)
+                .remove(targets)
+
+            if (removeError) {
+                console.warn(
+                    '[PlanPhotoStorageService] remove failed:',
+                    removeError.message
+                )
+                return 0
+            }
+
+            return removed?.length ?? 0
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : 'Unknown error'
+            console.warn('[PlanPhotoStorageService] cleanup error:', message)
+            return 0
+        }
+    }
+}
+
+export const PlanPhotoStorageService = PlanPhotoStorageServiceImpl.getInstance()

--- a/supabase/add_photo_reference_to_plans.sql
+++ b/supabase/add_photo_reference_to_plans.sql
@@ -1,0 +1,8 @@
+-- plans 테이블에 photo_reference 컬럼 추가
+-- Google Places photo_reference 토큰을 보존하여 on-demand 복구 및 백그라운드 업로드의 키로 사용
+
+ALTER TABLE public.plans
+  ADD COLUMN IF NOT EXISTS photo_reference TEXT;
+
+COMMENT ON COLUMN public.plans.photo_reference IS
+  'Google Places photo_reference 토큰. on-demand 갱신 및 백그라운드 업로드에 사용.';

--- a/supabase/create_place_photos_bucket.sql
+++ b/supabase/create_place_photos_bucket.sql
@@ -1,0 +1,51 @@
+-- place-photos Storage 버킷 + RLS 정책
+-- 경로 규칙: place-photos/{user_id}/{trip_id}/{plan_id}_{placeIdHash8}.jpg
+-- SELECT: 누구나(public) / INSERT, UPDATE, DELETE: 본인 폴더만(auth.uid())
+
+-- 1) 버킷 생성 (public)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('place-photos', 'place-photos', true)
+ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public;
+
+-- 2) RLS 정책: 기존 정책 제거 후 재생성 (idempotent)
+DROP POLICY IF EXISTS "place_photos_select_public" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_insert_own" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_update_own" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_delete_own" ON storage.objects;
+
+-- 2-1) SELECT: 누구나 (public 버킷이므로 모든 사용자가 조회 가능)
+CREATE POLICY "place_photos_select_public"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'place-photos');
+
+-- 2-2) INSERT: 본인 폴더에만 업로드 가능
+CREATE POLICY "place_photos_insert_own"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 2-3) UPDATE: 본인 폴더 객체만 수정 가능
+CREATE POLICY "place_photos_update_own"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+)
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 2-4) DELETE: 본인 폴더 객체만 삭제 가능
+CREATE POLICY "place_photos_delete_own"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);


### PR DESCRIPTION
## Summary

Google Places Photo API CDN URL이 시간 경과 후 403으로 만료되는 문제를 해결한다.

- **영구 저장**: 이미지를 Supabase Storage(`place-photos` 버킷)에 저장 + `plans.photo_reference` 컬럼 추가
- **하이브리드 비동기 UX**: 일정 저장은 즉시 완료(INSERT), 이미지 업로드는 백그라운드 처리
- **On-demand 복구**: 레거시 만료 URL은 `<img onError>` 트리거로 자동 복구
- **Zero Noise UX**: shimmer → 페이드인 / 실패 시 회색 배경 + 아이콘 (신규 디자인 토큰 0개, 10% Rule 100% 준수)

Resolves #184

## 주요 변경

### DB / Storage
- `supabase/add_photo_reference_to_plans.sql` — `plans.photo_reference TEXT` 컬럼 추가
- `supabase/create_place_photos_bucket.sql` — `place-photos` 버킷 + RLS 4종

### 백엔드
- `src/app/api/places/photo/store/route.ts` (신규) — Google CDN fetch → Storage upload → plans UPDATE
- `src/app/api/places/photo/route.ts` — 응답에 `photoReference` 포함
- `src/services/PlanPhotoStorageService.ts` (신규) — DELETE 시 Storage cleanup (best-effort)

### 프론트엔드
- `src/services/PlacePhotoService.ts` (신규) — 백그라운드 업로드 + dedup `Set` + cooldown `Map`(5분/24h)
- `src/hooks/useImageRecovery.ts` (신규) — `<img onError>` 복구 훅
- `src/components/common/PlanImage.tsx` (신규) — 6-state 머신, shimmer/페이드인, a11y(aria-busy/role/label)
- `NewPlanModal`/`PlanList`/`PlanDetailModal`/`RouteMapView`/`TripClient` — PlanImage 적용 + DELETE cleanup chain
- `ExternalApiService.getPhoto` — 단일 메서드로 통합

### 문서
- `docs/adrs/ADR-006-google-place-photo-permanent-storage.md`

## 배포 전 사용자 작업

1. **Supabase 마이그레이션 실행** (모두 idempotent)
   - `supabase/add_photo_reference_to_plans.sql`
   - `supabase/create_place_photos_bucket.sql`
2. **환경변수 확인**
   - `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` (필수)
   - `GOOGLE_PLACES_API_KEY` (권장, 서버 전용)
   - `NEXT_PUBLIC_APP_URL` (모바일 환경 필수)

## Test plan

- [x] 신규 plan 저장 → 1초 내 thumbnail shimmer → 이미지 전환
- [x] `photo_reference`만 있는 plan 진입 → hero shimmer → 이미지 전환
- [x] DevTools Network에서 `/api/places/photo/store` 중복 호출 없음 확인
- [x] plan DELETE → Supabase Studio Storage 패널에서 객체 제거 확인
- [x] 오프라인 모드 → 5분 cooldown 후 placeholder 수렴
- [x] iOS/Android 빌드(`pnpm build:mobile`) 정상 동작

## 검증 결과 (사전)

- `pnpm build` / `pnpm build:mobile` 성공 (TypeScript 0 에러)
- 리뷰 2차 PASS / QA 시나리오 8개 PASS / 회귀 없음

## 약관 관련 메모

Google Maps Platform §3.2.3 (a) "No Caching of Content"에 대해 1인 서비스 범위에서 정책적 리스크를 감수하는 결정. `photo_reference`를 보존하므로 정책 강화 시 언제든 전환 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)