### PR TITLE
feat: Playwright E2E 테스트 인프라 구축 Phase 1~3 (Resolves #191)

### DIFF
--- a/docs/develop-context/e2e-testing-guide.md
+++ b/docs/develop-context/e2e-testing-guide.md
@@ -1,0 +1,167 @@
+# E2E 테스트 도입 가이드 (Playwright)
+
+> 작성일: 2026-06-09 / 최종 업데이트: 2026-06-10
+> 상태: **Phase 1~3 완료** — Playwright 설치, 로컬 Supabase 마이그레이션 체계, 인증 픽스처, 스모크 테스트 4개 통과.
+> 목적: OnVoy 프로젝트에 Playwright 기반 E2E 테스트를 도입하기 위한 사전 분석 및 실행 계획 정리.
+
+---
+
+## 1. 현재 상태 (As-Is)
+
+| 항목 | 내용 |
+|------|------|
+| 스택 | Next.js 16 (App Router) + React 19, Supabase 인증, Panda CSS, Capacitor 하이브리드 |
+| 테스트 인프라 | **전무** — Playwright / Vitest / Jest 미설치, 테스트 파일 0개 |
+| 인증 방식 | Supabase + 카카오/구글 OAuth (`@supabase/ssr` 쿠키 기반) |
+| 페이지 라우트 (약 20개) | `login`, `signup`, `join`, `trips`(new/detail/checklist), `templates`(new/detail), `profile`(licenses/places-visited/travel-log/withdrawal), `share/detail`, `offline`, `auth`(callback/success/error) |
+
+→ 처음부터 테스트 인프라를 구축하는 셈이다.
+
+---
+
+## 2. 적용 가능성
+
+| 대상 | 가능 여부 | 비고 |
+|------|----------|------|
+| **웹 빌드** (`next dev` / `next start`) | ✅ 완전히 가능 | Playwright의 정석 영역 |
+| **모바일 빌드** (Capacitor static export) | ⚠️ 부분적 | 웹뷰는 동일 코드라 웹에서 대부분 검증 가능. 단, 네이티브 플러그인(푸시·로컬알림·네트워크·preferences 등)은 Playwright로 불가 → 필요 시 Appium 등 별도 도구 |
+
+**결론: 웹 기준 E2E는 충분히 도입 가능하다.** 모바일 네이티브 영역은 범위에서 제외하고 시작하는 것을 권장한다.
+
+---
+
+## 3. 핵심 고려사항 (착수 전 반드시 결정)
+
+### 3.1 인증 우회 전략 (가장 중요)
+카카오/구글 OAuth는 E2E에서 실제 로그인 플로우를 그대로 타기 어렵다(외부 IdP 화면, 캡차 등).
+
+- **권장 방식**: Supabase `service_role` 키로 **테스트 전용 유저의 세션을 발급 → 쿠키 / `storageState` 로 주입**하여 로그인 상태에서 테스트를 시작한다.
+  - `@supabase/ssr`의 쿠키 구조(`sb-<project-ref>-auth-token` 등)에 맞춰 세션 쿠키를 심는 방식.
+  - Playwright의 `storageState` 기능으로 인증 픽스처를 한 번 만들어 재사용.
+- OAuth 콜백(`/auth/callback`) 자체를 검증하고 싶다면 별도 시나리오로 분리하되, 외부 IdP는 mock 처리.
+
+> ⚠️ **[보안 주의]** 테스트에 `SUPABASE_SERVICE_ROLE_KEY`와 테스트 계정이 사용된다.
+> - 운영 DB가 아닌 **별도 테스트/로컬 Supabase 인스턴스** 사용을 강력히 권장.
+> - service_role 키·비밀번호·토큰은 **테스트 코드나 픽스처에 하드코딩 금지**, 환경변수(`.env.test.local` 등, gitignore 처리)로만 주입.
+> - 테스트 데이터에 **실제 고객/임직원 정보 사용 금지** — 시드 데이터로 격리.
+> - 기준: 야놀자그룹 AI 보안 가이드 https://yanoljagroup.atlassian.net/wiki/spaces/Compliance/pages/2451412038/AI
+
+### 3.2 Google Maps API
+- E2E에서 실제 호출 시 비용·쿼터 발생 → **mock** 처리하거나 **테스트 전용 키** 분리.
+- 지도 렌더링 자체보다 지도 위의 우리 UI 동작 검증에 집중.
+
+### 3.3 테스트 데이터 격리
+- 실제 운영 데이터 사용 금지. **시드 스크립트**로 테스트 데이터 생성 → 테스트 후 정리(teardown).
+- Supabase RLS 정책이 테스트 유저 기준으로 정상 동작하는지도 함께 검증 가능.
+
+### 3.4 환경변수
+필요한 키(값은 `.env.local` 참조):
+`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`(테스트 인스턴스용), `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`(또는 mock), `NEXT_PUBLIC_APP_URL`.
+
+---
+
+## 4. 제안 셋업 구성
+
+```
+playwright.config.ts          # webServer로 next dev 자동 기동, baseURL, projects(브라우저) 설정
+e2e/
+  ├── fixtures/
+  │   └── auth.ts             # 인증된 세션(storageState) 주입 픽스처
+  ├── helpers/
+  │   └── supabase.ts         # 테스트 유저 생성/세션 발급/정리
+  ├── trips.spec.ts           # 여행 생성/조회/체크리스트
+  ├── templates.spec.ts       # 템플릿 생성/조회
+  └── ...
+.env.test.local               # 테스트 전용 환경변수 (gitignore)
+```
+
+`package.json` 스크립트 추가(예시):
+```jsonc
+"test:e2e": "playwright test",
+"test:e2e:ui": "playwright test --ui"
+```
+
+설치(예시):
+```bash
+pnpm add -D @playwright/test
+pnpm exec playwright install --with-deps chromium
+```
+
+`playwright.config.ts` 골격(예시):
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: { baseURL: 'http://localhost:3000', trace: 'on-first-retry' },
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});
+```
+
+> 참고: `next dev`는 `NODE_OPTIONS='--dns-result-order=ipv4first'` 옵션과 함께 실행됨(package.json `dev` 스크립트). webServer command를 `pnpm dev`로 두면 그대로 적용된다.
+
+---
+
+## 5. 권장 진행 범위 (택1로 시작)
+
+1. **셋업만** — Playwright 설치 + `playwright.config.ts` + 인증 픽스처 골격까지.
+2. **셋업 + 스모크 1~2개** — "로그인 → 여행 생성 → 체크리스트 작성" 핵심 플로우 1개.  ← **권장 시작점**
+3. **전체 주요 플로우** — 위 라우트들의 핵심 시나리오 일괄 작성.
+
+### 추천 우선순위 시나리오
+1. (스모크) 로그인 상태 진입 → 홈 렌더링 확인
+2. 여행 생성 → 상세 진입 → 체크리스트 항목 추가/체크
+3. 템플릿 생성 → 여행에 적용
+4. 프로필 조회 / 여행 기록 확인
+5. 공유 링크(`share/detail`) 비로그인 접근 동작
+
+---
+
+## 6. 하네스 통합 (선택)
+
+반복적인 E2E 작성·실행을 위해 OnVoy 하네스에 **E2E 전담 스킬/에이전트** 추가를 고려할 수 있다.
+- 예: `e2e-author` 스킬 — 시나리오 명세 → spec 작성 → 실행 → 결과 리포트.
+- 기존 `qa-engineer` 에이전트의 책임 범위에 E2E 실행 검증을 포함시키는 방안도 가능.
+
+---
+
+## 7. 구현 완료 현황
+
+### Phase 1 — 셋업 ✅
+- `@playwright/test` v1.60.0 설치
+- `playwright.config.ts` — `webServer: pnpm dev:e2e`, baseURL, chromium
+- `e2e/fixtures/`, `e2e/helpers/` 디렉토리 구조 생성
+- `.env.test.local` (로컬 Supabase 접속 정보, gitignore 처리)
+- `package.json` 스크립트: `test:e2e`, `test:e2e:ui`, `test:e2e:report`, `dev:e2e`
+
+### Phase 2 — 로컬 Supabase 마이그레이션 체계 ✅
+- `supabase` CLI v2.105.0 설치
+- `supabase/migrations/` — 14개 파일, 날짜순 정렬
+- 운영 URL·키 하드코딩 → `app.supabase_functions_url` 참조 방식으로 교체
+- `supabase db reset --local` 으로 13개 테이블 재현 확인
+
+### Phase 2 — 인증 픽스처 ✅
+- `e2e/helpers/supabase.ts` — REST API 직접 호출로 유저 생성/세션 발급/teardown
+- `e2e/fixtures/auth.ts` — `createBrowserClient.setSession()`으로 쿠키 생성 후 주입
+- `scripts/dev-e2e.mjs` — `.env.local` 무수정 원칙 준수, `process.env` 직접 주입 방식
+
+### Phase 3 — 스모크 테스트 ✅
+`e2e/smoke.spec.ts` — 4개 테스트 모두 통과:
+1. 비인증 사용자 → 랜딩 페이지 렌더링
+2. 비인증 사용자 → 보호 경로 접근 시 `/login` 리다이렉트
+3. 인증된 사용자 → 홈 렌더링 ("님! 👋", "새 여행 만들기" 버튼)
+4. 인증된 사용자 → 보호 경로 `/trips/new` 접근 가능
+
+---
+
+## 8. 다음 액션
+- [ ] 여행 생성 → 상세 진입 → 체크리스트 항목 추가/체크 (스모크 시나리오 2)
+- [ ] 템플릿 생성 → 여행에 적용 (시나리오 3)
+- [ ] Google Maps API mock 구성 (Playwright route intercept)
+- [ ] 시드 스크립트 작성 (테스트 데이터 생성 + teardown)
+- [ ] CI 통합 (GitHub Actions)

--- a/docs/develop-context/rules.md
+++ b/docs/develop-context/rules.md
@@ -47,5 +47,42 @@ OnVoy의 디자인 가치와 브랜드 아이デン티티를 훼손하지 마십
 
 ---
 
+---
+
+## 5. 🧪 E2E 테스트 환경 규칙
+
+E2E 테스트 실행 및 인프라 작업 시 다음 규칙을 **절대적으로** 준수한다.
+
+### 5.1 환경변수 파일 보호 (절대 규칙)
+
+- **`.env.local`은 스크립트나 코드로 절대 수정·덮어쓰기·이동·삭제하지 않는다.**
+  - 이 파일에는 운영 API 키, Supabase 키, 카카오/구글 키 등 복구 불가능한 민감 정보가 포함된다.
+  - 백업 후 교체 방식(`rename` → `copyFile` → 복원)도 금지한다. 프로세스 비정상 종료 시 복원이 보장되지 않는다.
+- **E2E 전용 환경변수는 `process.env`에 직접 주입하는 방식으로만 처리한다.**
+  - Next.js 우선순위: `process.env` > `.env.local` — 이미 주입된 값은 `.env.local`이 덮어쓰지 않는다.
+  - 구현체: `scripts/dev-e2e.mjs` — `.env.test.local`을 읽어 `process.env`에 assign 후 `next dev` 실행.
+- `.env.test.local`은 `.gitignore`로 보호되며, 예시 구조는 `.env.test.local.example`에 유지한다.
+
+### 5.2 로컬 Supabase 인스턴스
+
+- E2E 테스트는 **반드시 로컬 Supabase 인스턴스**(`supabase start`)를 사용한다. 운영 DB 절대 금지.
+- 마이그레이션은 `supabase/migrations/`에 날짜순으로 관리하며, `supabase db reset --local`로 재현 가능해야 한다.
+- 운영 URL·키가 마이그레이션 파일에 하드코딩되지 않도록 한다 (`app.supabase_functions_url` 설정 참조 방식 사용).
+
+### 5.3 테스트 유저 관리
+
+- 테스트 유저는 `e2e/helpers/supabase.ts`의 `createTestUser` / `deleteTestUser`로만 생성·삭제한다.
+- 실제 고객·임직원 정보를 테스트 데이터로 사용하지 않는다.
+- 테스트 유저 이메일은 `*.onvoy.local` 도메인을 사용한다 (운영 도메인과 명확히 구분).
+
+### 5.4 @supabase/ssr 쿠키 주입
+
+- 인증 픽스처(`e2e/fixtures/auth.ts`)는 `createBrowserClient`의 `setSession()`을 통해 쿠키를 생성한다.
+  - 쿠키 이름은 SDK가 자동 결정한다 — 직접 계산하거나 하드코딩하지 않는다.
+  - 로컬 인스턴스(`127.0.0.1`)의 쿠키 이름은 `sb-127-auth-token`으로 생성된다.
+- 쿠키 주입 후 보호 경로 접근 가능 여부를 스모크 테스트로 반드시 검증한다.
+
+---
+
 > [!WARNING]
 > 본 가이드라인을 어기는 것은 프로젝트의 일관성을 해치는 심각한 위험으로 간주됩니다. 불확실할 경우 항상 질문하십시오.

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,72 @@
+import { test as base, type BrowserContext } from '@playwright/test';
+import { createBrowserClient } from '@supabase/ssr';
+import { createTestUser, deleteTestUser, type TestUser } from '../helpers/supabase';
+
+const TEST_USER_EMAIL = process.env.E2E_TEST_USER_EMAIL ?? 'e2e-test@onvoy.local';
+const TEST_USER_PASSWORD = process.env.E2E_TEST_USER_PASSWORD ?? 'E2eTestPassword1!';
+
+export type AuthFixtures = {
+  authenticatedContext: BrowserContext;
+  testUser: TestUser;
+};
+
+/**
+ * @supabase/ssr의 createBrowserClient를 사용해 실제 쿠키 이름과 인코딩 방식을
+ * 그대로 재현한다. 쿠키 이름은 Supabase URL의 호스트명 첫 세그먼트에서 결정되므로
+ * 직접 계산하지 않고 SDK에 위임한다.
+ */
+async function injectSession(context: BrowserContext, user: TestUser) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const baseURL = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const domain = new URL(baseURL).hostname;
+
+  const collectedCookies: Array<{ name: string; value: string }> = [];
+
+  const client = createBrowserClient(supabaseUrl, anonKey, {
+    cookies: {
+      getAll: () => collectedCookies,
+      setAll: (toSet) => {
+        toSet.forEach(({ name, value }) => {
+          const idx = collectedCookies.findIndex((c) => c.name === name);
+          if (idx >= 0) collectedCookies[idx].value = value;
+          else collectedCookies.push({ name, value });
+        });
+      },
+    },
+  });
+
+  // SDK가 세션을 설정하면서 올바른 쿠키 이름/인코딩으로 collectedCookies에 저장한다
+  await client.auth.setSession({
+    access_token: user.accessToken,
+    refresh_token: user.refreshToken,
+  });
+
+  await context.addCookies(
+    collectedCookies.map(({ name, value }) => ({
+      name,
+      value,
+      domain,
+      path: '/',
+      httpOnly: false,
+      sameSite: 'Lax' as const,
+    }))
+  );
+}
+
+export const test = base.extend<AuthFixtures>({
+  testUser: async ({}, use) => {
+    const user = await createTestUser(TEST_USER_EMAIL, TEST_USER_PASSWORD);
+    await use(user);
+    await deleteTestUser(TEST_USER_EMAIL);
+  },
+
+  authenticatedContext: async ({ browser, testUser }, use) => {
+    const context = await browser.newContext();
+    await injectSession(context, testUser);
+    await use(context);
+    await context.close();
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,3 @@
+export default function globalTeardown() {
+  // .env.local을 수정하지 않으므로 별도 복원 불필요
+}

--- a/e2e/helpers/supabase.ts
+++ b/e2e/helpers/supabase.ts
@@ -1,0 +1,101 @@
+import { createClient } from '@supabase/supabase-js';
+
+function getEnv(key: string): string {
+  const val = process.env[key];
+  if (!val) throw new Error(`환경변수 누락: ${key}`);
+  return val;
+}
+
+export interface TestUser {
+  id: string;
+  email: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * 테스트 전용 유저를 생성하고 세션 토큰을 반환한다.
+ * 실제 고객/임직원 정보를 사용하지 말 것.
+ */
+export async function createTestUser(email: string, password: string): Promise<TestUser> {
+  const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const anonKey = getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  const serviceKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+  // 1. 유저 생성 또는 비밀번호 업데이트 (admin REST API)
+  const createRes = await fetch(`${url}/auth/v1/admin/users`, {
+    method: 'POST',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password, email_confirm: true }),
+  });
+
+  const createBody = await createRes.json();
+
+  let userId: string;
+  if (createRes.ok) {
+    userId = createBody.id;
+  } else if (createBody.msg?.includes('already') || createBody.code === 'email_exists' || createBody.code === '23505') {
+    // 이미 존재하면 목록에서 찾아 비밀번호 업데이트
+    const listRes = await fetch(`${url}/auth/v1/admin/users?per_page=1000`, {
+      headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+    });
+    const { users } = await listRes.json();
+    const found = (users as any[]).find((u) => u.email === email);
+    if (!found) throw new Error(`테스트 유저를 찾을 수 없음: ${email}`);
+    userId = found.id;
+
+    await fetch(`${url}/auth/v1/admin/users/${userId}`, {
+      method: 'PUT',
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ password, email_confirm: true }),
+    });
+  } else {
+    throw new Error(`테스트 유저 생성 실패: ${JSON.stringify(createBody)}`);
+  }
+
+  // 2. 세션 발급 (anon key로 signInWithPassword)
+  const signInRes = await fetch(`${url}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const session = await signInRes.json();
+  if (!session.access_token) {
+    throw new Error(`세션 발급 실패: ${JSON.stringify(session)}`);
+  }
+
+  return {
+    id: userId,
+    email,
+    accessToken: session.access_token,
+    refreshToken: session.refresh_token,
+  };
+}
+
+/**
+ * 테스트 유저와 연관된 모든 데이터를 삭제한다 (teardown).
+ */
+export async function deleteTestUser(email: string): Promise<void> {
+  const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const serviceKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+  const listRes = await fetch(`${url}/auth/v1/admin/users?per_page=1000`, {
+    headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+  });
+  const { users } = await listRes.json();
+  const found = (users as any[]).find((u) => u.email === email);
+  if (!found) return;
+
+  await fetch(`${url}/auth/v1/admin/users/${found.id}`, {
+    method: 'DELETE',
+    headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+  });
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from './fixtures/auth';
+
+test.describe('스모크: 홈 페이지', () => {
+  test('비인증 사용자 — 랜딩 페이지 렌더링', async ({ page }) => {
+    await page.goto('/');
+
+    // 비로그인 랜딩 페이지 핵심 요소 확인 (동일 텍스트 복수 존재 → first() 사용)
+    await expect(page.getByRole('link', { name: '지금 바로 시작하기' }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: '로그인하기' })).toBeVisible();
+  });
+
+  test('인증된 사용자 — 홈 렌더링 및 주요 UI 확인', async ({ authenticatedContext }) => {
+    const page = await authenticatedContext.newPage();
+    await page.goto('/');
+
+    // 인증된 홈: 환영 메시지 ("님! 👋" 포함)
+    await expect(page.getByText('님! 👋')).toBeVisible({ timeout: 10000 });
+
+    // 새 여행 만들기 버튼
+    await expect(page.getByRole('button', { name: /새 여행 만들기/ })).toBeVisible();
+
+    // 비로그인 랜딩 CTA가 보이지 않아야 함
+    await expect(page.getByRole('link', { name: '지금 바로 시작하기' }).first()).not.toBeVisible();
+
+    await page.close();
+  });
+
+  test('인증된 사용자 — 보호 경로 접근 가능', async ({ authenticatedContext }) => {
+    const page = await authenticatedContext.newPage();
+
+    await page.goto('/trips/new');
+
+    // /login으로 리다이렉트되지 않아야 함
+    await expect(page).not.toHaveURL(/\/login/, { timeout: 8000 });
+
+    await page.close();
+  });
+
+  test('비인증 사용자 — 보호 경로 접근 시 로그인 리다이렉트', async ({ page }) => {
+    await page.goto('/trips/new');
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 8000 });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "build:mobile": "mv src/app/api src/app_api_tmp && mv src/app/auth src/app_auth_tmp && mv src/app/share src/app_share_tmp && BUILD_TARGET=mobile next build; BS=$?; mv src/app_api_tmp src/app/api; mv src/app_auth_tmp src/app/auth; mv src/app_share_tmp src/app/share; exit $BS",
     "start": "NODE_OPTIONS='--dns-result-order=ipv4first' next start",
     "lint": "eslint",
-    "prepare": "panda codegen"
+    "prepare": "panda codegen",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report",
+    "dev:e2e": "node scripts/dev-e2e.mjs"
   },
   "dependencies": {
     "@capacitor-community/firebase-analytics": "^8.0.0",
@@ -43,6 +47,7 @@
   "devDependencies": {
     "@capacitor/cli": "^8.2.0",
     "@pandacss/dev": "^1.8.2",
+    "@playwright/test": "^1.60.0",
     "@types/archiver": "^6.0.3",
     "@types/google.maps": "^3.58.1",
     "@types/node": "^20.19.33",
@@ -50,6 +55,8 @@
     "@types/react-dom": "^19",
     "archiver": "^7.0.1",
     "babel-plugin-react-compiler": "1.0.0",
+    "dotenv": "^17.4.2",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "postcss": "^8.5.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+import { config } from 'dotenv';
+
+// .env.test.local을 playwright 프로세스 및 테스트 코드에 주입
+config({ path: '.env.test.local' });
+
+export default defineConfig({
+  testDir: './e2e',
+  globalTeardown: './e2e/global-teardown.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    // E2E 전용 dev 서버: .env.local 대신 .env.e2e를 사용
+    // pnpm e2e:dev 스크립트가 .env.e2e를 .env.local로 교체하고 실행
+    command: 'pnpm dev:e2e',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 8.45.1(@capacitor/core@8.2.0)
       '@next/third-parties':
         specifier: latest
-        version: 16.2.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 16.2.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@react-google-maps/api':
         specifier: ^2.19.3
         version: 2.20.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -61,7 +61,7 @@ importers:
         version: 3.2.0(@capacitor/core@8.2.0)
       '@sentry/nextjs':
         specifier: 8.47.0
-        version: 8.47.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)
+        version: 8.47.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)
       '@supabase/ssr':
         specifier: ^0.8.0
         version: 0.8.0(@supabase/supabase-js@2.98.0)
@@ -70,7 +70,7 @@ importers:
         version: 2.98.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -82,7 +82,7 @@ importers:
         version: 0.575.0(react@19.2.3)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -99,6 +99,9 @@ importers:
       '@pandacss/dev':
         specifier: ^1.8.2
         version: 1.8.2(typescript@5.9.3)
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/archiver':
         specifier: ^6.0.3
         version: 6.0.4
@@ -120,6 +123,12 @@ importers:
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
       eslint:
         specifier: ^9
         version: 9.39.3
@@ -1132,6 +1141,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/instrumentation@5.22.0':
     resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
@@ -2193,8 +2207,20 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv-cli@11.0.0:
+    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
+    hasBin: true
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -2558,6 +2584,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3413,6 +3444,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -4843,9 +4884,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
-  '@next/third-parties@16.2.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@next/third-parties@16.2.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       third-party-capital: 1.0.20
 
@@ -5368,6 +5409,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@prisma/instrumentation@5.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -5532,7 +5577,7 @@ snapshots:
 
   '@sentry/core@8.47.0': {}
 
-  '@sentry/nextjs@8.47.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)':
+  '@sentry/nextjs@8.47.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -5545,7 +5590,7 @@ snapshots:
       '@sentry/vercel-edge': 8.47.0
       '@sentry/webpack-plugin': 2.22.7(webpack@5.105.4)
       chalk: 3.0.0
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.11
@@ -5932,9 +5977,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/speed-insights@2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/speed-insights@2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vue/compiler-core@3.5.25':
@@ -6546,7 +6591,20 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv-cli@11.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 17.4.2
+      dotenv-expand: 12.0.3
+      minimist: 1.2.8
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
   dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -7094,6 +7152,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -7703,7 +7764,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -7723,6 +7784,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.60.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -7898,6 +7960,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:

--- a/scripts/dev-e2e.mjs
+++ b/scripts/dev-e2e.mjs
@@ -1,0 +1,44 @@
+/**
+ * E2E 테스트용 dev 서버 실행 스크립트
+ *
+ * 원칙: .env.local을 절대 수정하지 않는다.
+ * Next.js는 이미 process.env에 설정된 값을 .env.local로 덮어쓰지 않으므로,
+ * .env.test.local 값을 process.env에 먼저 주입한 뒤 next dev를 실행한다.
+ */
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { spawn } from 'child_process';
+
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) throw new Error(`파일 없음: ${filePath}`);
+  return Object.fromEntries(
+    readFileSync(resolve(filePath), 'utf-8')
+      .split('\n')
+      .filter((line) => line.trim() && !line.startsWith('#'))
+      .map((line) => {
+        const idx = line.indexOf('=');
+        return [line.slice(0, idx).trim(), line.slice(idx + 1).trim()];
+      })
+      .filter(([k]) => k)
+  );
+}
+
+const testEnv = loadEnvFile('.env.test.local');
+
+// .env.test.local 값을 현재 process.env에 주입 (next dev가 상속받음)
+// Next.js 우선순위: process.env > .env.local > .env
+// → 이미 주입된 값은 .env.local이 덮어쓰지 않는다
+Object.assign(process.env, testEnv);
+
+const dev = spawn('node_modules/.bin/next', ['dev'], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    NODE_OPTIONS: '--dns-result-order=ipv4first',
+  },
+  shell: false,
+});
+
+dev.on('exit', (code) => process.exit(code ?? 0));
+process.on('SIGINT', () => dev.kill('SIGINT'));
+process.on('SIGTERM', () => dev.kill('SIGTERM'));

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,413 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "travel-pack"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. Leave unset today to preserve local behaviour. The implicit default
+# flips to `false` on 2026-05-30 to match the new cloud default, and the field is removed in
+# 2026-10-30 once the always-revoked behaviour is permanent. Set to `false` to opt in early.
+# auto_expose_new_tables = false
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260309000001_initial_schema.sql
+++ b/supabase/migrations/20260309000001_initial_schema.sql
@@ -1,0 +1,408 @@
+-- 1. Create profiles table linked to auth.users
+CREATE TABLE public.profiles (
+  id uuid references auth.users on delete cascade not null primary key,
+  email text,
+  nickname text,
+  auth_provider text,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Enable RLS on profiles
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own profile." ON public.profiles FOR SELECT USING (auth.uid() = id);
+CREATE POLICY "Users can update own profile." ON public.profiles FOR UPDATE USING (auth.uid() = id);
+
+-- 2. Create trips table
+CREATE TABLE public.trips (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references public.profiles(id) on delete cascade not null,
+  destination text not null,
+  start_date date not null,
+  end_date date not null,
+  adults_count integer default 1,
+  children_count integer default 0,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.trips ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own trips." ON public.trips FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own trips." ON public.trips FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own trips." ON public.trips FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own trips." ON public.trips FOR DELETE USING (auth.uid() = user_id);
+
+-- 3. Create plans table
+CREATE TABLE public.plans (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  title text not null,
+  location text,
+  cost numeric default 0,
+  memo text,
+  start_datetime_local timestamp without time zone not null,
+  end_datetime_local timestamp without time zone not null,
+  timezone_string text not null,
+  alarm_minutes_before integer,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.plans ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage plans for their trips" ON public.plans
+  FOR ALL USING (trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid()));
+
+-- 4. Create plan_urls table
+CREATE TABLE public.plan_urls (
+  id uuid default gen_random_uuid() primary key,
+  plan_id uuid references public.plans(id) on delete cascade not null,
+  url text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.plan_urls ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage plan urls for their trips" ON public.plan_urls
+  FOR ALL USING (plan_id IN (SELECT id FROM public.plans WHERE trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid())));
+
+-- 5. Checklist Templates
+CREATE TABLE public.checklist_templates (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references public.profiles(id) on delete cascade, -- null means public template
+  title text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.checklist_templates ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view public or own templates" ON public.checklist_templates
+  FOR SELECT USING (user_id IS NULL OR user_id = auth.uid());
+CREATE POLICY "Users can insert own templates" ON public.checklist_templates
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own templates" ON public.checklist_templates
+  FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own templates" ON public.checklist_templates
+  FOR DELETE USING (auth.uid() = user_id);
+
+CREATE TABLE public.checklist_template_items (
+  id uuid default gen_random_uuid() primary key,
+  template_id uuid references public.checklist_templates(id) on delete cascade not null,
+  item_name text not null,
+  category text default '기타' not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.checklist_template_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view public or own template items" ON public.checklist_template_items
+  FOR SELECT USING (
+    template_id IN (
+      SELECT id FROM public.checklist_templates WHERE user_id IS NULL OR user_id = auth.uid()
+    )
+  );
+CREATE POLICY "Users can manage own template items" ON public.checklist_template_items
+  FOR ALL USING (
+    template_id IN (
+      SELECT id FROM public.checklist_templates WHERE user_id = auth.uid()
+    )
+  );
+
+-- 6. Trip Checklists
+CREATE TABLE public.checklists (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  title text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.checklists ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage checklists for their trips" ON public.checklists
+  FOR ALL USING (trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid()));
+
+CREATE TABLE public.checklist_items (
+  id uuid default gen_random_uuid() primary key,
+  checklist_id uuid references public.checklists(id) on delete cascade not null,
+  item_name text not null,
+  category text default '기타' not null,
+  is_checked boolean default false not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.checklist_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage checklist items for their trips" ON public.checklist_items
+  FOR ALL USING (checklist_id IN (SELECT id FROM public.checklists WHERE trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid())));
+
+-- 7. Function to handle new user insertion automatically
+CREATE OR REPLACE FUNCTION public.handle_new_user() 
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, nickname, auth_provider)
+  VALUES (
+    new.id,
+    new.email,
+    new.raw_user_meta_data->>'full_name',
+    new.raw_app_meta_data->>'provider'
+  );
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger to call handle_new_user
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE PROCEDURE public.handle_new_user();
+-- 1. Create trip_members table
+CREATE TABLE public.trip_members (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) on delete cascade, -- Null if pending invite
+  invited_email text not null,
+  role text check (role in ('owner', 'editor', 'viewer')) default 'editor' not null,
+  status text check (status in ('pending', 'accepted')) default 'pending' not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.trip_members ENABLE ROW LEVEL SECURITY;
+
+-- 2. Create trip_shares table
+CREATE TABLE public.trip_shares (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  share_token text unique not null,
+  share_type text check (share_type in ('public', 'password')) default 'public' not null,
+  password_hash text,
+  expires_at timestamp with time zone,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.trip_shares ENABLE ROW LEVEL SECURITY;
+
+-- 3. Revise RLS Policies for trips
+-- Allow owners and members to select trips
+DROP POLICY IF EXISTS "Users can view own trips." ON public.trips;
+CREATE POLICY "Users can view trips they own or are members of." ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = public.trips.id AND user_id = auth.uid())
+  );
+
+-- Allow owners to update
+DROP POLICY IF EXISTS "Users can update own trips." ON public.trips;
+CREATE POLICY "Owners can update their trips." ON public.trips
+  FOR UPDATE USING (auth.uid() = user_id);
+
+-- Allow owners to delete
+DROP POLICY IF EXISTS "Users can delete own trips." ON public.trips;
+CREATE POLICY "Owners can delete their trips." ON public.trips
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- 4. Revise RLS Policies for plans
+DROP POLICY IF EXISTS "Users can manage plans for their trips" ON public.plans;
+CREATE POLICY "Users with edit permission can manage plans" ON public.plans
+  FOR ALL USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    )
+  )
+  WITH CHECK (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    )
+  );
+
+-- Allow viewers and shared link users to view plans
+CREATE POLICY "Viewers can select plans" ON public.plans
+  FOR SELECT USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_shares WHERE share_type = 'public' -- basic check, more logic needed in app for password
+    )
+  );
+
+-- 5. Revise RLS Policies for checklists and items (Same pattern as plans)
+DROP POLICY IF EXISTS "Users can manage checklists for their trips" ON public.checklists;
+CREATE POLICY "Users with edit permission can manage checklists" ON public.checklists
+  FOR ALL USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can manage checklist items for their trips" ON public.checklist_items;
+CREATE POLICY "Users with edit permission can manage checklist items" ON public.checklist_items
+  FOR ALL USING (
+    checklist_id IN (
+      SELECT id FROM public.checklists WHERE trip_id IN (
+        SELECT id FROM public.trips WHERE user_id = auth.uid()
+        UNION
+        SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+      )
+    )
+  );
+
+-- 6. Policies for trip_members
+CREATE POLICY "Users can see members of trips they belong to" ON public.trip_members
+  FOR SELECT USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Owners can manage members" ON public.trip_members
+  FOR ALL USING (
+    trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid())
+  );
+-- Add missing RLS policies for trip_shares
+CREATE POLICY "Owners can manage share links" ON public.trip_shares
+  FOR ALL USING (
+    trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid())
+  );
+
+-- Allow anyone to select share links by token (for public/password access)
+CREATE POLICY "Anyone can select share link by token" ON public.trip_shares
+  FOR SELECT USING (true);
+-- 1. Create security functions to break recursion
+CREATE OR REPLACE FUNCTION public.check_is_trip_owner(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trips
+    WHERE id = _trip_id AND user_id = _user_id
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_trip_member(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_members
+    WHERE trip_id = _trip_id AND user_id = _user_id AND status = 'accepted'
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_trip_editor(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_members
+    WHERE trip_id = _trip_id AND user_id = _user_id AND status = 'accepted' AND role IN ('owner', 'editor')
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- 2. Update Trips Policies
+DROP POLICY IF EXISTS "Users can view trips they own or are members of." ON public.trips;
+CREATE POLICY "Users can view trips they own or are members of." ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR public.check_is_trip_member(id, auth.uid())
+  );
+
+-- 3. Update Trip Members Policies
+DROP POLICY IF EXISTS "Users can see members of trips they belong to" ON public.trip_members;
+CREATE POLICY "Users can see members of trips they belong to" ON public.trip_members
+  FOR SELECT USING (
+    user_id = auth.uid() OR 
+    invited_email = (auth.jwt() ->> 'email') OR
+    public.check_is_trip_owner(trip_id, auth.uid()) OR
+    public.check_is_trip_member(trip_id, auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Owners can manage members" ON public.trip_members;
+CREATE POLICY "Owners can manage members" ON public.trip_members
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid())
+  );
+
+-- 4. Update Trip Shares Policies
+DROP POLICY IF EXISTS "Owners can manage share links" ON public.trip_shares;
+CREATE POLICY "Owners can manage share links" ON public.trip_shares
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid())
+  );
+
+-- 5. Update Plans Policies
+DROP POLICY IF EXISTS "Users with edit permission can manage plans" ON public.plans;
+CREATE POLICY "Users with edit permission can manage plans" ON public.plans
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_editor(trip_id, auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Viewers can select plans" ON public.plans;
+CREATE POLICY "Viewers can select plans" ON public.plans
+  FOR SELECT USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_member(trip_id, auth.uid()) OR
+    EXISTS (SELECT 1 FROM public.trip_shares WHERE trip_id = public.plans.trip_id AND share_type = 'public')
+  );
+
+-- 6. Update Checklists Policies
+DROP POLICY IF EXISTS "Users with edit permission can manage checklists" ON public.checklists;
+CREATE POLICY "Users with edit permission can manage checklists" ON public.checklists
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_editor(trip_id, auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Users with edit permission can manage checklist items" ON public.checklist_items;
+CREATE POLICY "Users with edit permission can manage checklist items" ON public.checklist_items
+  FOR ALL USING (
+    checklist_id IN (
+      SELECT id FROM public.checklists 
+      WHERE public.check_is_trip_owner(trip_id, auth.uid()) OR public.check_is_trip_editor(trip_id, auth.uid())
+    )
+  );
+-- Allow anyone to select trip basic info if a public share link exists
+DROP POLICY IF EXISTS "Users can view trips they own or are members of." ON public.trips;
+CREATE POLICY "Users can view trips via owner, member or public share" ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    public.check_is_trip_member(id, auth.uid()) OR
+    EXISTS (SELECT 1 FROM public.trip_shares WHERE trip_id = public.trips.id AND share_type = 'public')
+  );
+-- Create a function to check if a trip has any public share link
+CREATE OR REPLACE FUNCTION public.check_is_public_trip(_trip_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_shares
+    WHERE trip_id = _trip_id AND share_type = 'public'
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- Update trips SELECT policy
+DROP POLICY IF EXISTS "Users can view trips via owner, member or public share" ON public.trips;
+CREATE POLICY "Users can view trips via owner, member or public share" ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    public.check_is_trip_member(id, auth.uid()) OR
+    public.check_is_public_trip(id)
+  );
+-- Final RLS fix for trips and shares to ensure guest access
+-- 1. Ensure trip_shares is truly public for SELECT
+DROP POLICY IF EXISTS "Anyone can select share link by token" ON public.trip_shares;
+CREATE POLICY "Public select trip_shares" ON public.trip_shares
+  FOR SELECT USING (true);
+
+-- 2. Ensure trips is readable if a public share link exists
+DROP POLICY IF EXISTS "Users can view trips via owner, member or public share" ON public.trips;
+CREATE POLICY "Public select trips if shared" ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    public.check_is_trip_member(id, auth.uid()) OR
+    EXISTS (SELECT 1 FROM public.trip_shares ts WHERE ts.trip_id = id AND ts.share_type = 'public')
+  );
+
+-- 3. Ensure plans are also readable
+DROP POLICY IF EXISTS "Viewers can select plans" ON public.plans;
+CREATE POLICY "Public select plans if shared" ON public.plans
+  FOR SELECT USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_member(trip_id, auth.uid()) OR
+    EXISTS (SELECT 1 FROM public.trip_shares ts WHERE ts.trip_id = trip_id AND ts.share_type = 'public')
+  );

