### PR TITLE
fix: checklist_items.is_private 누락 마이그레이션 추가 (Resolves #194)

### DIFF
--- a/supabase/migrations/20260610000001_checklist_items_is_private.sql
+++ b/supabase/migrations/20260610000001_checklist_items_is_private.sql
@@ -1,0 +1,4 @@
+-- checklist_items.is_private 컬럼 추가
+-- 운영 DB에는 이미 존재하나 로컬 마이그레이션에 누락된 스키마 드리프트 수정
+ALTER TABLE checklist_items
+  ADD COLUMN IF NOT EXISTS is_private BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

- `checklist_items.is_private` 컬럼이 로컬 마이그레이션에 누락된 스키마 드리프트 수정
- `ADD COLUMN IF NOT EXISTS`로 운영 DB 재적용 안전 보장

## 변경 파일

- `supabase/migrations/20260610000001_checklist_items_is_private.sql` (신규)

## 검증

- `supabase db reset --local` 적용 성공
- `is_private BOOLEAN NOT NULL DEFAULT false` 컬럼 생성 확인

## Test plan

- [ ] `supabase db reset --local` 오류 없이 완료
- [ ] `checklist_items` 테이블에 `is_private` 컬럼 존재 확인
- [ ] `pnpm build` 통과

Resolves #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)