### PR TITLE
feat: E2E 템플릿 생성→아이템 추가→여행 적용 시나리오 추가 (Resolves #198)

### DIFF
--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -232,3 +232,197 @@ export async function cleanupTripsByUser(userId: string): Promise<void> {
     throw new Error(`cleanupTripsByUser 실패: ${error.message}`);
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 템플릿 시드/정리/검증 헬퍼
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SeededTemplate {
+  id: string;
+  title: string;
+}
+
+type TemplateOverrides = Partial<{
+  title: string;
+}>;
+
+/**
+ * checklist_templates 테이블에 직접 템플릿을 시드한다.
+ * @param userId 소유자 user_id (RLS 정합성을 위해 반드시 인자로 받음)
+ */
+export async function seedTemplate(
+  userId: string,
+  overrides: TemplateOverrides = {}
+): Promise<SeededTemplate> {
+  const client = getServiceClient();
+
+  const payload = {
+    user_id: userId,
+    title: overrides.title ?? 'E2E 테스트 템플릿',
+  };
+
+  const { data, error } = await client
+    .from('checklist_templates')
+    .insert(payload)
+    .select('id, title')
+    .single();
+
+  if (error || !data) {
+    throw new Error(`seedTemplate 실패: ${error?.message ?? '데이터 없음'}`);
+  }
+
+  return data as SeededTemplate;
+}
+
+/**
+ * 검증용: 해당 유저의 템플릿 중 title로 단건을 조회한다.
+ * UI로 생성된 템플릿의 DB 반영 여부를 검증할 때 사용한다.
+ */
+export async function getTemplateByTitle(
+  userId: string,
+  title: string
+): Promise<{ id: string; title: string } | null> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_templates')
+    .select('id, title')
+    .eq('user_id', userId)
+    .eq('title', title)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`getTemplateByTitle 실패: ${error.message}`);
+  }
+
+  return (data as { id: string; title: string } | null) ?? null;
+}
+
+export interface SeededTemplateItem {
+  id: string;
+  item_name: string;
+}
+
+type TemplateItemOverrides = Partial<{
+  category: string;
+  is_private: boolean;
+}>;
+
+/**
+ * checklist_template_items 테이블에 항목을 시드한다.
+ */
+export async function seedTemplateItem(
+  templateId: string,
+  itemName: string,
+  overrides: TemplateItemOverrides = {}
+): Promise<SeededTemplateItem> {
+  const client = getServiceClient();
+
+  const payload = {
+    template_id: templateId,
+    item_name: itemName,
+    category: overrides.category ?? '기타',
+    is_private: overrides.is_private ?? false,
+  };
+
+  const { data, error } = await client
+    .from('checklist_template_items')
+    .insert(payload)
+    .select('id, item_name')
+    .single();
+
+  if (error || !data) {
+    throw new Error(`seedTemplateItem 실패: ${error?.message ?? '데이터 없음'}`);
+  }
+
+  return data as SeededTemplateItem;
+}
+
+/**
+ * 검증용: template_id로 템플릿 항목 목록을 조회한다.
+ */
+export async function getTemplateItems(
+  templateId: string
+): Promise<{ id: string; item_name: string }[]> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_template_items')
+    .select('id, item_name')
+    .eq('template_id', templateId)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(`getTemplateItems 실패: ${error.message}`);
+  }
+
+  return (data as { id: string; item_name: string }[] | null) ?? [];
+}
+
+/**
+ * 검증용: template_id + item_name으로 템플릿 항목 단건을 조회한다.
+ * UI로 추가된 항목의 DB 반영 여부를 검증할 때 사용한다.
+ */
+export async function getTemplateItemByName(
+  templateId: string,
+  itemName: string
+): Promise<{ id: string; item_name: string } | null> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_template_items')
+    .select('id, item_name')
+    .eq('template_id', templateId)
+    .eq('item_name', itemName)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`getTemplateItemByName 실패: ${error.message}`);
+  }
+
+  return (data as { id: string; item_name: string } | null) ?? null;
+}
+
+/**
+ * 검증용: 체크리스트 내 source_template_name 기준으로 항목 목록을 조회한다.
+ * 템플릿 불러오기 적용 결과를 검증할 때 사용한다.
+ */
+export async function getChecklistItemBySourceTemplate(
+  checklistId: string,
+  sourceTemplateName: string
+): Promise<{ id: string; item_name: string; source_template_name: string }[]> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_items')
+    .select('id, item_name, source_template_name')
+    .eq('checklist_id', checklistId)
+    .eq('source_template_name', sourceTemplateName);
+
+  if (error) {
+    throw new Error(`getChecklistItemBySourceTemplate 실패: ${error.message}`);
+  }
+
+  return (
+    (data as { id: string; item_name: string; source_template_name: string }[] | null) ?? []
+  );
+}
+
+/**
+ * 해당 유저의 모든 템플릿을 삭제한다.
+ * checklist_templates → checklist_template_items는 on delete cascade로 함께 정리된다.
+ */
+export async function cleanupTemplatesByUser(userId: string): Promise<void> {
+  const client = getServiceClient();
+
+  const { error } = await client
+    .from('checklist_templates')
+    .delete()
+    .eq('user_id', userId);
+
+  if (error) {
+    throw new Error(`cleanupTemplatesByUser 실패: ${error.message}`);
+  }
+}