--- a/supabase/migrations/20260309000002_add_unique_trip_members.sql
+++ b/supabase/migrations/20260309000002_add_unique_trip_members.sql
@@ -1,0 +1,5 @@
+-- trip_members 테이블에 중복 초대 방지를 위한 유니크 제약 조건 추가
+
+-- 같은 여행(trip_id)에 같은 이메일(invited_email)이 중복 등록되지 않도록 합니다.
+ALTER TABLE public.trip_members 
+ADD CONSTRAINT trip_members_trip_id_invited_email_key UNIQUE (trip_id, invited_email);

--- a/supabase/migrations/20260320000001_collaboration_and_sharing.sql
+++ b/supabase/migrations/20260320000001_collaboration_and_sharing.sql
@@ -1,0 +1,136 @@
+-- ==========================================
+-- Nexvoy Collaboration & Sharing System
+-- Consolidated Database Patch
+-- ==========================================
+
+-- 1. Create Tables (if not exists)
+CREATE TABLE IF NOT EXISTS public.trip_members (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) on delete cascade,
+  invited_email text not null,
+  role text check (role in ('owner', 'editor', 'viewer')) default 'editor' not null,
+  status text check (status in ('pending', 'accepted')) default 'pending' not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+CREATE TABLE IF NOT EXISTS public.trip_shares (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  share_token text unique not null,
+  share_type text check (share_type in ('public', 'password')) default 'public' not null,
+  password_hash text,
+  expires_at timestamp with time zone,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Enable RLS
+ALTER TABLE public.trip_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.trip_shares ENABLE ROW LEVEL SECURITY;
+
+-- 2. Security Functions (to break recursion and handle guest access)
+CREATE OR REPLACE FUNCTION public.check_is_trip_owner(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trips
+    WHERE id = _trip_id AND user_id = _user_id
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_trip_member(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_members
+    WHERE trip_id = _trip_id AND user_id = _user_id AND status = 'accepted'
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_trip_editor(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_members
+    WHERE trip_id = _trip_id AND user_id = _user_id AND status = 'accepted' AND role IN ('owner', 'editor')
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_public_trip(_trip_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_shares
+    WHERE trip_id = _trip_id AND share_type = 'public'
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- 3. Comprehensive RLS Policies
+
+-- [TRIPS]
+DROP POLICY IF EXISTS "Users can view own trips." ON public.trips;
+DROP POLICY IF EXISTS "Users can view trips they own or are members of." ON public.trips;
+DROP POLICY IF EXISTS "Users can view trips via owner, member or public share" ON public.trips;
+DROP POLICY IF EXISTS "Public select trips if shared" ON public.trips;
+DROP POLICY IF EXISTS "Access trips by owner, member, or public share" ON public.trips;
+
+CREATE POLICY "Access trips by owner, member, or public share" ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    public.check_is_trip_member(id, auth.uid()) OR
+    public.check_is_public_trip(id)
+  );
+
+-- [TRIP_SHARES]
+DROP POLICY IF EXISTS "Anyone can select share link by token" ON public.trip_shares;
+DROP POLICY IF EXISTS "Owners can manage share links" ON public.trip_shares;
+DROP POLICY IF EXISTS "Public select trip_shares" ON public.trip_shares;
+DROP POLICY IF EXISTS "Public select shares" ON public.trip_shares;
+DROP POLICY IF EXISTS "Manage shares as owner" ON public.trip_shares;
+
+CREATE POLICY "Public select shares" ON public.trip_shares FOR SELECT USING (true);
+CREATE POLICY "Manage shares as owner" ON public.trip_shares FOR ALL USING (public.check_is_trip_owner(trip_id, auth.uid()));
+
+-- [TRIP_MEMBERS]
+DROP POLICY IF EXISTS "Users can see members of trips they belong to" ON public.trip_members;
+DROP POLICY IF EXISTS "Owners can manage members" ON public.trip_members;
+DROP POLICY IF EXISTS "Select members if related" ON public.trip_members;
+DROP POLICY IF EXISTS "Manage members as owner" ON public.trip_members;
+DROP POLICY IF EXISTS "Invited users can accept invitations" ON public.trip_members;
+
+CREATE POLICY "Select members if related" ON public.trip_members
+  FOR SELECT USING (
+    user_id = auth.uid() OR 
+    invited_email = (auth.jwt() ->> 'email') OR
+    public.check_is_trip_owner(trip_id, auth.uid()) OR
+    public.check_is_trip_member(trip_id, auth.uid())
+  );
+
+CREATE POLICY "Manage members as owner" ON public.trip_members
+  FOR ALL USING (public.check_is_trip_owner(trip_id, auth.uid()));
+
+CREATE POLICY "Invited users can accept invitations" ON public.trip_members
+  FOR UPDATE 
+  USING (
+    invited_email = (auth.jwt() ->> 'email') AND status = 'pending'
+  )
+  WITH CHECK (
+    user_id = auth.uid() AND status = 'accepted'
+  );
+
+-- [PLANS]
+DROP POLICY IF EXISTS "Users can manage plans for their trips" ON public.plans;
+DROP POLICY IF EXISTS "Users with edit permission can manage plans" ON public.plans;
+DROP POLICY IF EXISTS "Viewers can select plans" ON public.plans;
+DROP POLICY IF EXISTS "Public select plans if shared" ON public.plans;
+DROP POLICY IF EXISTS "Select plans if shared or related" ON public.plans;
+DROP POLICY IF EXISTS "Manage plans if editor or owner" ON public.plans;
+
+CREATE POLICY "Select plans if shared or related" ON public.plans
+  FOR SELECT USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_member(trip_id, auth.uid()) OR
+    public.check_is_public_trip(trip_id)
+  );
+
+CREATE POLICY "Manage plans if editor or owner" ON public.plans
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_editor(trip_id, auth.uid())
+  );

--- a/supabase/migrations/20260320000002_user_devices.sql
+++ b/supabase/migrations/20260320000002_user_devices.sql
@@ -1,0 +1,24 @@
+-- Create user_devices table for Push Notifications
+CREATE TABLE IF NOT EXISTS public.user_devices (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    fcm_token TEXT UNIQUE NOT NULL,
+    platform TEXT,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE public.user_devices ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+-- 1. Users can insert/upsert their own device tokens
+CREATE POLICY "Users can manage their own device tokens" 
+ON public.user_devices 
+FOR ALL 
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_user_devices_user_id ON public.user_devices(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_devices_fcm_token ON public.user_devices(fcm_token);

--- a/supabase/migrations/20260324000001_fix_plan_urls_rls.sql
+++ b/supabase/migrations/20260324000001_fix_plan_urls_rls.sql
@@ -1,0 +1,36 @@
+-- 1. 기존 '소유자 전용' 정책 제거
+DROP POLICY IF EXISTS "Users can manage plan urls for their trips" ON public.plan_urls;
+
+-- 2. 조회(SELECT) 정책 추가: 여행 소유자, 멤버(Accepted), 또는 공개 공유 링크 대상에게 허용
+CREATE POLICY "Allow members and public to view plan urls" ON public.plan_urls
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id AND (
+        public.check_is_trip_owner(p.trip_id, auth.uid()) OR 
+        public.check_is_trip_member(p.trip_id, auth.uid()) OR
+        EXISTS (SELECT 1 FROM public.trip_shares ts WHERE ts.trip_id = p.trip_id AND ts.share_type = 'public')
+      )
+    )
+  );
+
+-- 3. 관리(ALL) 정책 추가: 소유자 또는 편집자(Owner, Editor) 권한을 가진 사용자에게 허용
+CREATE POLICY "Allow editors to manage plan urls" ON public.plan_urls
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id AND (
+        public.check_is_trip_owner(p.trip_id, auth.uid()) OR 
+        public.check_is_trip_editor(p.trip_id, auth.uid())
+      )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id AND (
+        public.check_is_trip_owner(p.trip_id, auth.uid()) OR 
+        public.check_is_trip_editor(p.trip_id, auth.uid())
+      )
+    )
+  );

