### PR TITLE
fix: 누락 컬럼 보정 마이그레이션 — template_items.is_private, checklist_items.source_template_name (Resolves #196)

### DIFF
--- a/supabase/migrations/20260610000002_schema_drift_template_checklist.sql
+++ b/supabase/migrations/20260610000002_schema_drift_template_checklist.sql
@@ -1,0 +1,8 @@
+-- 누락 컬럼 보정: 운영 DB에 존재하나 로컬 마이그레이션에 미반영된 스키마 드리프트 수정
+-- checklist_template_items.is_private: 템플릿 아이템 비공개 여부
+ALTER TABLE checklist_template_items
+  ADD COLUMN IF NOT EXISTS is_private BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- checklist_items.source_template_name: 템플릿 불러오기 시 출처 템플릿명 (중복 필터 기준)
+ALTER TABLE checklist_items
+  ADD COLUMN IF NOT EXISTS source_template_name TEXT;


### PR DESCRIPTION
## Summary

- `checklist_template_items.is_private`, `checklist_items.source_template_name` 컬럼이 로컬 마이그레이션에 누락된 스키마 드리프트 수정
- 두 컬럼 모두 앱 코드에서 실제 사용 중이며, 로컬 `supabase db reset --local` 시 insert 실패 위험

## 변경 파일

- `supabase/migrations/20260610000002_schema_drift_template_checklist.sql` (신규)

## 검증

- `supabase db reset --local` 적용 성공
- `checklist_template_items.is_private BOOLEAN NOT NULL DEFAULT false` ✅
- `checklist_items.source_template_name TEXT NULL` ✅

## Test plan

- [ ] `supabase db reset --local` 오류 없이 완료
- [ ] 두 컬럼 존재 확인

Resolves #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)