--- a/e2e/templates.spec.ts
+++ b/e2e/templates.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from './fixtures/auth';
+import {
+  seedTrip,
+  getOrCreateChecklist,
+  seedChecklistItem,
+  cleanupTripsByUser,
+  seedTemplate,
+  seedTemplateItem,
+  getTemplateByTitle,
+  getTemplateItemByName,
+  getChecklistItemBySourceTemplate,
+  cleanupTemplatesByUser,
+} from './helpers/seed';
+
+test.describe('템플릿 생성 → 아이템 추가 → 여행 적용 플로우', () => {
+  // 각 테스트 전후로 해당 유저의 템플릿/여행 데이터를 정리해 테스트 간 격리를 보장한다.
+  test.beforeEach(async ({ testUser }) => {
+    await cleanupTemplatesByUser(testUser.id);
+    await cleanupTripsByUser(testUser.id);
+  });
+
+  test.afterEach(async ({ testUser }) => {
+    await cleanupTemplatesByUser(testUser.id);
+    await cleanupTripsByUser(testUser.id);
+  });
+
+  test('템플릿 생성 → 목록 노출 및 DB 검증', async ({ authenticatedContext, testUser }) => {
+    const page = await authenticatedContext.newPage();
+    await page.goto('/templates');
+
+    // "새 템플릿 만들기" 버튼 클릭 → 전역 생성 모달 오픈
+    await page.getByRole('button', { name: '새 템플릿 만들기' }).click();
+
+    // 모달 폼 필드가 노출될 때까지 대기
+    const titleInput = page.getByPlaceholder('예: 여름 바다 여행 필수템 🏖️');
+    await expect(titleInput).toBeVisible({ timeout: 15000 });
+
+    // 제목 / 첫 번째 아이템 입력
+    await titleInput.fill('E2E 테스트 템플릿');
+    await page.getByPlaceholder('1번째 준비물').fill('선글라스');
+
+    // 저장
+    await page.getByRole('button', { name: '템플릿 저장할게요' }).click();
+
+    // 모달 닫힘 확인
+    await expect(titleInput).toBeHidden({ timeout: 10000 });
+
+    // 목록에 제목 노출
+    await expect(page.getByText('E2E 테스트 템플릿')).toBeVisible({ timeout: 10000 });
+
+    // DB 검증 1: checklist_templates에 title='E2E 테스트 템플릿'이 존재할 때까지 폴링
+    await expect
+      .poll(async () => (await getTemplateByTitle(testUser.id, 'E2E 테스트 템플릿')) !== null, {
+        timeout: 10000,
+      })
+      .toBe(true);
+
+    // DB 검증 2: 해당 템플릿에 '선글라스' 항목이 함께 저장되었는지 확인
+    const created = await getTemplateByTitle(testUser.id, 'E2E 테스트 템플릿');
+    expect(created).not.toBeNull();
+    expect(await getTemplateItemByName(created!.id, '선글라스')).not.toBeNull();
+
+    await page.close();
+  });
+
+  test('기존 템플릿 카드 클릭 → 아이템 추가 → DB 검증', async ({
+    authenticatedContext,
+    testUser,
+  }) => {
+    // 편집 대상 템플릿과 기존 항목 1개를 사전 시드한다.
+    const template = await seedTemplate(testUser.id, { title: 'E2E 편집 템플릿' });
+    await seedTemplateItem(template.id, '기존항목');
+
+    const page = await authenticatedContext.newPage();
+    await page.goto('/templates');
+
+    // 목록 로드 대기: 시드한 템플릿 카드가 노출될 때까지 대기 후 클릭하여 편집 모달 오픈
+    const templateCard = page.getByText('E2E 편집 템플릿');
+    await expect(templateCard).toBeVisible({ timeout: 15000 });
+    await templateCard.click();
+
+    // 편집 모달 로드 대기: 기존 항목이 입력 필드(1번째 준비물)에 채워질 때까지 대기
+    const firstItemInput = page.getByPlaceholder('1번째 준비물');
+    await expect(firstItemInput).toHaveValue('기존항목', { timeout: 10000 });
+
+    // "준비물 항목 추가하기" 버튼 클릭 → 새 행 추가
+    await page.getByRole('button', { name: '준비물 항목 추가하기' }).click();
+
+    // 새 행(2번째 준비물)에 입력
+    const secondItemInput = page.getByPlaceholder('2번째 준비물');
+    await expect(secondItemInput).toBeVisible({ timeout: 10000 });
+    await secondItemInput.fill('추가항목');
+
+    // 저장 (편집 모달 제출 버튼: "변경 내용 저장할게요")
+    await page.getByRole('button', { name: /저장/ }).click();
+
+    // 모달 닫힘 확인
+    await expect(firstItemInput).toBeHidden({ timeout: 10000 });
+
+    // DB 검증: '추가항목'이 해당 템플릿에 존재할 때까지 폴링
+    await expect
+      .poll(async () => (await getTemplateItemByName(template.id, '추가항목')) !== null, {
+        timeout: 10000,
+      })
+      .toBe(true);
+
+    await page.close();
+  });
+
+  test('템플릿을 여행 체크리스트에 적용', async ({ authenticatedContext, testUser }) => {
+    // 여행 + 체크리스트 시드. 더미 항목 1개를 미리 넣어 "템플릿 불러오기" 버튼 영역의
+    // 게이팅(목록 비어있을 때 UI 분기) 영향을 회피한다.
+    const trip = await seedTrip(testUser.id);
+    const checklist = await getOrCreateChecklist(trip.id);
+    await seedChecklistItem(checklist.id, '기존항목');
+
+    // 적용할 템플릿 + 항목 시드
+    const template = await seedTemplate(testUser.id, { title: '적용할 템플릿' });
+    await seedTemplateItem(template.id, '여권');
+
+    const page = await authenticatedContext.newPage();
+    await page.goto(`/trips/detail?id=${trip.id}&tab=checklist`);
+
+    // "템플릿 불러오기" 버튼 노출 대기 후 클릭
+    const loadTemplateButton = page.getByRole('button', { name: '템플릿 불러오기' });
+    await expect(loadTemplateButton).toBeVisible({ timeout: 15000 });
+    await loadTemplateButton.click();
+
+    // 적용 모달에서 '적용할 템플릿' 행의 "가져오기" 버튼 클릭
+    const templateRowName = page.getByText('적용할 템플릿');
+    await expect(templateRowName).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: '가져오기' }).first().click();
+
+    // 체크리스트에 '여권' 노출
+    await expect(page.getByText('여권')).toBeVisible({ timeout: 10000 });
+
+    // DB 검증: source_template_name='적용할 템플릿'인 항목이 존재할 때까지 폴링
+    await expect
+      .poll(
+        async () =>
+          (await getChecklistItemBySourceTemplate(checklist.id, '적용할 템플릿')).length > 0,
+        { timeout: 10000 }
+      )
+      .toBe(true);
+
+    const applied = await getChecklistItemBySourceTemplate(checklist.id, '적용할 템플릿');
+    expect(applied.some((i) => i.item_name === '여권')).toBe(true);
+
+    await page.close();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    // E2E 전용 dev 서버: .env.local 대신 .env.e2e를 사용
-    // pnpm e2e:dev 스크립트가 .env.e2e를 .env.local로 교체하고 실행
+    // E2E 전용 dev 서버: .env.test.local을 process.env로 주입 후 next dev 실행
+    // .env.local은 절대 수정하지 않음 (rules.md §5)
     command: 'pnpm dev:e2e',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Summary

- 템플릿 도메인 E2E 시나리오 3개 추가 (총 9개 테스트)
- `seed.ts` 템플릿 시드/조회/정리 헬퍼 6종 추가
- `playwright.config.ts` 주석 드리프트 수정

## 변경 파일

- `e2e/helpers/seed.ts` — `seedTemplate`, `seedTemplateItem`, `getTemplateItems`, `getTemplateItemByName`, `getChecklistItemBySourceTemplate`, `cleanupTemplatesByUser` 추가
- `e2e/templates.spec.ts` (신규) — 3개 시나리오
- `playwright.config.ts` — webServer 주석 수정

## 시나리오

1. **템플릿 생성** — `/templates` → "새 템플릿 만들기" 모달 → 저장 → 목록 노출 + DB 폴링
2. **아이템 추가** — `seedTemplate` 사전 시드 → 카드 클릭 → EditModal → 행 추가 → 저장 → DB 폴링
3. **여행 적용** — `seedTrip` + `seedTemplate` + 더미 체크리스트 아이템 시드 → "템플릿 불러오기" → "가져오기" → `source_template_name` DB 폴링

## 선행 작업
- #194 `checklist_items.is_private` 마이그레이션
- #196 `checklist_template_items.is_private`, `checklist_items.source_template_name` 마이그레이션

## Test plan

- [ ] `pnpm build` 통과
- [ ] `pnpm test:e2e --list` — 9개 테스트 디스커버리 확인
- [ ] `pnpm test:e2e` — 전체 9개 통과 확인

Resolves #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)