--- a/supabase/migrations/20260325000001_alarm_sent_at_and_rpc.sql
+++ b/supabase/migrations/20260325000001_alarm_sent_at_and_rpc.sql
@@ -1,0 +1,44 @@
+-- Add alarm_sent_at column to public.plans table
+ALTER TABLE public.plans
+ADD COLUMN IF NOT EXISTS alarm_sent_at TIMESTAMP WITH TIME ZONE;
+
+-- Create an index to optimize searching for unsent alarms
+CREATE INDEX IF NOT EXISTS idx_plans_alarm_minutes_before_sent_at 
+ON public.plans (alarm_minutes_before, alarm_sent_at) 
+WHERE alarm_minutes_before IS NOT NULL AND alarm_sent_at IS NULL;
+
+-- RPC to get pending alarms
+CREATE OR REPLACE FUNCTION get_pending_alarms()
+RETURNS TABLE (
+  plan_id UUID,
+  title TEXT,
+  location TEXT,
+  user_id UUID,
+  email TEXT,
+  timezone_string TEXT,
+  fcm_tokens TEXT[],
+  trip_destination TEXT
+) LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    p.id, 
+    p.title, 
+    p.location, 
+    t.user_id, 
+    pr.email, 
+    p.timezone_string, 
+    array_agg(DISTINCT d.fcm_token) FILTER (WHERE d.fcm_token IS NOT NULL) as fcm_tokens,
+    t.destination
+  FROM public.plans p
+  JOIN public.trips t ON p.trip_id = t.id
+  JOIN public.profiles pr ON t.user_id = pr.id
+  LEFT JOIN public.user_devices d ON t.user_id = d.user_id
+  WHERE 
+    p.alarm_minutes_before IS NOT NULL 
+    AND p.alarm_sent_at IS NULL
+    AND (now() AT TIME ZONE p.timezone_string) >= (p.start_datetime_local - (p.alarm_minutes_before || ' minutes')::interval)
+    AND p.start_datetime_local > (now() AT TIME ZONE p.timezone_string - interval '1 day')
+  GROUP BY p.id, p.title, p.location, t.user_id, pr.email, p.timezone_string, t.destination;
+END;
+$$;

--- a/supabase/migrations/20260325000002_setup_cron_job.sql
+++ b/supabase/migrations/20260325000002_setup_cron_job.sql
@@ -1,0 +1,11 @@
+-- 1. pg_cron 확장 활성화 (이미 되어 있을 수 있음)
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- 2. 기존 동일 이름의 크론 잡 삭제 (존재할 경우에만)
+SELECT cron.unschedule(jobid) 
+FROM cron.job 
+WHERE jobname = 'check-pending-alarms-cron';
+
+-- 3. 크론 잡은 운영 환경에서만 등록
+-- 로컬/테스트 환경에서는 적용하지 않음 (Edge Function URL과 service_role 키가 환경별로 다름)
+-- 운영 적용 시 Supabase 대시보드 또는 별도 스크립트로 수동 등록할 것

--- a/supabase/migrations/20260330000001_push_notification_trigger.sql
+++ b/supabase/migrations/20260330000001_push_notification_trigger.sql
@@ -1,0 +1,60 @@
+-- 1. Enable pg_net extension (if not already enabled)
+-- CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- 2. Function to trigger the Edge Function
+CREATE OR REPLACE FUNCTION public.handle_new_plan_notification()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_tokens TEXT[];
+    trip_name TEXT;
+    payload JSONB;
+BEGIN
+    -- Get trip destination for the message
+    SELECT destination INTO trip_name FROM public.trips WHERE id = NEW.trip_id;
+
+    -- 1. Find all members of the trip except the one who created the plan
+    -- 2. Join with user_devices to get their FCM tokens
+    SELECT array_agg(d.fcm_token)
+    INTO target_tokens
+    FROM public.trip_members m
+    JOIN public.user_devices d ON m.user_id = d.user_id
+    WHERE m.trip_id = NEW.trip_id
+      AND m.status = 'accepted'
+      AND m.user_id != auth.uid(); -- Don't notify the sender
+
+    -- If no tokens found, exit
+    IF target_tokens IS NULL OR array_length(target_tokens, 1) = 0 THEN
+        RETURN NEW;
+    END IF;
+
+    -- Prepare the payload for the Edge Function
+    payload := jsonb_build_object(
+        'tokens', target_tokens,
+        'title', '새로운 일정이 추가되었습니다!',
+        'body', '[' || trip_name || '] 여행에 "' || NEW.title || '" 일정이 등록되었습니다.',
+        'data', jsonb_build_object('tripId', NEW.trip_id::text)
+    );
+
+    -- Edge Function 호출 (운영 환경에서만 실제 동작)
+    -- 로컬/테스트 환경에서는 pg_net 미설치 시 함수 정의만 적용되고 호출은 skip됨
+    IF current_setting('app.env', true) != 'local' THEN
+      PERFORM
+        net.http_post(
+          url := current_setting('app.supabase_functions_url', true) || '/send-push-notification',
+          headers := jsonb_build_object(
+              'Content-Type', 'application/json',
+              'Authorization', 'Bearer ' || current_setting('app.service_role_key', true)
+          ),
+          body := payload
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 3. Create the Trigger
+DROP TRIGGER IF EXISTS on_plan_created ON public.plans;
+CREATE TRIGGER on_plan_created
+    AFTER INSERT ON public.plans
+    FOR EACH ROW EXECUTE FUNCTION public.handle_new_plan_notification();

--- a/supabase/migrations/20260330000002_trip_invitation_trigger.sql
+++ b/supabase/migrations/20260330000002_trip_invitation_trigger.sql
@@ -1,0 +1,67 @@
+-- 여행 초대 알림을 위한 트리거 및 함수
+CREATE OR REPLACE FUNCTION public.handle_trip_invitation_notification()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_tokens TEXT[];
+    inviter_name TEXT;
+    trip_title TEXT;
+    payload JSONB;
+BEGIN
+    -- 1. 초대한 사람의 닉네임 가져오기 (trips 테이블의 소유자)
+    -- 주의: 초대 액션을 수행한 사람이 반드시 소유자라고 가정 (현재 RLS 정책상 초대 권한은 소유자에게 있음)
+    SELECT p.nickname INTO inviter_name 
+    FROM public.trips t
+    JOIN public.profiles p ON t.user_id = p.id
+    WHERE t.id = NEW.trip_id;
+
+    -- 2. 여행 목적지 가져오기
+    SELECT destination INTO trip_title FROM public.trips WHERE id = NEW.trip_id;
+
+    -- 3. 초대받은 이메일과 일치하는 사용자의 FCM 토큰 가져오기
+    -- (이미 가입된 유저일 경우에만 알림 발송 가능)
+    SELECT array_agg(d.fcm_token)
+    INTO target_tokens
+    FROM public.profiles p
+    JOIN public.user_devices d ON p.id = d.user_id
+    WHERE p.email = NEW.invited_email;
+
+    -- 토큰이 없으면 종료
+    IF target_tokens IS NULL OR array_length(target_tokens, 1) = 0 THEN
+        RETURN NEW;
+    END IF;
+
+    -- 4. 페이로드 준비
+    payload := jsonb_build_object(
+        'tokens', target_tokens,
+        'title', '새로운 여행 초대!',
+        'body', inviter_name || '님이 "' || trip_title || '" 여행에 초대했습니다.',
+        'data', jsonb_build_object(
+            'tripId', NEW.trip_id::text,
+            'type', 'invitation'
+        )
+    );
+
+    -- 5. Edge Function 호출 (운영 환경에서만 실제 동작)
+    IF current_setting('app.env', true) != 'local' THEN
+      PERFORM
+        net.http_post(
+          url := current_setting('app.supabase_functions_url', true) || '/send-push-notification',
+          headers := jsonb_build_object(
+              'Content-Type', 'application/json',
+              'Authorization', 'Bearer ' || current_setting('app.service_role_key', true)
+          ),
+          body := payload
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 트리거 생성
+DROP TRIGGER IF EXISTS on_trip_invitation ON public.trip_members;
+CREATE TRIGGER on_trip_invitation
+    AFTER INSERT ON public.trip_members
+    FOR EACH ROW
+    WHEN (NEW.status = 'pending')
+    EXECUTE FUNCTION public.handle_trip_invitation_notification();

--- a/supabase/migrations/20260330000003_checklist_collaboration.sql
+++ b/supabase/migrations/20260330000003_checklist_collaboration.sql
@@ -1,0 +1,42 @@
+-- 1. checklist_items 테이블 구조 확장
+ALTER TABLE public.checklist_items 
+ADD COLUMN IF NOT EXISTS assignment_type text check (assignment_type in ('anyone', 'specific', 'everyone')) default 'anyone' NOT NULL,
+ADD COLUMN IF NOT EXISTS assigned_user_id uuid references public.profiles(id);
+
+-- 2. 개별 체크 기록을 위한 checklist_item_user_checks 테이블 신설
+CREATE TABLE IF NOT EXISTS public.checklist_item_user_checks (
+  id uuid default gen_random_uuid() primary key,
+  item_id uuid references public.checklist_items(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) on delete cascade not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  unique(item_id, user_id)
+);
+
+-- 3. RLS 설정 (기존 checklist_items와 동일한 로직 적용)
+ALTER TABLE public.checklist_item_user_checks ENABLE ROW LEVEL SECURITY;
+
+-- 3-1. 사용자가 조회 권한을 가진 여행의 체크리스트 항목이면 열람 가능
+DROP POLICY IF EXISTS "Users can view user checks for accessible trips" ON public.checklist_item_user_checks;
+CREATE POLICY "Users can view user checks for accessible trips" ON public.checklist_item_user_checks
+  FOR SELECT USING (
+    item_id IN (
+      SELECT id FROM public.checklist_items 
+      WHERE checklist_id IN (
+        SELECT id FROM public.checklists 
+        WHERE trip_id IN (
+          SELECT id FROM public.trips WHERE user_id = auth.uid()
+          UNION
+          SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid()
+        )
+      )
+    )
+  );
+
+-- 3-2. 사용자가 본인의 체크 내역을 관리(추가/삭제) 가능
+DROP POLICY IF EXISTS "Users can manage their own checks" ON public.checklist_item_user_checks;
+CREATE POLICY "Users can manage their own checks" ON public.checklist_item_user_checks
+  FOR ALL USING (auth.uid() = user_id);
+
+-- 4. 특정인(assigned_user_id) 외 다른 사용자의 checklist_items 업데이트 제한을 위한 정책 보완
+-- 이 부분은 애플리케이션 레벨(UI)에서 주로 제어하며, DB 레벨 정책은 기존의 "편집 권한 소유자"를 유지하되
+-- 필요한 경우 트리거 등으로 보조할 수 있으나, 이번 개선에서는 애플리케이션 로직을 우선 적용합니다.

--- a/supabase/migrations/20260412000001_plans_address_image_url.sql
+++ b/supabase/migrations/20260412000001_plans_address_image_url.sql
@@ -1,0 +1,9 @@
+-- plans 테이블에 누락된 address 및 image_url 컬럼 추가
+-- user의 요청에 따라 상세 주소 및 구글 맵 이미지 URL 저장 공간 확보
+
+ALTER TABLE public.plans 
+ADD COLUMN IF NOT EXISTS address TEXT,
+ADD COLUMN IF NOT EXISTS image_url TEXT;
+
+COMMENT ON COLUMN public.plans.address IS '일정의 상세 주소 정보';
+COMMENT ON COLUMN public.plans.image_url IS '일정의 대표 이미지 (구글 맵 제공 URL 등)';

--- a/supabase/migrations/20260502000001_trip_invitation_links.sql
+++ b/supabase/migrations/20260502000001_trip_invitation_links.sql
@@ -1,0 +1,174 @@
+-- 1. Create table for invitation links
+CREATE TABLE IF NOT EXISTS public.trip_invitation_links (
+    id uuid default gen_random_uuid() primary key,
+    trip_id uuid references public.trips(id) on delete cascade not null,
+    token text unique not null,
+    expires_at timestamp with time zone not null,
+    created_by uuid references public.profiles(id) on delete cascade not null,
+    created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.trip_invitation_links ENABLE ROW LEVEL SECURITY;
+
+-- Allow owners/editors to create and view links
+CREATE POLICY "Users can manage invitation links for their trips" ON public.trip_invitation_links
+  FOR ALL USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    )
+  );
+
+-- Allow anyone to view a link by token
+CREATE POLICY "Anyone can select invitation link by token" ON public.trip_invitation_links
+  FOR SELECT USING (true);
+
+
+-- 2. RPC to generate invitation link
+CREATE OR REPLACE FUNCTION public.generate_invitation_link(p_trip_id uuid)
+RETURNS text AS $$
+DECLARE
+    new_token text;
+BEGIN
+    -- Check if user has permission (owner or editor)
+    IF NOT EXISTS (
+        SELECT 1 FROM public.trips WHERE id = p_trip_id AND user_id = auth.uid()
+        UNION
+        SELECT 1 FROM public.trip_members WHERE trip_id = p_trip_id AND user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    ) THEN
+        RAISE EXCEPTION '권한이 없습니다.';
+    END IF;
+
+    -- Generate a simple random token
+    new_token := encode(gen_random_bytes(16), 'hex');
+
+    INSERT INTO public.trip_invitation_links (trip_id, token, expires_at, created_by)
+    VALUES (p_trip_id, new_token, now() + interval '6 hours', auth.uid());
+
+    RETURN new_token;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- 3. RPC to get trip summary by token
+CREATE OR REPLACE FUNCTION public.get_trip_summary_by_token(p_token text)
+RETURNS jsonb AS $$
+DECLARE
+    link_record RECORD;
+    trip_summary jsonb;
+BEGIN
+    SELECT * INTO link_record FROM public.trip_invitation_links WHERE token = p_token;
+    
+    IF NOT FOUND THEN
+        RAISE EXCEPTION '유효하지 않은 링크입니다.';
+    END IF;
+
+    IF link_record.expires_at < now() THEN
+        RAISE EXCEPTION '만료된 링크입니다.';
+    END IF;
+
+    -- Get trip details
+    SELECT jsonb_build_object(
+        'trip_id', t.id,
+        'destination', t.destination,
+        'start_date', t.start_date,
+        'end_date', t.end_date,
+        'owner_nickname', p.nickname,
+        'member_count', (SELECT count(*) FROM public.trip_members WHERE trip_id = t.id AND status = 'accepted') + 1 -- owner + accepted members
+    ) INTO trip_summary
+    FROM public.trips t
+    JOIN public.profiles p ON t.user_id = p.id
+    WHERE t.id = link_record.trip_id;
+
+    RETURN trip_summary;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- 4. RPC to join trip via token
+CREATE OR REPLACE FUNCTION public.join_trip_via_token(p_token text)
+RETURNS uuid AS $$
+DECLARE
+    link_record RECORD;
+    user_email text;
+    user_nickname text;
+    trip_owner_id uuid;
+    target_tokens TEXT[];
+    payload JSONB;
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION '로그인이 필요합니다.';
+    END IF;
+
+    SELECT * INTO link_record FROM public.trip_invitation_links WHERE token = p_token;
+    
+    IF NOT FOUND THEN
+        RAISE EXCEPTION '유효하지 않은 링크입니다.';
+    END IF;
+
+    IF link_record.expires_at < now() THEN
+        RAISE EXCEPTION '만료된 링크입니다.';
+    END IF;
+
+    -- Check if user is the owner
+    IF EXISTS (SELECT 1 FROM public.trips WHERE id = link_record.trip_id AND user_id = auth.uid()) THEN
+        RETURN link_record.trip_id; -- Already owner
+    END IF;
+
+    -- Check if user is already a member
+    IF EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = link_record.trip_id AND user_id = auth.uid() AND status = 'accepted') THEN
+        RETURN link_record.trip_id; -- Already a member
+    END IF;
+
+    -- Update or insert member
+    SELECT email, nickname INTO user_email, user_nickname FROM public.profiles WHERE id = auth.uid();
+
+    IF EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = link_record.trip_id AND user_id = auth.uid()) THEN
+        UPDATE public.trip_members 
+        SET status = 'accepted', role = 'editor'
+        WHERE trip_id = link_record.trip_id AND user_id = auth.uid();
+    ELSIF EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = link_record.trip_id AND invited_email = user_email) THEN
+        UPDATE public.trip_members 
+        SET status = 'accepted', role = 'editor', user_id = auth.uid()
+        WHERE trip_id = link_record.trip_id AND invited_email = user_email;
+    ELSE
+        INSERT INTO public.trip_members (trip_id, user_id, invited_email, role, status)
+        VALUES (link_record.trip_id, auth.uid(), user_email, 'editor', 'accepted');
+    END IF;
+
+    -- Send notification to trip owner
+    SELECT user_id INTO trip_owner_id FROM public.trips WHERE id = link_record.trip_id;
+    
+    SELECT array_agg(d.fcm_token)
+    INTO target_tokens
+    FROM public.user_devices d
+    WHERE d.user_id = trip_owner_id;
+
+    IF target_tokens IS NOT NULL AND array_length(target_tokens, 1) > 0 THEN
+        payload := jsonb_build_object(
+            'tokens', target_tokens,
+            'title', '새로운 동행자 참여!',
+            'body', user_nickname || '님이 초대 링크를 통해 여정에 참여했습니다.',
+            'data', jsonb_build_object(
+                'tripId', link_record.trip_id::text,
+                'type', 'join'
+            )
+        );
+
+        IF current_setting('app.env', true) != 'local' THEN
+          PERFORM
+            net.http_post(
+              url := current_setting('app.supabase_functions_url', true) || '/send-push-notification',
+              headers := jsonb_build_object(
+                  'Content-Type', 'application/json',
+                  'Authorization', 'Bearer ' || current_setting('app.service_role_key', true)
+              ),
+              body := payload
+            );
+        END IF;
+    END IF;
+
+    RETURN link_record.trip_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20260527000001_plans_photo_reference.sql
+++ b/supabase/migrations/20260527000001_plans_photo_reference.sql
@@ -1,0 +1,8 @@
+-- plans 테이블에 photo_reference 컬럼 추가
+-- Google Places photo_reference 토큰을 보존하여 on-demand 복구 및 백그라운드 업로드의 키로 사용
+
+ALTER TABLE public.plans
+  ADD COLUMN IF NOT EXISTS photo_reference TEXT;
+
+COMMENT ON COLUMN public.plans.photo_reference IS
+  'Google Places photo_reference 토큰. on-demand 갱신 및 백그라운드 업로드에 사용.';

--- a/supabase/migrations/20260527000002_place_photos_bucket.sql
+++ b/supabase/migrations/20260527000002_place_photos_bucket.sql
@@ -1,0 +1,51 @@
+-- place-photos Storage 버킷 + RLS 정책
+-- 경로 규칙: place-photos/{user_id}/{trip_id}/{plan_id}_{placeIdHash8}.jpg
+-- SELECT: 누구나(public) / INSERT, UPDATE, DELETE: 본인 폴더만(auth.uid())
+
+-- 1) 버킷 생성 (public)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('place-photos', 'place-photos', true)
+ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public;
+
+-- 2) RLS 정책: 기존 정책 제거 후 재생성 (idempotent)
+DROP POLICY IF EXISTS "place_photos_select_public" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_insert_own" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_update_own" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_delete_own" ON storage.objects;
+
+-- 2-1) SELECT: 누구나 (public 버킷이므로 모든 사용자가 조회 가능)
+CREATE POLICY "place_photos_select_public"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'place-photos');
+
+-- 2-2) INSERT: 본인 폴더에만 업로드 가능
+CREATE POLICY "place_photos_insert_own"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 2-3) UPDATE: 본인 폴더 객체만 수정 가능
+CREATE POLICY "place_photos_update_own"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+)
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 2-4) DELETE: 본인 폴더 객체만 삭제 가능
+CREATE POLICY "place_photos_delete_own"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);


### PR DESCRIPTION
## Summary

- Playwright E2E 테스트 인프라 Phase 1~3 구축 + 여행/체크리스트 시나리오 추가
- 로컬 Supabase 마이그레이션 14개 파일 정렬 (`supabase db reset --local` 재현 가능)
- Auth fixtures + Smoke 테스트 4개 + 여행 생성/체크리스트 2개 = 총 6개 테스트
- `.env.local` 보호 규칙 명문화 (`rules.md` §5)

## 변경 사항

### Phase 1 — Playwright 설치 및 설정
- `playwright.config.ts`: webServer `pnpm dev:e2e`로 구성
- `scripts/dev-e2e.mjs`: `.env.test.local` → `process.env` 주입 후 `next dev` 실행 (`.env.local` 무수정)

### Phase 2 — 로컬 Supabase + Auth Fixtures
- `supabase/config.toml`, `supabase/migrations/` 14개 파일
- `e2e/helpers/supabase.ts`: REST API로 테스트 유저 생성/삭제
- `e2e/fixtures/auth.ts`: `createBrowserClient.setSession()`으로 쿠키 자동 주입

### Phase 3 — Smoke 테스트
- `e2e/smoke.spec.ts`: 4개 테스트 (비인증 랜딩, 인증 홈, 보호 경로 접근/리다이렉트)

### Phase 4 — 여행 생성 / 체크리스트 시나리오
- `e2e/helpers/seed.ts`: service role 기반 시드/정리/검증 헬퍼 (seedTrip, cleanupTripsByUser 등)
- `e2e/trips.spec.ts`: 2개 테스트
  1. 여행 생성 → `/trips/detail?id=` 진입 (Google Maps Autocomplete 우회)
  2. seedTrip 독립 셋업 → 준비물 '여권' 추가 → is_checked DB 폴링 검증

### 문서
- `docs/develop-context/rules.md` §5: `.env.local` 절대 보호 규칙
- `docs/develop-context/e2e-testing-guide.md`: Phase 1~3 완료 상태

## Test plan

- [ ] `pnpm build` 통과 확인
- [ ] `supabase start` 후 `supabase db reset --local` 실행 가능 확인
- [ ] `pnpm test:e2e` — smoke 4개 + trips 2개 총 6개 통과 확인
- [ ] `.env.local` 파일이 테스트 전후로 변경되지 않음 확인

## 알려진 제한사항
- 테스트 1(여행 생성)은 Google Maps API 키가 `.env.test.local`에 있어야 `destination` input 활성화
- `checklist_items.is_private` 컬럼이 로컬 마이그레이션에 누락됨 (운영 DB에는 존재) — `seedChecklistItem` 사용 시 별도 마이그레이션 추가 필요

Resolves #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)