### PR TITLE
release: E2E 테스트 인프라 구축 및 CI 통합

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,63 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+      NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: e2e-dummy-key
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      CI: "true"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase local instance
+        run: supabase start
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Stop Supabase
+        if: always()
+        run: supabase stop

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/docs/adrs/ADR-006-google-place-photo-permanent-storage.md
+++ b/docs/adrs/ADR-006-google-place-photo-permanent-storage.md
@@ -1,0 +1,56 @@
+# ADR-006: Google Place Photo 영구 저장 및 On-demand 복구
+
+- 상태: 제안됨
+- 결정일: 2026-05-27
+- 결정자: ysjee141
+- 관련 이슈: #184
+
+## 컨텍스트
+
+Google Maps Places Photo API의 CDN URL은 만료되어 일정 시간 후 403을 반환한다.
+OnVoy는 현재 해당 URL을 `plans.image_url`에 그대로 저장하고 있어 일정 목록/상세에서 이미지가 깨지는 문제가 발생한다.
+오프라인 캐시(`DownloadService`) 또한 만료 URL을 그대로 캐싱하여 오프라인에서도 깨진 이미지가 표시될 수 있다.
+
+Google Maps Platform 약관 §3.2.3 (a)는 콘텐츠의 영구 캐싱을 제한하지만,
+1인 운영 서비스의 사용자 경험 및 운영 부담을 고려하여 정책적 리스크를 감수하는 결정을 내린다.
+
+## 결정
+
+1. **영구 저장**: 서버가 Google Photo 바이너리를 다운로드하여 Supabase Storage `place-photos` 버킷에 업로드하고, 그 publicUrl을 `plans.image_url`에 저장한다.
+2. **photo_reference 보존**: `plans.photo_reference TEXT` 컬럼을 추가하여 재발급/복구의 키로 사용한다.
+3. **하이브리드 비동기 처리**: `plans` INSERT는 즉시 완료(`image_url=null`)되고, 이미지 다운로드/업로드/UPDATE는 백그라운드에서 처리한다.
+4. **On-demand 복구**: 클라이언트는 `<img onError>`에서 만료/누락을 감지하여 `photo_reference`로 서버에 복구를 요청한다. 동일 plan에 대한 중복 호출은 클라이언트에서 dedup한다(모듈 스코프 `Set` + 5분 cooldown `Map`, 410 응답 시 24시간 cooldown).
+5. **Storage 경로/권한**:
+   - 경로: `place-photos/{user_id}/{trip_id}/{plan_id}_{placeIdHash8}.jpg`
+   - 버킷: public, SELECT는 누구나
+   - RLS: INSERT/UPDATE/DELETE는 본인 폴더(`user_id == auth.uid()`)에 한정
+6. **Plan 삭제 시 정리**: plan DELETE 흐름에서 동일 폴더의 Storage 객체를 best-effort로 제거한다.
+
+## 대안 비교
+
+- **CDN URL 직접 저장(현행)**: 만료 시 이미지 깨짐. 채택하지 않음.
+- **표시 시점 매번 Places API 재요청**: 쿼터/요금/지연 부담. 채택하지 않음.
+- **동기 INSERT(저장 완료까지 대기)**: 사용자 대기 시간 증가로 UX 저하. 채택하지 않음.
+- **일괄 백필 마이그레이션**: 다수의 만료 토큰으로 효율 낮음. 채택하지 않음.
+- **선택안(채택)**: 영구 저장 + 하이브리드 비동기 + on-demand 복구.
+
+## 결과
+
+### 긍정
+- 일정 이미지 안정성 확보
+- 신규 일정 생성 UX 즉시 완료 유지
+- 레거시 데이터 점진적 자동 복구
+- Storage 사용 패턴 표준화의 첫 사례 마련 (trip 커버, profile 아바타 등 후속 기능 재사용 가능)
+
+### 부정/감수
+- Google Maps Platform 약관 §3.2.3 (a) 캐싱 제한에 대한 위반 가능성 (감수)
+- Storage 저장 비용 발생 (현 규모 무시 가능)
+- Attribution(저작자 표시) 의무 검토 필요 — 본 ADR에서는 보류, 후속 TODO
+
+## 후속 TODO
+
+- Attribution(`html_attributions`) 표시 정책 검토 및 별도 ADR/이슈로 처리
+- 주기 갱신 잡(예: 30~60일 주기) 도입 검토
+- Zustand `usePlansStore` 도입으로 콜백 prop chain 축소
+- Supabase `Database` 자동 생성 타입 재생성
+- `NEXT_PUBLIC_APP_URL` 미설정 가드 (모바일 빌드)

--- a/docs/develop-context/e2e-testing-guide.md
+++ b/docs/develop-context/e2e-testing-guide.md
@@ -1,0 +1,167 @@
+# E2E 테스트 도입 가이드 (Playwright)
+
+> 작성일: 2026-06-09 / 최종 업데이트: 2026-06-10
+> 상태: **Phase 1~3 완료** — Playwright 설치, 로컬 Supabase 마이그레이션 체계, 인증 픽스처, 스모크 테스트 4개 통과.
+> 목적: OnVoy 프로젝트에 Playwright 기반 E2E 테스트를 도입하기 위한 사전 분석 및 실행 계획 정리.
+
+---
+
+## 1. 현재 상태 (As-Is)
+
+| 항목 | 내용 |
+|------|------|
+| 스택 | Next.js 16 (App Router) + React 19, Supabase 인증, Panda CSS, Capacitor 하이브리드 |
+| 테스트 인프라 | **전무** — Playwright / Vitest / Jest 미설치, 테스트 파일 0개 |
+| 인증 방식 | Supabase + 카카오/구글 OAuth (`@supabase/ssr` 쿠키 기반) |
+| 페이지 라우트 (약 20개) | `login`, `signup`, `join`, `trips`(new/detail/checklist), `templates`(new/detail), `profile`(licenses/places-visited/travel-log/withdrawal), `share/detail`, `offline`, `auth`(callback/success/error) |
+
+→ 처음부터 테스트 인프라를 구축하는 셈이다.
+
+---
+
+## 2. 적용 가능성
+
+| 대상 | 가능 여부 | 비고 |
+|------|----------|------|
+| **웹 빌드** (`next dev` / `next start`) | ✅ 완전히 가능 | Playwright의 정석 영역 |
+| **모바일 빌드** (Capacitor static export) | ⚠️ 부분적 | 웹뷰는 동일 코드라 웹에서 대부분 검증 가능. 단, 네이티브 플러그인(푸시·로컬알림·네트워크·preferences 등)은 Playwright로 불가 → 필요 시 Appium 등 별도 도구 |
+
+**결론: 웹 기준 E2E는 충분히 도입 가능하다.** 모바일 네이티브 영역은 범위에서 제외하고 시작하는 것을 권장한다.
+
+---
+
+## 3. 핵심 고려사항 (착수 전 반드시 결정)
+
+### 3.1 인증 우회 전략 (가장 중요)
+카카오/구글 OAuth는 E2E에서 실제 로그인 플로우를 그대로 타기 어렵다(외부 IdP 화면, 캡차 등).
+
+- **권장 방식**: Supabase `service_role` 키로 **테스트 전용 유저의 세션을 발급 → 쿠키 / `storageState` 로 주입**하여 로그인 상태에서 테스트를 시작한다.
+  - `@supabase/ssr`의 쿠키 구조(`sb-<project-ref>-auth-token` 등)에 맞춰 세션 쿠키를 심는 방식.
+  - Playwright의 `storageState` 기능으로 인증 픽스처를 한 번 만들어 재사용.
+- OAuth 콜백(`/auth/callback`) 자체를 검증하고 싶다면 별도 시나리오로 분리하되, 외부 IdP는 mock 처리.
+
+> ⚠️ **[보안 주의]** 테스트에 `SUPABASE_SERVICE_ROLE_KEY`와 테스트 계정이 사용된다.
+> - 운영 DB가 아닌 **별도 테스트/로컬 Supabase 인스턴스** 사용을 강력히 권장.
+> - service_role 키·비밀번호·토큰은 **테스트 코드나 픽스처에 하드코딩 금지**, 환경변수(`.env.test.local` 등, gitignore 처리)로만 주입.
+> - 테스트 데이터에 **실제 고객/임직원 정보 사용 금지** — 시드 데이터로 격리.
+> - 기준: 야놀자그룹 AI 보안 가이드 https://yanoljagroup.atlassian.net/wiki/spaces/Compliance/pages/2451412038/AI
+
+### 3.2 Google Maps API
+- E2E에서 실제 호출 시 비용·쿼터 발생 → **mock** 처리하거나 **테스트 전용 키** 분리.
+- 지도 렌더링 자체보다 지도 위의 우리 UI 동작 검증에 집중.
+
+### 3.3 테스트 데이터 격리
+- 실제 운영 데이터 사용 금지. **시드 스크립트**로 테스트 데이터 생성 → 테스트 후 정리(teardown).
+- Supabase RLS 정책이 테스트 유저 기준으로 정상 동작하는지도 함께 검증 가능.
+
+### 3.4 환경변수
+필요한 키(값은 `.env.local` 참조):
+`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`(테스트 인스턴스용), `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`(또는 mock), `NEXT_PUBLIC_APP_URL`.
+
+---
+
+## 4. 제안 셋업 구성
+
+```
+playwright.config.ts          # webServer로 next dev 자동 기동, baseURL, projects(브라우저) 설정
+e2e/
+  ├── fixtures/
+  │   └── auth.ts             # 인증된 세션(storageState) 주입 픽스처
+  ├── helpers/
+  │   └── supabase.ts         # 테스트 유저 생성/세션 발급/정리
+  ├── trips.spec.ts           # 여행 생성/조회/체크리스트
+  ├── templates.spec.ts       # 템플릿 생성/조회
+  └── ...
+.env.test.local               # 테스트 전용 환경변수 (gitignore)
+```
+
+`package.json` 스크립트 추가(예시):
+```jsonc
+"test:e2e": "playwright test",
+"test:e2e:ui": "playwright test --ui"
+```
+
+설치(예시):
+```bash
+pnpm add -D @playwright/test
+pnpm exec playwright install --with-deps chromium
+```
+
+`playwright.config.ts` 골격(예시):
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: { baseURL: 'http://localhost:3000', trace: 'on-first-retry' },
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});
+```
+
+> 참고: `next dev`는 `NODE_OPTIONS='--dns-result-order=ipv4first'` 옵션과 함께 실행됨(package.json `dev` 스크립트). webServer command를 `pnpm dev`로 두면 그대로 적용된다.
+
+---
+
+## 5. 권장 진행 범위 (택1로 시작)
+
+1. **셋업만** — Playwright 설치 + `playwright.config.ts` + 인증 픽스처 골격까지.
+2. **셋업 + 스모크 1~2개** — "로그인 → 여행 생성 → 체크리스트 작성" 핵심 플로우 1개.  ← **권장 시작점**
+3. **전체 주요 플로우** — 위 라우트들의 핵심 시나리오 일괄 작성.
+
+### 추천 우선순위 시나리오
+1. (스모크) 로그인 상태 진입 → 홈 렌더링 확인
+2. 여행 생성 → 상세 진입 → 체크리스트 항목 추가/체크
+3. 템플릿 생성 → 여행에 적용
+4. 프로필 조회 / 여행 기록 확인
+5. 공유 링크(`share/detail`) 비로그인 접근 동작
+
+---
+
+## 6. 하네스 통합 (선택)
+
+반복적인 E2E 작성·실행을 위해 OnVoy 하네스에 **E2E 전담 스킬/에이전트** 추가를 고려할 수 있다.
+- 예: `e2e-author` 스킬 — 시나리오 명세 → spec 작성 → 실행 → 결과 리포트.
+- 기존 `qa-engineer` 에이전트의 책임 범위에 E2E 실행 검증을 포함시키는 방안도 가능.
+
+---
+
+## 7. 구현 완료 현황
+
+### Phase 1 — 셋업 ✅
+- `@playwright/test` v1.60.0 설치
+- `playwright.config.ts` — `webServer: pnpm dev:e2e`, baseURL, chromium
+- `e2e/fixtures/`, `e2e/helpers/` 디렉토리 구조 생성
+- `.env.test.local` (로컬 Supabase 접속 정보, gitignore 처리)
+- `package.json` 스크립트: `test:e2e`, `test:e2e:ui`, `test:e2e:report`, `dev:e2e`
+
+### Phase 2 — 로컬 Supabase 마이그레이션 체계 ✅
+- `supabase` CLI v2.105.0 설치
+- `supabase/migrations/` — 14개 파일, 날짜순 정렬
+- 운영 URL·키 하드코딩 → `app.supabase_functions_url` 참조 방식으로 교체
+- `supabase db reset --local` 으로 13개 테이블 재현 확인
+
+### Phase 2 — 인증 픽스처 ✅
+- `e2e/helpers/supabase.ts` — REST API 직접 호출로 유저 생성/세션 발급/teardown
+- `e2e/fixtures/auth.ts` — `createBrowserClient.setSession()`으로 쿠키 생성 후 주입
+- `scripts/dev-e2e.mjs` — `.env.local` 무수정 원칙 준수, `process.env` 직접 주입 방식
+
+### Phase 3 — 스모크 테스트 ✅
+`e2e/smoke.spec.ts` — 4개 테스트 모두 통과:
+1. 비인증 사용자 → 랜딩 페이지 렌더링
+2. 비인증 사용자 → 보호 경로 접근 시 `/login` 리다이렉트
+3. 인증된 사용자 → 홈 렌더링 ("님! 👋", "새 여행 만들기" 버튼)
+4. 인증된 사용자 → 보호 경로 `/trips/new` 접근 가능
+
+---
+
+## 8. 다음 액션
+- [ ] 여행 생성 → 상세 진입 → 체크리스트 항목 추가/체크 (스모크 시나리오 2)
+- [ ] 템플릿 생성 → 여행에 적용 (시나리오 3)
+- [ ] Google Maps API mock 구성 (Playwright route intercept)
+- [ ] 시드 스크립트 작성 (테스트 데이터 생성 + teardown)
+- [ ] CI 통합 (GitHub Actions)

--- a/docs/develop-context/rules.md
+++ b/docs/develop-context/rules.md
@@ -47,5 +47,42 @@ OnVoy의 디자인 가치와 브랜드 아이デン티티를 훼손하지 마십
 
 ---
 
+---
+
+## 5. 🧪 E2E 테스트 환경 규칙
+
+E2E 테스트 실행 및 인프라 작업 시 다음 규칙을 **절대적으로** 준수한다.
+
+### 5.1 환경변수 파일 보호 (절대 규칙)
+
+- **`.env.local`은 스크립트나 코드로 절대 수정·덮어쓰기·이동·삭제하지 않는다.**
+  - 이 파일에는 운영 API 키, Supabase 키, 카카오/구글 키 등 복구 불가능한 민감 정보가 포함된다.
+  - 백업 후 교체 방식(`rename` → `copyFile` → 복원)도 금지한다. 프로세스 비정상 종료 시 복원이 보장되지 않는다.
+- **E2E 전용 환경변수는 `process.env`에 직접 주입하는 방식으로만 처리한다.**
+  - Next.js 우선순위: `process.env` > `.env.local` — 이미 주입된 값은 `.env.local`이 덮어쓰지 않는다.
+  - 구현체: `scripts/dev-e2e.mjs` — `.env.test.local`을 읽어 `process.env`에 assign 후 `next dev` 실행.
+- `.env.test.local`은 `.gitignore`로 보호되며, 예시 구조는 `.env.test.local.example`에 유지한다.
+
+### 5.2 로컬 Supabase 인스턴스
+
+- E2E 테스트는 **반드시 로컬 Supabase 인스턴스**(`supabase start`)를 사용한다. 운영 DB 절대 금지.
+- 마이그레이션은 `supabase/migrations/`에 날짜순으로 관리하며, `supabase db reset --local`로 재현 가능해야 한다.
+- 운영 URL·키가 마이그레이션 파일에 하드코딩되지 않도록 한다 (`app.supabase_functions_url` 설정 참조 방식 사용).
+
+### 5.3 테스트 유저 관리
+
+- 테스트 유저는 `e2e/helpers/supabase.ts`의 `createTestUser` / `deleteTestUser`로만 생성·삭제한다.
+- 실제 고객·임직원 정보를 테스트 데이터로 사용하지 않는다.
+- 테스트 유저 이메일은 `*.onvoy.local` 도메인을 사용한다 (운영 도메인과 명확히 구분).
+
+### 5.4 @supabase/ssr 쿠키 주입
+
+- 인증 픽스처(`e2e/fixtures/auth.ts`)는 `createBrowserClient`의 `setSession()`을 통해 쿠키를 생성한다.
+  - 쿠키 이름은 SDK가 자동 결정한다 — 직접 계산하거나 하드코딩하지 않는다.
+  - 로컬 인스턴스(`127.0.0.1`)의 쿠키 이름은 `sb-127-auth-token`으로 생성된다.
+- 쿠키 주입 후 보호 경로 접근 가능 여부를 스모크 테스트로 반드시 검증한다.
+
+---
+
 > [!WARNING]
 > 본 가이드라인을 어기는 것은 프로젝트의 일관성을 해치는 심각한 위험으로 간주됩니다. 불확실할 경우 항상 질문하십시오.

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,6 +1,6 @@
 import { test as base, type BrowserContext } from '@playwright/test';
 import { createBrowserClient } from '@supabase/ssr';
-import { createTestUser, deleteTestUser, type TestUser } from '../helpers/supabase';
+import { createTestUser, type TestUser } from '../helpers/supabase';
 
 const TEST_USER_EMAIL = process.env.E2E_TEST_USER_EMAIL ?? 'e2e-test@onvoy.local';
 const TEST_USER_PASSWORD = process.env.E2E_TEST_USER_PASSWORD ?? 'E2eTestPassword1!';
@@ -58,7 +58,9 @@ export const test = base.extend<AuthFixtures>({
   testUser: async ({}, use) => {
     const user = await createTestUser(TEST_USER_EMAIL, TEST_USER_PASSWORD);
     await use(user);
-    await deleteTestUser(TEST_USER_EMAIL);
+    // 유저 삭제 대신 데이터만 cleanup: deleteTestUser는 병렬 실행 시
+    // 다른 테스트의 createTestUser와 충돌하고 profiles cascade 삭제로
+    // seed FK 오류를 유발한다.
   },
 
   authenticatedContext: async ({ browser, testUser }, use) => {

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,72 @@
+import { test as base, type BrowserContext } from '@playwright/test';
+import { createBrowserClient } from '@supabase/ssr';
+import { createTestUser, deleteTestUser, type TestUser } from '../helpers/supabase';
+
+const TEST_USER_EMAIL = process.env.E2E_TEST_USER_EMAIL ?? 'e2e-test@onvoy.local';
+const TEST_USER_PASSWORD = process.env.E2E_TEST_USER_PASSWORD ?? 'E2eTestPassword1!';
+
+export type AuthFixtures = {
+  authenticatedContext: BrowserContext;
+  testUser: TestUser;
+};
+
+/**
+ * @supabase/ssr의 createBrowserClient를 사용해 실제 쿠키 이름과 인코딩 방식을
+ * 그대로 재현한다. 쿠키 이름은 Supabase URL의 호스트명 첫 세그먼트에서 결정되므로
+ * 직접 계산하지 않고 SDK에 위임한다.
+ */
+async function injectSession(context: BrowserContext, user: TestUser) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const baseURL = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const domain = new URL(baseURL).hostname;
+
+  const collectedCookies: Array<{ name: string; value: string }> = [];
+
+  const client = createBrowserClient(supabaseUrl, anonKey, {
+    cookies: {
+      getAll: () => collectedCookies,
+      setAll: (toSet) => {
+        toSet.forEach(({ name, value }) => {
+          const idx = collectedCookies.findIndex((c) => c.name === name);
+          if (idx >= 0) collectedCookies[idx].value = value;
+          else collectedCookies.push({ name, value });
+        });
+      },
+    },
+  });
+
+  // SDK가 세션을 설정하면서 올바른 쿠키 이름/인코딩으로 collectedCookies에 저장한다
+  await client.auth.setSession({
+    access_token: user.accessToken,
+    refresh_token: user.refreshToken,
+  });
+
+  await context.addCookies(
+    collectedCookies.map(({ name, value }) => ({
+      name,
+      value,
+      domain,
+      path: '/',
+      httpOnly: false,
+      sameSite: 'Lax' as const,
+    }))
+  );
+}
+
+export const test = base.extend<AuthFixtures>({
+  testUser: async ({}, use) => {
+    const user = await createTestUser(TEST_USER_EMAIL, TEST_USER_PASSWORD);
+    await use(user);
+    await deleteTestUser(TEST_USER_EMAIL);
+  },
+
+  authenticatedContext: async ({ browser, testUser }, use) => {
+    const context = await browser.newContext();
+    await injectSession(context, testUser);
+    await use(context);
+    await context.close();
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,6 +1,7 @@
 import { test as base, type BrowserContext } from '@playwright/test';
 import { createBrowserClient } from '@supabase/ssr';
 import { createTestUser, type TestUser } from '../helpers/supabase';
+import { installGoogleMapsMock } from '../helpers/google-maps-mock';
 
 const TEST_USER_EMAIL = process.env.E2E_TEST_USER_EMAIL ?? 'e2e-test@onvoy.local';
 const TEST_USER_PASSWORD = process.env.E2E_TEST_USER_PASSWORD ?? 'E2eTestPassword1!';
@@ -66,6 +67,9 @@ export const test = base.extend<AuthFixtures>({
   authenticatedContext: async ({ browser, testUser }, use) => {
     const context = await browser.newContext();
     await injectSession(context, testUser);
+    // Google Maps JS API를 결정적 스텁으로 대체 → 실제 외부 호출/쿼터/비결정성 제거.
+    // 컨텍스트 레벨에 설치해 이 컨텍스트의 모든 page에 일괄 적용한다.
+    await installGoogleMapsMock(context);
     await use(context);
     await context.close();
   },

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,3 @@
+export default function globalTeardown() {
+  // .env.local을 수정하지 않으므로 별도 복원 불필요
+}

--- a/e2e/helpers/google-maps-mock.ts
+++ b/e2e/helpers/google-maps-mock.ts
@@ -1,0 +1,103 @@
+import type { BrowserContext, Page } from '@playwright/test';
+
+/**
+ * Google Maps JS API 결정적 스텁.
+ *
+ * `@react-google-maps/api`의 `useLoadScript`는 `<script ...&callback=initMap>`을
+ * head에 주입하고, **스크립트가 `window.initMap()`을 호출할 때** `isLoaded`를 true로 전환한다.
+ * 따라서 이 스텁은 `window.google.maps`를 정의한 뒤 **반드시** 끝에서 `window.initMap()`을
+ * 호출해야 한다. (이 호출이 없으면 `isLoaded`가 영원히 false → input enable 무한 대기 → 타임아웃)
+ *
+ * 또한 `<Autocomplete>` 컴포넌트는 mount 시 `invariant(!!google.maps.places, ...)`로
+ * `google.maps.places`가 truthy임을 요구하므로 절대 falsy로 두면 안 된다.
+ *
+ * 라이브러리/버전 의존 사실:
+ * - 콜백명은 `initMap`으로 하드코딩(`@react-google-maps/api` v2.19.3).
+ * - 라이브러리가 스크립트 append 전에 `window.initMap`을 자기 resolver로 정의하므로,
+ *   스텁 평가 시점에 이미 `window.initMap`이 존재한다.
+ */
+const GOOGLE_MAPS_STUB = /* js */ `
+(function () {
+  window.google = window.google || {};
+  window.google.maps = {
+    places: {
+      // <Autocomplete>가 new google.maps.places.Autocomplete(input, opts)로 생성.
+      Autocomplete: function (input, opts) {
+        this._input = input;
+        this._opts = opts;
+        // 앱은 getPlace()의 name || formatted_address로 destination을 채운다.
+        this.getPlace = function () {
+          var value = (input && input.value) || '';
+          return { name: value, formatted_address: value };
+        };
+        this.addListener = function () { return { remove: function () {} }; };
+        this.setFields = function () {};
+        this.setComponentRestrictions = function () {};
+        this.setBounds = function () {};
+        this.getBounds = function () { return null; };
+      },
+      AutocompleteService: function () {
+        this.getPlacePredictions = function () { return Promise.resolve({ predictions: [] }); };
+      },
+    },
+    Map: function () {
+      this.setOptions = function () {};
+      this.fitBounds = function () {};
+      this.panTo = function () {};
+      this.setCenter = function () {};
+      this.setZoom = function () {};
+      this.addListener = function () { return { remove: function () {} }; };
+    },
+    OverlayView: function () {},
+    Polyline: function () {
+      this.setMap = function () {};
+      this.setOptions = function () {};
+      this.setPath = function () {};
+    },
+    Marker: function () {
+      this.setMap = function () {};
+      this.setPosition = function () {};
+      this.addListener = function () { return { remove: function () {} }; };
+    },
+    LatLngBounds: function () {
+      this.extend = function () { return this; };
+      this.isEmpty = function () { return true; };
+      this.getCenter = function () { return { lat: function () { return 0; }, lng: function () { return 0; } }; };
+    },
+    LatLng: function (lat, lng) {
+      this.lat = function () { return lat; };
+      this.lng = function () { return lng; };
+    },
+    Size: function () {},
+    Point: function () {},
+    SymbolPath: { CIRCLE: 0, FORWARD_CLOSED_ARROW: 1 },
+    event: {
+      addListener: function () { return { remove: function () {} }; },
+      removeListener: function () {},
+      clearInstanceListeners: function () {},
+    },
+    MapTypeId: { ROADMAP: 'roadmap' },
+  };
+
+  // ⚠️ 가장 중요한 불변식: 이 호출이 없으면 useLoadScript의 isLoaded가 영원히 false.
+  if (typeof window.initMap === 'function') {
+    window.initMap();
+  }
+})();
+`;
+
+/**
+ * Maps JS API 스크립트 요청을 결정적 스텁으로 대체한다.
+ * BrowserContext에 설치하면 해당 컨텍스트의 모든 page에 일괄 적용된다.
+ *
+ * `maps/api/js`만 매칭하므로 geocode/photo 등 다른 maps 엔드포인트나
+ * fonts.googleapis.com 등 폰트 요청에는 영향을 주지 않는다.
+ */
+export async function installGoogleMapsMock(target: BrowserContext | Page): Promise<void> {
+  await target.route('**/maps.googleapis.com/maps/api/js**', (route) =>
+    route.fulfill({
+      contentType: 'application/javascript',
+      body: GOOGLE_MAPS_STUB,
+    })
+  );
+}

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -232,3 +232,197 @@ export async function cleanupTripsByUser(userId: string): Promise<void> {
     throw new Error(`cleanupTripsByUser 실패: ${error.message}`);
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 템플릿 시드/정리/검증 헬퍼
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SeededTemplate {
+  id: string;
+  title: string;
+}
+
+type TemplateOverrides = Partial<{
+  title: string;
+}>;
+
+/**
+ * checklist_templates 테이블에 직접 템플릿을 시드한다.
+ * @param userId 소유자 user_id (RLS 정합성을 위해 반드시 인자로 받음)
+ */
+export async function seedTemplate(
+  userId: string,
+  overrides: TemplateOverrides = {}
+): Promise<SeededTemplate> {
+  const client = getServiceClient();
+
+  const payload = {
+    user_id: userId,
+    title: overrides.title ?? 'E2E 테스트 템플릿',
+  };
+
+  const { data, error } = await client
+    .from('checklist_templates')
+    .insert(payload)
+    .select('id, title')
+    .single();
+
+  if (error || !data) {
+    throw new Error(`seedTemplate 실패: ${error?.message ?? '데이터 없음'}`);
+  }
+
+  return data as SeededTemplate;
+}
+
+/**
+ * 검증용: 해당 유저의 템플릿 중 title로 단건을 조회한다.
+ * UI로 생성된 템플릿의 DB 반영 여부를 검증할 때 사용한다.
+ */
+export async function getTemplateByTitle(
+  userId: string,
+  title: string
+): Promise<{ id: string; title: string } | null> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_templates')
+    .select('id, title')
+    .eq('user_id', userId)
+    .eq('title', title)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`getTemplateByTitle 실패: ${error.message}`);
+  }
+
+  return (data as { id: string; title: string } | null) ?? null;
+}
+
+export interface SeededTemplateItem {
+  id: string;
+  item_name: string;
+}
+
+type TemplateItemOverrides = Partial<{
+  category: string;
+  is_private: boolean;
+}>;
+
+/**
+ * checklist_template_items 테이블에 항목을 시드한다.
+ */
+export async function seedTemplateItem(
+  templateId: string,
+  itemName: string,
+  overrides: TemplateItemOverrides = {}
+): Promise<SeededTemplateItem> {
+  const client = getServiceClient();
+
+  const payload = {
+    template_id: templateId,
+    item_name: itemName,
+    category: overrides.category ?? '기타',
+    is_private: overrides.is_private ?? false,
+  };
+
+  const { data, error } = await client
+    .from('checklist_template_items')
+    .insert(payload)
+    .select('id, item_name')
+    .single();
+
+  if (error || !data) {
+    throw new Error(`seedTemplateItem 실패: ${error?.message ?? '데이터 없음'}`);
+  }
+
+  return data as SeededTemplateItem;
+}
+
+/**
+ * 검증용: template_id로 템플릿 항목 목록을 조회한다.
+ */
+export async function getTemplateItems(
+  templateId: string
+): Promise<{ id: string; item_name: string }[]> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_template_items')
+    .select('id, item_name')
+    .eq('template_id', templateId)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(`getTemplateItems 실패: ${error.message}`);
+  }
+
+  return (data as { id: string; item_name: string }[] | null) ?? [];
+}
+
+/**
+ * 검증용: template_id + item_name으로 템플릿 항목 단건을 조회한다.
+ * UI로 추가된 항목의 DB 반영 여부를 검증할 때 사용한다.
+ */
+export async function getTemplateItemByName(
+  templateId: string,
+  itemName: string
+): Promise<{ id: string; item_name: string } | null> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_template_items')
+    .select('id, item_name')
+    .eq('template_id', templateId)
+    .eq('item_name', itemName)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`getTemplateItemByName 실패: ${error.message}`);
+  }
+
+  return (data as { id: string; item_name: string } | null) ?? null;
+}
+
+/**
+ * 검증용: 체크리스트 내 source_template_name 기준으로 항목 목록을 조회한다.
+ * 템플릿 불러오기 적용 결과를 검증할 때 사용한다.
+ */
+export async function getChecklistItemBySourceTemplate(
+  checklistId: string,
+  sourceTemplateName: string
+): Promise<{ id: string; item_name: string; source_template_name: string }[]> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_items')
+    .select('id, item_name, source_template_name')
+    .eq('checklist_id', checklistId)
+    .eq('source_template_name', sourceTemplateName);
+
+  if (error) {
+    throw new Error(`getChecklistItemBySourceTemplate 실패: ${error.message}`);
+  }
+
+  return (
+    (data as { id: string; item_name: string; source_template_name: string }[] | null) ?? []
+  );
+}
+
+/**
+ * 해당 유저의 모든 템플릿을 삭제한다.
+ * checklist_templates → checklist_template_items는 on delete cascade로 함께 정리된다.
+ */
+export async function cleanupTemplatesByUser(userId: string): Promise<void> {
+  const client = getServiceClient();
+
+  const { error } = await client
+    .from('checklist_templates')
+    .delete()
+    .eq('user_id', userId);
+
+  if (error) {
+    throw new Error(`cleanupTemplatesByUser 실패: ${error.message}`);
+  }
+}

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -1,0 +1,234 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * E2E 시드/정리/검증 헬퍼.
+ *
+ * service role 키로 생성한 클라이언트는 RLS를 우회한다. 따라서 trips insert 시
+ * user_id를 반드시 인자로 받아 명시적으로 지정해 RLS 정합성을 유지한다.
+ *
+ * 보안:
+ * - SUPABASE_SERVICE_ROLE_KEY는 process.env에서만 읽으며 하드코딩하지 않는다.
+ * - 키/토큰을 로그로 출력하지 않는다.
+ * - 테스트 전용 데이터만 다루며 실제 고객/임직원 데이터를 사용하지 않는다.
+ */
+
+function getEnv(key: string): string {
+  const val = process.env[key];
+  if (!val) throw new Error(`환경변수 누락: ${key}`);
+  return val;
+}
+
+let cachedClient: SupabaseClient | null = null;
+
+function getServiceClient(): SupabaseClient {
+  if (cachedClient) return cachedClient;
+
+  const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const serviceKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+  cachedClient = createClient(url, serviceKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+  return cachedClient;
+}
+
+/** YYYY-MM-DD 형식으로 오늘 기준 offset일 후 날짜를 반환 */
+function dateOffset(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export interface SeededTrip {
+  id: string;
+  user_id: string;
+  destination: string;
+  start_date: string;
+  end_date: string;
+  adults_count: number;
+  children_count: number;
+}
+
+type TripOverrides = Partial<{
+  destination: string;
+  start_date: string;
+  end_date: string;
+  adults_count: number;
+  children_count: number;
+}>;
+
+/**
+ * trips 테이블에 직접 여행을 시드한다.
+ * @param userId 소유자 user_id (RLS 정합성을 위해 반드시 인자로 받음)
+ */
+export async function seedTrip(
+  userId: string,
+  overrides: TripOverrides = {}
+): Promise<SeededTrip> {
+  const client = getServiceClient();
+
+  const payload = {
+    user_id: userId,
+    destination: overrides.destination ?? 'E2E 테스트 여행지',
+    start_date: overrides.start_date ?? dateOffset(1),
+    end_date: overrides.end_date ?? dateOffset(2),
+    adults_count: overrides.adults_count ?? 1,
+    children_count: overrides.children_count ?? 0,
+  };
+
+  const { data, error } = await client
+    .from('trips')
+    .insert(payload)
+    .select('id, user_id, destination, start_date, end_date, adults_count, children_count')
+    .single();
+
+  if (error || !data) {
+    throw new Error(`seedTrip 실패: ${error?.message ?? '데이터 없음'}`);
+  }
+
+  return data as SeededTrip;
+}
+
+/**
+ * 해당 trip의 체크리스트를 조회하고, 없으면 생성한다.
+ */
+export async function getOrCreateChecklist(tripId: string): Promise<{ id: string }> {
+  const client = getServiceClient();
+
+  const { data: existing, error: selectError } = await client
+    .from('checklists')
+    .select('id')
+    .eq('trip_id', tripId)
+    .limit(1)
+    .maybeSingle();
+
+  if (selectError) {
+    throw new Error(`getOrCreateChecklist 조회 실패: ${selectError.message}`);
+  }
+
+  if (existing?.id) {
+    return { id: existing.id };
+  }
+
+  const { data: created, error: insertError } = await client
+    .from('checklists')
+    .insert({ trip_id: tripId, title: '기본 준비물' })
+    .select('id')
+    .single();
+
+  if (insertError || !created) {
+    throw new Error(`getOrCreateChecklist 생성 실패: ${insertError?.message ?? '데이터 없음'}`);
+  }
+
+  return { id: created.id };
+}
+
+export interface SeededChecklistItem {
+  id: string;
+  item_name: string;
+  is_checked: boolean;
+}
+
+type ChecklistItemOverrides = Partial<{
+  category: string;
+  assignment_type: 'anyone' | 'specific' | 'everyone';
+  is_checked: boolean;
+  is_private: boolean;
+  assigned_user_id: string | null;
+}>;
+
+/**
+ * checklist_items 테이블에 항목을 시드한다.
+ */
+export async function seedChecklistItem(
+  checklistId: string,
+  itemName: string,
+  overrides: ChecklistItemOverrides = {}
+): Promise<SeededChecklistItem> {
+  const client = getServiceClient();
+
+  const payload = {
+    checklist_id: checklistId,
+    item_name: itemName,
+    category: overrides.category ?? '기타',
+    assignment_type: overrides.assignment_type ?? 'anyone',
+    is_checked: overrides.is_checked ?? false,
+    is_private: overrides.is_private ?? false,
+    assigned_user_id: overrides.assigned_user_id ?? null,
+  };
+
+  const { data, error } = await client
+    .from('checklist_items')
+    .insert(payload)
+    .select('id, item_name, is_checked')
+    .single();
+
+  if (error || !data) {
+    throw new Error(`seedChecklistItem 실패: ${error?.message ?? '데이터 없음'}`);
+  }
+
+  return data as SeededChecklistItem;
+}
+
+/**
+ * 검증용: 체크리스트 내 item_name으로 항목을 조회한다.
+ * UI로 추가된 항목의 DB 상태를 검증할 때 사용한다.
+ */
+export async function getChecklistItemByName(
+  checklistId: string,
+  itemName: string
+): Promise<{ id: string; is_checked: boolean } | null> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_items')
+    .select('id, is_checked')
+    .eq('checklist_id', checklistId)
+    .eq('item_name', itemName)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`getChecklistItemByName 실패: ${error.message}`);
+  }
+
+  return (data as { id: string; is_checked: boolean } | null) ?? null;
+}
+
+/**
+ * 검증용 단일 항목 조회.
+ */
+export async function getChecklistItem(
+  itemId: string
+): Promise<{ id: string; is_checked: boolean }> {
+  const client = getServiceClient();
+
+  const { data, error } = await client
+    .from('checklist_items')
+    .select('id, is_checked')
+    .eq('id', itemId)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`getChecklistItem 실패: ${error?.message ?? '데이터 없음'}`);
+  }
+
+  return data as { id: string; is_checked: boolean };
+}
+
+/**
+ * 해당 유저의 모든 trips를 삭제한다.
+ * trips → checklists → checklist_items는 on delete cascade로 함께 정리된다.
+ */
+export async function cleanupTripsByUser(userId: string): Promise<void> {
+  const client = getServiceClient();
+
+  const { error } = await client.from('trips').delete().eq('user_id', userId);
+
+  if (error) {
+    throw new Error(`cleanupTripsByUser 실패: ${error.message}`);
+  }
+}

--- a/e2e/helpers/supabase.ts
+++ b/e2e/helpers/supabase.ts
@@ -1,0 +1,101 @@
+import { createClient } from '@supabase/supabase-js';
+
+function getEnv(key: string): string {
+  const val = process.env[key];
+  if (!val) throw new Error(`환경변수 누락: ${key}`);
+  return val;
+}
+
+export interface TestUser {
+  id: string;
+  email: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * 테스트 전용 유저를 생성하고 세션 토큰을 반환한다.
+ * 실제 고객/임직원 정보를 사용하지 말 것.
+ */
+export async function createTestUser(email: string, password: string): Promise<TestUser> {
+  const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const anonKey = getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  const serviceKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+  // 1. 유저 생성 또는 비밀번호 업데이트 (admin REST API)
+  const createRes = await fetch(`${url}/auth/v1/admin/users`, {
+    method: 'POST',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password, email_confirm: true }),
+  });
+
+  const createBody = await createRes.json();
+
+  let userId: string;
+  if (createRes.ok) {
+    userId = createBody.id;
+  } else if (createBody.msg?.includes('already') || createBody.code === 'email_exists' || createBody.code === '23505') {
+    // 이미 존재하면 목록에서 찾아 비밀번호 업데이트
+    const listRes = await fetch(`${url}/auth/v1/admin/users?per_page=1000`, {
+      headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+    });
+    const { users } = await listRes.json();
+    const found = (users as any[]).find((u) => u.email === email);
+    if (!found) throw new Error(`테스트 유저를 찾을 수 없음: ${email}`);
+    userId = found.id;
+
+    await fetch(`${url}/auth/v1/admin/users/${userId}`, {
+      method: 'PUT',
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ password, email_confirm: true }),
+    });
+  } else {
+    throw new Error(`테스트 유저 생성 실패: ${JSON.stringify(createBody)}`);
+  }
+
+  // 2. 세션 발급 (anon key로 signInWithPassword)
+  const signInRes = await fetch(`${url}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const session = await signInRes.json();
+  if (!session.access_token) {
+    throw new Error(`세션 발급 실패: ${JSON.stringify(session)}`);
+  }
+
+  return {
+    id: userId,
+    email,
+    accessToken: session.access_token,
+    refreshToken: session.refresh_token,
+  };
+}
+
+/**
+ * 테스트 유저와 연관된 모든 데이터를 삭제한다 (teardown).
+ */
+export async function deleteTestUser(email: string): Promise<void> {
+  const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const serviceKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+  const listRes = await fetch(`${url}/auth/v1/admin/users?per_page=1000`, {
+    headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+  });
+  const { users } = await listRes.json();
+  const found = (users as any[]).find((u) => u.email === email);
+  if (!found) return;
+
+  await fetch(`${url}/auth/v1/admin/users/${found.id}`, {
+    method: 'DELETE',
+    headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+  });
+}

--- a/e2e/helpers/supabase.ts
+++ b/e2e/helpers/supabase.ts
@@ -1,5 +1,18 @@
 import { createClient } from '@supabase/supabase-js';
 
+// handle_new_user trigger가 비동기로 profiles row를 생성하므로
+// seed FK 오류 방지를 위해 row가 생길 때까지 최대 5초 폴링한다.
+async function waitForProfile(userId: string, url: string, serviceKey: string): Promise<void> {
+  const client = createClient(url, serviceKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const { data } = await client.from('profiles').select('id').eq('id', userId).maybeSingle();
+    if (data?.id) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`profiles row 생성 타임아웃: userId=${userId}`);
+}
+
 function getEnv(key: string): string {
   const val = process.env[key];
   if (!val) throw new Error(`환경변수 누락: ${key}`);
@@ -60,6 +73,9 @@ export async function createTestUser(email: string, password: string): Promise<T
   } else {
     throw new Error(`테스트 유저 생성 실패: ${JSON.stringify(createBody)}`);
   }
+
+  // 1-b. profiles trigger 완료 대기
+  await waitForProfile(userId, url, serviceKey);
 
   // 2. 세션 발급 (anon key로 signInWithPassword)
   const signInRes = await fetch(`${url}/auth/v1/token?grant_type=password`, {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from './fixtures/auth';
+
+test.describe('스모크: 홈 페이지', () => {
+  test('비인증 사용자 — 랜딩 페이지 렌더링', async ({ page }) => {
+    await page.goto('/');
+
+    // 비로그인 랜딩 페이지 핵심 요소 확인 (동일 텍스트 복수 존재 → first() 사용)
+    await expect(page.getByRole('link', { name: '지금 바로 시작하기' }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: '로그인하기' })).toBeVisible();
+  });
+
+  test('인증된 사용자 — 홈 렌더링 및 주요 UI 확인', async ({ authenticatedContext }) => {
+    const page = await authenticatedContext.newPage();
+    await page.goto('/');
+
+    // 인증된 홈: 환영 메시지 ("님! 👋" 포함)
+    await expect(page.getByText('님! 👋')).toBeVisible({ timeout: 10000 });
+
+    // 새 여행 만들기 버튼
+    await expect(page.getByRole('button', { name: /새 여행 만들기/ })).toBeVisible();
+
+    // 비로그인 랜딩 CTA가 보이지 않아야 함
+    await expect(page.getByRole('link', { name: '지금 바로 시작하기' }).first()).not.toBeVisible();
+
+    await page.close();
+  });
+
+  test('인증된 사용자 — 보호 경로 접근 가능', async ({ authenticatedContext }) => {
+    const page = await authenticatedContext.newPage();
+
+    await page.goto('/trips/new');
+
+    // /login으로 리다이렉트되지 않아야 함
+    await expect(page).not.toHaveURL(/\/login/, { timeout: 8000 });
+
+    await page.close();
+  });
+
+  test('비인증 사용자 — 보호 경로 접근 시 로그인 리다이렉트', async ({ page }) => {
+    await page.goto('/trips/new');
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 8000 });
+  });
+});

--- a/e2e/templates.spec.ts
+++ b/e2e/templates.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from './fixtures/auth';
+import {
+  seedTrip,
+  getOrCreateChecklist,
+  seedChecklistItem,
+  cleanupTripsByUser,
+  seedTemplate,
+  seedTemplateItem,
+  getTemplateByTitle,
+  getTemplateItemByName,
+  getChecklistItemBySourceTemplate,
+  cleanupTemplatesByUser,
+} from './helpers/seed';
+
+test.describe('템플릿 생성 → 아이템 추가 → 여행 적용 플로우', () => {
+  // 각 테스트 전후로 해당 유저의 템플릿/여행 데이터를 정리해 테스트 간 격리를 보장한다.
+  test.beforeEach(async ({ testUser }) => {
+    await cleanupTemplatesByUser(testUser.id);
+    await cleanupTripsByUser(testUser.id);
+  });
+
+  test.afterEach(async ({ testUser }) => {
+    await cleanupTemplatesByUser(testUser.id);
+    await cleanupTripsByUser(testUser.id);
+  });
+
+  test('템플릿 생성 → 목록 노출 및 DB 검증', async ({ authenticatedContext, testUser }) => {
+    const page = await authenticatedContext.newPage();
+    await page.goto('/templates');
+
+    // "새 템플릿 만들기" 버튼 클릭 → 전역 생성 모달 오픈
+    await page.getByRole('button', { name: '새 템플릿 만들기' }).click();
+
+    // 모달 폼 필드가 노출될 때까지 대기
+    const titleInput = page.getByPlaceholder('예: 여름 바다 여행 필수템 🏖️');
+    await expect(titleInput).toBeVisible({ timeout: 15000 });
+
+    // 제목 / 첫 번째 아이템 입력
+    await titleInput.fill('E2E 테스트 템플릿');
+    await page.getByPlaceholder('1번째 준비물').fill('선글라스');
+
+    // 저장
+    await page.getByRole('button', { name: '템플릿 저장할게요' }).click();
+
+    // 모달 닫힘 확인
+    await expect(titleInput).toBeHidden({ timeout: 10000 });
+
+    // 목록에 제목 노출
+    await expect(page.getByText('E2E 테스트 템플릿')).toBeVisible({ timeout: 10000 });
+
+    // DB 검증 1: checklist_templates에 title='E2E 테스트 템플릿'이 존재할 때까지 폴링
+    await expect
+      .poll(async () => (await getTemplateByTitle(testUser.id, 'E2E 테스트 템플릿')) !== null, {
+        timeout: 10000,
+      })
+      .toBe(true);
+
+    // DB 검증 2: 해당 템플릿에 '선글라스' 항목이 함께 저장되었는지 확인
+    const created = await getTemplateByTitle(testUser.id, 'E2E 테스트 템플릿');
+    expect(created).not.toBeNull();
+    expect(await getTemplateItemByName(created!.id, '선글라스')).not.toBeNull();
+
+    await page.close();
+  });
+
+  test('기존 템플릿 카드 클릭 → 아이템 추가 → DB 검증', async ({
+    authenticatedContext,
+    testUser,
+  }) => {
+    // 편집 대상 템플릿과 기존 항목 1개를 사전 시드한다.
+    const template = await seedTemplate(testUser.id, { title: 'E2E 편집 템플릿' });
+    await seedTemplateItem(template.id, '기존항목');
+
+    const page = await authenticatedContext.newPage();
+    await page.goto('/templates');
+
+    // 목록 로드 대기: 시드한 템플릿 카드가 노출될 때까지 대기 후 클릭하여 편집 모달 오픈
+    const templateCard = page.getByText('E2E 편집 템플릿');
+    await expect(templateCard).toBeVisible({ timeout: 15000 });
+    await templateCard.click();
+
+    // 편집 모달 로드 대기: 기존 항목이 입력 필드(1번째 준비물)에 채워질 때까지 대기
+    const firstItemInput = page.getByPlaceholder('1번째 준비물');
+    await expect(firstItemInput).toHaveValue('기존항목', { timeout: 10000 });
+
+    // "준비물 항목 추가하기" 버튼 클릭 → 새 행 추가
+    await page.getByRole('button', { name: '준비물 항목 추가하기' }).click();
+
+    // 새 행(2번째 준비물)에 입력
+    const secondItemInput = page.getByPlaceholder('2번째 준비물');
+    await expect(secondItemInput).toBeVisible({ timeout: 10000 });
+    await secondItemInput.fill('추가항목');
+
+    // 저장 (편집 모달 제출 버튼: "변경 내용 저장할게요")
+    await page.getByRole('button', { name: /저장/ }).click();
+
+    // 모달 닫힘 확인
+    await expect(firstItemInput).toBeHidden({ timeout: 10000 });
+
+    // DB 검증: '추가항목'이 해당 템플릿에 존재할 때까지 폴링
+    await expect
+      .poll(async () => (await getTemplateItemByName(template.id, '추가항목')) !== null, {
+        timeout: 10000,
+      })
+      .toBe(true);
+
+    await page.close();
+  });
+
+  test('템플릿을 여행 체크리스트에 적용', async ({ authenticatedContext, testUser }) => {
+    // 여행 + 체크리스트 시드. 더미 항목 1개를 미리 넣어 "템플릿 불러오기" 버튼 영역의
+    // 게이팅(목록 비어있을 때 UI 분기) 영향을 회피한다.
+    const trip = await seedTrip(testUser.id);
+    const checklist = await getOrCreateChecklist(trip.id);
+    await seedChecklistItem(checklist.id, '기존항목');
+
+    // 적용할 템플릿 + 항목 시드
+    const template = await seedTemplate(testUser.id, { title: '적용할 템플릿' });
+    await seedTemplateItem(template.id, '여권');
+
+    const page = await authenticatedContext.newPage();
+    await page.goto(`/trips/detail?id=${trip.id}&tab=checklist`);
+
+    // "템플릿 불러오기" 버튼 노출 대기 후 클릭
+    const loadTemplateButton = page.getByRole('button', { name: '템플릿 불러오기' });
+    await expect(loadTemplateButton).toBeVisible({ timeout: 15000 });
+    await loadTemplateButton.click();
+
+    // 적용 모달에서 '적용할 템플릿' 행의 "가져오기" 버튼 클릭
+    const templateRowName = page.getByText('적용할 템플릿');
+    await expect(templateRowName).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: '가져오기' }).first().click();
+
+    // 체크리스트에 '여권' 노출
+    await expect(page.getByText('여권')).toBeVisible({ timeout: 10000 });
+
+    // DB 검증: source_template_name='적용할 템플릿'인 항목이 존재할 때까지 폴링
+    await expect
+      .poll(
+        async () =>
+          (await getChecklistItemBySourceTemplate(checklist.id, '적용할 템플릿')).length > 0,
+        { timeout: 10000 }
+      )
+      .toBe(true);
+
+    const applied = await getChecklistItemBySourceTemplate(checklist.id, '적용할 템플릿');
+    expect(applied.some((i) => i.item_name === '여권')).toBe(true);
+
+    await page.close();
+  });
+});

--- a/e2e/trips.spec.ts
+++ b/e2e/trips.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from './fixtures/auth';
+import {
+  seedTrip,
+  getOrCreateChecklist,
+  getChecklistItem,
+  getChecklistItemByName,
+  cleanupTripsByUser,
+} from './helpers/seed';
+
+test.describe('여행 생성 및 체크리스트 플로우', () => {
+  // 각 테스트 전후로 해당 유저의 여행 데이터를 정리해 테스트 간 격리를 보장한다.
+  test.beforeEach(async ({ testUser }) => {
+    await cleanupTripsByUser(testUser.id);
+  });
+
+  test.afterEach(async ({ testUser }) => {
+    await cleanupTripsByUser(testUser.id);
+  });
+
+  test('여행 생성 → 상세 페이지 진입', async ({ authenticatedContext }) => {
+    const page = await authenticatedContext.newPage();
+    await page.goto('/trips/new');
+
+    // 여행지 입력: Google Maps Autocomplete가 로드되면(isLoaded) input이 활성화된다.
+    const destinationInput = page.getByPlaceholder('어디로 떠나시나요?');
+    await expect(destinationInput).toBeEnabled({ timeout: 15000 });
+    await destinationInput.fill('도쿄');
+
+    // Autocomplete 드롭다운이 떠 있으면 닫아 제출 버튼 클릭을 가린지 않도록 한다.
+    await page.keyboard.press('Escape');
+
+    // 시작일 / 종료일 (input[type=date]는 두 개뿐)
+    await page.locator('input[type="date"]').first().fill('2026-08-01');
+    await page.locator('input[type="date"]').last().fill('2026-08-05');
+
+    // 제출
+    await page.getByRole('button', { name: '여행 계획 시작하기' }).click();
+
+    // 상세 페이지로 이동
+    await expect(page).toHaveURL(/\/trips\/detail\?id=/, { timeout: 10000 });
+
+    // 여행지 표시 확인 (헤더에 "도쿄 여행" 형태로 노출)
+    await expect(page.getByText('도쿄')).toBeVisible();
+
+    await page.close();
+  });
+
+  test('체크리스트 항목 추가 → 체크(완료 처리)', async ({ authenticatedContext, testUser }) => {
+    // UI 생성에 의존하지 않고 독립적으로 여행을 시드해 테스트 격리를 보장한다.
+    const trip = await seedTrip(testUser.id);
+
+    const page = await authenticatedContext.newPage();
+    await page.goto(`/trips/detail?id=${trip.id}&tab=checklist`);
+
+    // 준비물 탭 영역이 로드되어 '항목 추가' 버튼이 노출될 때까지 대기 후 클릭
+    const addToggleButton = page.getByRole('button', { name: '항목 추가' });
+    await expect(addToggleButton).toBeVisible({ timeout: 15000 });
+    await addToggleButton.click();
+
+    // 항목명 입력 후 제출
+    await page.getByPlaceholder('어떤 준비물인가요?').fill('여권');
+    await page.getByRole('button', { name: '추가' }).click();
+
+    // 목록에 추가 확인
+    await expect(page.getByText('여권')).toBeVisible();
+
+    // DB 검증: 추가된 항목이 존재할 때까지 폴링 후 id 확보
+    const checklist = await getOrCreateChecklist(trip.id);
+    await expect
+      .poll(async () => (await getChecklistItemByName(checklist.id, '여권')) !== null, {
+        timeout: 10000,
+      })
+      .toBe(true);
+
+    const created = await getChecklistItemByName(checklist.id, '여권');
+    expect(created).not.toBeNull();
+    expect(created!.is_checked).toBe(false);
+
+    // 체크 처리: '여권' 항목 행의 체크 영역(텍스트와 체크박스가 동일 클릭 래퍼에 속함)을 클릭.
+    // 항목 텍스트를 클릭하면 래퍼의 onClick(toggleItem)이 트리거된다.
+    await page.getByText('여권').click();
+
+    // DB 검증: is_checked === true 로 갱신될 때까지 폴링
+    await expect
+      .poll(async () => (await getChecklistItem(created!.id)).is_checked, { timeout: 10000 })
+      .toBe(true);
+
+    await page.close();
+  });
+});

--- a/e2e/trips.spec.ts
+++ b/e2e/trips.spec.ts
@@ -36,11 +36,11 @@ test.describe('여행 생성 및 체크리스트 플로우', () => {
     // 제출
     await page.getByRole('button', { name: '여행 계획 시작하기' }).click();
 
-    // 상세 페이지로 이동 (Next.js가 trailing slash를 추가할 수 있으므로 optional로 처리)
-    await expect(page).toHaveURL(/\/trips\/detail\/?id=/, { timeout: 10000 });
+    // Next.js가 /trips/detail/ (trailing slash) 또는 /trips/detail (no slash) 로 리다이렉트할 수 있다.
+    await expect(page).toHaveURL(/\/trips\/detail\/?\?id=/, { timeout: 10000 });
 
     // 여행지 표시 확인 (헤더에 "도쿄 여행" 형태로 노출)
-    await expect(page.getByText('도쿄')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '도쿄 여행' })).toBeVisible();
 
     await page.close();
   });
@@ -48,6 +48,10 @@ test.describe('여행 생성 및 체크리스트 플로우', () => {
   test('체크리스트 항목 추가 → 체크(완료 처리)', async ({ authenticatedContext, testUser }) => {
     // UI 생성에 의존하지 않고 독립적으로 여행을 시드해 테스트 격리를 보장한다.
     const trip = await seedTrip(testUser.id);
+    // 앱이 페이지 마운트 시 체크리스트를 concurrent하게 생성하면 race condition으로
+    // 두 개의 checklist가 생성되고 setItems가 덮어쓰이는 문제가 발생한다.
+    // 미리 checklist를 생성해 앱이 기존 row를 조회하도록 한다.
+    await getOrCreateChecklist(trip.id);
 
     const page = await authenticatedContext.newPage();
     await page.goto(`/trips/detail?id=${trip.id}&tab=checklist`);

--- a/e2e/trips.spec.ts
+++ b/e2e/trips.spec.ts
@@ -36,8 +36,8 @@ test.describe('여행 생성 및 체크리스트 플로우', () => {
     // 제출
     await page.getByRole('button', { name: '여행 계획 시작하기' }).click();
 
-    // 상세 페이지로 이동
-    await expect(page).toHaveURL(/\/trips\/detail\?id=/, { timeout: 10000 });
+    // 상세 페이지로 이동 (Next.js가 trailing slash를 추가할 수 있으므로 optional로 처리)
+    await expect(page).toHaveURL(/\/trips\/detail\/?id=/, { timeout: 10000 });
 
     // 여행지 표시 확인 (헤더에 "도쿄 여행" 형태로 노출)
     await expect(page.getByText('도쿄')).toBeVisible();
@@ -57,12 +57,16 @@ test.describe('여행 생성 및 체크리스트 플로우', () => {
     await expect(addToggleButton).toBeVisible({ timeout: 15000 });
     await addToggleButton.click();
 
-    // 항목명 입력 후 제출
-    await page.getByPlaceholder('어떤 준비물인가요?').fill('여권');
-    await page.getByRole('button', { name: '추가' }).click();
+    // 항목명 입력 후 제출 — React controlled input은 fill 대신 type 이벤트가 필요할 수 있음
+    const itemInput = page.getByPlaceholder('어떤 준비물인가요?');
+    await itemInput.click();
+    await itemInput.fill('여권');
+    // 추가 버튼 활성화 대기 (disabled={!newItemName.trim()} 조건)
+    await expect(page.getByRole('button', { name: '추가', exact: true })).toBeEnabled({ timeout: 5000 });
+    await page.getByRole('button', { name: '추가', exact: true }).click();
 
-    // 목록에 추가 확인
-    await expect(page.getByText('여권')).toBeVisible();
+    // 목록에 추가 확인 (DB insert + UI 반영 대기)
+    await expect(page.getByText('여권')).toBeVisible({ timeout: 10000 });
 
     // DB 검증: 추가된 항목이 존재할 때까지 폴링 후 id 확보
     const checklist = await getOrCreateChecklist(trip.id);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "build:mobile": "mv src/app/api src/app_api_tmp && mv src/app/auth src/app_auth_tmp && mv src/app/share src/app_share_tmp && BUILD_TARGET=mobile next build; BS=$?; mv src/app_api_tmp src/app/api; mv src/app_auth_tmp src/app/auth; mv src/app_share_tmp src/app/share; exit $BS",
     "start": "NODE_OPTIONS='--dns-result-order=ipv4first' next start",
     "lint": "eslint",
-    "prepare": "panda codegen"
+    "prepare": "panda codegen",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report",
+    "dev:e2e": "node scripts/dev-e2e.mjs"
   },
   "dependencies": {
     "@capacitor-community/firebase-analytics": "^8.0.0",
@@ -43,6 +47,7 @@
   "devDependencies": {
     "@capacitor/cli": "^8.2.0",
     "@pandacss/dev": "^1.8.2",
+    "@playwright/test": "^1.60.0",
     "@types/archiver": "^6.0.3",
     "@types/google.maps": "^3.58.1",
     "@types/node": "^20.19.33",
@@ -50,6 +55,8 @@
     "@types/react-dom": "^19",
     "archiver": "^7.0.1",
     "babel-plugin-react-compiler": "1.0.0",
+    "dotenv": "^17.4.2",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "postcss": "^8.5.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,17 +7,17 @@ config({ path: '.env.test.local' });
 export default defineConfig({
   testDir: './e2e',
   globalTeardown: './e2e/global-teardown.ts',
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
   },
   webServer: {
-    // E2E 전용 dev 서버: .env.test.local을 process.env로 주입 후 next dev 실행
+    // E2E 전용 dev 서버: NODE_ENV=test로 next dev 실행 → .env.test.local 자동 로드
     // .env.local은 절대 수정하지 않음 (rules.md §5)
     command: 'pnpm dev:e2e',
     url: 'http://localhost:3000',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    // E2E 전용 dev 서버: .env.local 대신 .env.e2e를 사용
-    // pnpm e2e:dev 스크립트가 .env.e2e를 .env.local로 교체하고 실행
+    // E2E 전용 dev 서버: .env.test.local을 process.env로 주입 후 next dev 실행
+    // .env.local은 절대 수정하지 않음 (rules.md §5)
     command: 'pnpm dev:e2e',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+import { config } from 'dotenv';
+
+// .env.test.local을 playwright 프로세스 및 테스트 코드에 주입
+config({ path: '.env.test.local' });
+
+export default defineConfig({
+  testDir: './e2e',
+  globalTeardown: './e2e/global-teardown.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    // E2E 전용 dev 서버: .env.local 대신 .env.e2e를 사용
+    // pnpm e2e:dev 스크립트가 .env.e2e를 .env.local로 교체하고 실행
+    command: 'pnpm dev:e2e',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 8.45.1(@capacitor/core@8.2.0)
       '@next/third-parties':
         specifier: latest
-        version: 16.2.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 16.2.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@react-google-maps/api':
         specifier: ^2.19.3
         version: 2.20.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -61,7 +61,7 @@ importers:
         version: 3.2.0(@capacitor/core@8.2.0)
       '@sentry/nextjs':
         specifier: 8.47.0
-        version: 8.47.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)
+        version: 8.47.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)
       '@supabase/ssr':
         specifier: ^0.8.0
         version: 0.8.0(@supabase/supabase-js@2.98.0)
@@ -70,7 +70,7 @@ importers:
         version: 2.98.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -82,7 +82,7 @@ importers:
         version: 0.575.0(react@19.2.3)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -99,6 +99,9 @@ importers:
       '@pandacss/dev':
         specifier: ^1.8.2
         version: 1.8.2(typescript@5.9.3)
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/archiver':
         specifier: ^6.0.3
         version: 6.0.4
@@ -120,6 +123,12 @@ importers:
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
       eslint:
         specifier: ^9
         version: 9.39.3
@@ -1132,6 +1141,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/instrumentation@5.22.0':
     resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
@@ -2193,8 +2207,20 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv-cli@11.0.0:
+    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
+    hasBin: true
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -2558,6 +2584,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3413,6 +3444,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -4843,9 +4884,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
-  '@next/third-parties@16.2.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@next/third-parties@16.2.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       third-party-capital: 1.0.20
 
@@ -5368,6 +5409,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@prisma/instrumentation@5.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -5532,7 +5577,7 @@ snapshots:
 
   '@sentry/core@8.47.0': {}
 
-  '@sentry/nextjs@8.47.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)':
+  '@sentry/nextjs@8.47.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -5545,7 +5590,7 @@ snapshots:
       '@sentry/vercel-edge': 8.47.0
       '@sentry/webpack-plugin': 2.22.7(webpack@5.105.4)
       chalk: 3.0.0
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.11
@@ -5932,9 +5977,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/speed-insights@2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/speed-insights@2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vue/compiler-core@3.5.25':
@@ -6546,7 +6591,20 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv-cli@11.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 17.4.2
+      dotenv-expand: 12.0.3
+      minimist: 1.2.8
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
   dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -7094,6 +7152,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -7703,7 +7764,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -7723,6 +7784,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.60.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -7898,6 +7960,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:

--- a/scripts/dev-e2e.mjs
+++ b/scripts/dev-e2e.mjs
@@ -1,0 +1,44 @@
+/**
+ * E2E 테스트용 dev 서버 실행 스크립트
+ *
+ * 원칙: .env.local을 절대 수정하지 않는다.
+ * Next.js는 이미 process.env에 설정된 값을 .env.local로 덮어쓰지 않으므로,
+ * .env.test.local 값을 process.env에 먼저 주입한 뒤 next dev를 실행한다.
+ */
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { spawn } from 'child_process';
+
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) throw new Error(`파일 없음: ${filePath}`);
+  return Object.fromEntries(
+    readFileSync(resolve(filePath), 'utf-8')
+      .split('\n')
+      .filter((line) => line.trim() && !line.startsWith('#'))
+      .map((line) => {
+        const idx = line.indexOf('=');
+        return [line.slice(0, idx).trim(), line.slice(idx + 1).trim()];
+      })
+      .filter(([k]) => k)
+  );
+}
+
+const testEnv = loadEnvFile('.env.test.local');
+
+// .env.test.local 값을 현재 process.env에 주입 (next dev가 상속받음)
+// Next.js 우선순위: process.env > .env.local > .env
+// → 이미 주입된 값은 .env.local이 덮어쓰지 않는다
+Object.assign(process.env, testEnv);
+
+const dev = spawn('node_modules/.bin/next', ['dev'], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    NODE_OPTIONS: '--dns-result-order=ipv4first',
+  },
+  shell: false,
+});
+
+dev.on('exit', (code) => process.exit(code ?? 0));
+process.on('SIGINT', () => dev.kill('SIGINT'));
+process.on('SIGTERM', () => dev.kill('SIGTERM'));

--- a/scripts/dev-e2e.mjs
+++ b/scripts/dev-e2e.mjs
@@ -2,38 +2,18 @@
  * E2E 테스트용 dev 서버 실행 스크립트
  *
  * 원칙: .env.local을 절대 수정하지 않는다.
- * Next.js는 이미 process.env에 설정된 값을 .env.local로 덮어쓰지 않으므로,
- * .env.test.local 값을 process.env에 먼저 주입한 뒤 next dev를 실행한다.
+ * NODE_ENV=test 설정 → Next.js가 .env.test.local을 .env.local보다 높은 우선순위로
+ * 자동 로드하므로 NEXT_PUBLIC_* 변수도 올바르게 테스트용 값으로 번들링된다.
+ * 참고: @next/env의 loadEnvConfig는 NODE_ENV=test일 때 .env.test.local만 로드하고
+ * .env.local은 로드하지 않는다.
  */
-import { readFileSync, existsSync } from 'fs';
-import { resolve } from 'path';
 import { spawn } from 'child_process';
-
-function loadEnvFile(filePath) {
-  if (!existsSync(filePath)) throw new Error(`파일 없음: ${filePath}`);
-  return Object.fromEntries(
-    readFileSync(resolve(filePath), 'utf-8')
-      .split('\n')
-      .filter((line) => line.trim() && !line.startsWith('#'))
-      .map((line) => {
-        const idx = line.indexOf('=');
-        return [line.slice(0, idx).trim(), line.slice(idx + 1).trim()];
-      })
-      .filter(([k]) => k)
-  );
-}
-
-const testEnv = loadEnvFile('.env.test.local');
-
-// .env.test.local 값을 현재 process.env에 주입 (next dev가 상속받음)
-// Next.js 우선순위: process.env > .env.local > .env
-// → 이미 주입된 값은 .env.local이 덮어쓰지 않는다
-Object.assign(process.env, testEnv);
 
 const dev = spawn('node_modules/.bin/next', ['dev'], {
   stdio: 'inherit',
   env: {
     ...process.env,
+    NODE_ENV: 'test',
     NODE_OPTIONS: '--dns-result-order=ipv4first',
   },
   shell: false,

--- a/src/app/api/places/photo/route.ts
+++ b/src/app/api/places/photo/route.ts
@@ -21,17 +21,21 @@ export async function GET(request: Request) {
         const detailsData = await detailsRes.json()
 
         if (detailsData.status !== 'OK' || !detailsData.result?.photos?.length) {
-            return NextResponse.json({ url: null })
+            return NextResponse.json({ url: null, photoReference: null })
         }
 
-        const photoRef = detailsData.result.photos[0].photo_reference
+        const photoRef: string = detailsData.result.photos[0].photo_reference
 
-        // 2. Places Photo URL로 리다이렉트를 따라가 영구 CDN URL 획득
+        // 2. Places Photo URL로 리다이렉트를 따라가 영구 CDN URL 획득 (미리보기용)
         const photoApiUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=${maxwidth}&photo_reference=${photoRef}&key=${apiKey}`
         const photoRes = await fetch(photoApiUrl, { redirect: 'manual', next: { revalidate: 3600 } })
         const finalUrl = photoRes.headers.get('location')
 
-        return NextResponse.json({ url: finalUrl || photoApiUrl })
+        // photoReference는 클라이언트가 plans INSERT 시 함께 저장해야 함 (영구 저장 키)
+        return NextResponse.json({
+            url: finalUrl || photoApiUrl,
+            photoReference: photoRef,
+        })
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         console.error('[places/photo] Error:', message)

--- a/src/app/api/places/photo/store/route.ts
+++ b/src/app/api/places/photo/store/route.ts
@@ -1,0 +1,238 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import { createHash } from 'crypto'
+
+interface StoreRequestBody {
+    planId?: string
+    tripId?: string
+    placeId?: string
+    photoReference?: string | null
+}
+
+const PHOTO_MAX_WIDTH = 800
+const STORAGE_BUCKET = 'place-photos'
+const STORAGE_CONTENT_TYPE = 'image/jpeg'
+
+/**
+ * Google Places Details API로부터 photo_reference를 조회한다.
+ * - 레거시 plan(photo_reference 컬럼이 null인 데이터) 자동 복구 fallback에 사용.
+ * - 실패/photos 없음/non-OK status는 모두 null 반환 → 호출 측에서 410 처리.
+ */
+async function fetchPhotoReferenceByPlaceId(
+    placeId: string,
+    apiKey: string
+): Promise<string | null> {
+    const detailsUrl =
+        `https://maps.googleapis.com/maps/api/place/details/json` +
+        `?place_id=${encodeURIComponent(placeId)}` +
+        `&fields=photos` +
+        `&language=ko` +
+        `&key=${apiKey}`
+
+    try {
+        const res = await fetch(detailsUrl)
+        if (!res.ok) {
+            console.error(
+                `[photo/store] Places Details HTTP ${res.status} for placeId lookup`
+            )
+            return null
+        }
+        const json = (await res.json()) as {
+            status?: string
+            result?: { photos?: Array<{ photo_reference?: string }> }
+        }
+        if (json.status !== 'OK') {
+            console.warn(`[photo/store] Places Details status=${json.status}`)
+            return null
+        }
+        const photoRef = json.result?.photos?.[0]?.photo_reference
+        if (!photoRef) {
+            return null
+        }
+        return photoRef
+    } catch (err) {
+        const message = err instanceof Error ? err.message : 'fetch failed'
+        console.error('[photo/store] Places Details fetch failed:', message)
+        return null
+    }
+}
+
+function placeIdHash8(placeId: string): string {
+    return createHash('sha256').update(placeId).digest('hex').slice(0, 8)
+}
+
+function buildStoragePath(userId: string, tripId: string, planId: string, placeId: string): string {
+    return `${userId}/${tripId}/${planId}_${placeIdHash8(placeId)}.jpg`
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        // 1) 요청 본문 파싱
+        let body: StoreRequestBody
+        try {
+            body = (await request.json()) as StoreRequestBody
+        } catch {
+            return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+        }
+
+        const { planId, tripId, placeId } = body
+        // photoReference는 optional. 누락 시 placeId 기반 fallback으로 조회.
+        let photoReference: string | null | undefined = body.photoReference
+        if (!planId || !tripId || !placeId) {
+            return NextResponse.json(
+                { error: 'Missing required fields: planId, tripId, placeId' },
+                { status: 400 }
+            )
+        }
+
+        // 2) 인증 확인
+        const supabase = await createClient()
+        const {
+            data: { user },
+            error: authError,
+        } = await supabase.auth.getUser()
+
+        if (authError || !user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        // 3) 멤버십 검증
+        //    plan이 존재하며 동일 trip_id에 속하고, 현재 사용자가 owner/editor 권한을 가진다.
+        //    RLS만 의존하지 않고 service 레이어에서 명시 검증.
+        const { data: planRow, error: planLookupError } = await supabase
+            .from('plans')
+            .select('id, trip_id')
+            .eq('id', planId)
+            .maybeSingle()
+
+        if (planLookupError) {
+            console.error('[places/photo/store] plan lookup failed:', planLookupError.message)
+            return NextResponse.json({ error: 'Plan lookup failed' }, { status: 500 })
+        }
+        if (!planRow) {
+            return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+        }
+        if (planRow.trip_id !== tripId) {
+            return NextResponse.json({ error: 'Trip mismatch' }, { status: 400 })
+        }
+
+        // 소유자 또는 멤버(편집자) 권한 검증.
+        // 두 보조 함수를 RPC 호출하여 OR 조건을 평가한다.
+        const [ownerResp, editorResp] = await Promise.all([
+            supabase.rpc('check_is_trip_owner', { _trip_id: tripId, _user_id: user.id }),
+            supabase.rpc('check_is_trip_editor', { _trip_id: tripId, _user_id: user.id }),
+        ])
+        if (ownerResp.error) {
+            console.error('[places/photo/store] check_is_trip_owner failed:', ownerResp.error.message)
+        }
+        if (editorResp.error) {
+            console.error('[places/photo/store] check_is_trip_editor failed:', editorResp.error.message)
+        }
+        const isOwner = ownerResp.data === true
+        const isEditor = editorResp.data === true
+        if (!isOwner && !isEditor) {
+            return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+        }
+
+        // 4) Google Maps API Key (서버 보유)
+        //    Places Photo API는 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY를 사용하지만,
+        //    가능하면 서버 전용 키를 분리해서 도메인 제약을 우회한다.
+        const apiKey =
+            process.env.GOOGLE_PLACES_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+        if (!apiKey) {
+            return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+        }
+
+        // 4-b) photoReference fallback
+        //      레거시 plan(photo_reference=null) 자동 복구: placeId로 Places Details API 호출하여
+        //      photo_reference를 재조회한다. 조회 실패 시 410으로 반환하여 클라이언트는 만료 처리.
+        if (!photoReference) {
+            console.info('[photo/store] photoReference fallback via placeId', { planId })
+            const recovered = await fetchPhotoReferenceByPlaceId(placeId, apiKey)
+            if (!recovered) {
+                return NextResponse.json(
+                    { error: 'Photo reference unavailable' },
+                    { status: 410 }
+                )
+            }
+            photoReference = recovered
+        }
+
+        // 5) Google Photo CDN fetch
+        //    Places Photo API는 302 리다이렉트 → 실제 CDN. fetch는 자동 follow.
+        const photoApiUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=${PHOTO_MAX_WIDTH}&photo_reference=${encodeURIComponent(
+            photoReference
+        )}&key=${apiKey}`
+
+        let photoRes: Response
+        try {
+            photoRes = await fetch(photoApiUrl, { redirect: 'follow' })
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'fetch failed'
+            console.error('[places/photo/store] Google Photo fetch failed:', message)
+            return NextResponse.json({ error: 'Photo fetch failed' }, { status: 502 })
+        }
+
+        // 403/410은 토큰 만료/거부 — 클라이언트가 photo_reference 무효화 처리해야 함
+        if (photoRes.status === 403 || photoRes.status === 410) {
+            console.warn(
+                `[places/photo/store] Google Photo expired (status=${photoRes.status}) for plan=${planId}`
+            )
+            return NextResponse.json({ error: 'Photo reference expired' }, { status: 410 })
+        }
+        if (!photoRes.ok) {
+            console.error(
+                `[places/photo/store] Google Photo fetch returned ${photoRes.status} for plan=${planId}`
+            )
+            return NextResponse.json({ error: 'Photo fetch failed' }, { status: 502 })
+        }
+
+        const photoArrayBuffer = await photoRes.arrayBuffer()
+        if (!photoArrayBuffer.byteLength) {
+            return NextResponse.json({ error: 'Empty photo response' }, { status: 502 })
+        }
+        const photoBuffer = Buffer.from(photoArrayBuffer)
+
+        // 6) Supabase Storage upload
+        const storagePath = buildStoragePath(user.id, tripId, planId, placeId)
+        const { error: uploadError } = await supabase.storage
+            .from(STORAGE_BUCKET)
+            .upload(storagePath, photoBuffer, {
+                contentType: STORAGE_CONTENT_TYPE,
+                upsert: true,
+                cacheControl: '31536000',
+            })
+        if (uploadError) {
+            console.error('[places/photo/store] Storage upload failed:', uploadError.message)
+            return NextResponse.json({ error: 'Storage upload failed' }, { status: 500 })
+        }
+
+        // 7) publicUrl 획득
+        const { data: publicUrlData } = supabase.storage
+            .from(STORAGE_BUCKET)
+            .getPublicUrl(storagePath)
+        const publicUrl = publicUrlData?.publicUrl
+        if (!publicUrl) {
+            console.error('[places/photo/store] getPublicUrl returned empty for', storagePath)
+            return NextResponse.json({ error: 'Public URL generation failed' }, { status: 500 })
+        }
+
+        // 8) plans UPDATE { image_url, photo_reference }
+        //    RLS 정책에 의해 권한이 있는 경우만 통과.
+        const { error: updateError } = await supabase
+            .from('plans')
+            .update({ image_url: publicUrl, photo_reference: photoReference })
+            .eq('id', planId)
+
+        if (updateError) {
+            console.error('[places/photo/store] plans UPDATE failed:', updateError.message)
+            return NextResponse.json({ error: 'Plan update failed' }, { status: 500 })
+        }
+
+        return NextResponse.json({ imageUrl: publicUrl }, { status: 200 })
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        console.error('[places/photo/store] Unhandled error:', message)
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next"
 import BugReportFAB from '@/components/layout/BugReportFAB'
 import UpdateOverlay from '@/components/layout/UpdateOverlay'
 import GlobalModals from '@/components/layout/GlobalModals'
+import ToastContainer from '@/components/common/ToastContainer'
 
 export const metadata: Metadata = {
   title: '온여정 - 당신의 따뜻한 여행 동반자',
@@ -75,6 +76,7 @@ export default function RootLayout({
         )}
         <NativeAnalytics />
         <GlobalModals />
+        <ToastContainer />
       </body>
     </html>
   )

--- a/src/app/offline/trips/detail/page.tsx
+++ b/src/app/offline/trips/detail/page.tsx
@@ -39,7 +39,7 @@ function OfflineTripContent() {
                 }
             } else {
                 alert('해당 여행의 오프라인 데이터가 없습니다.')
-                router.replace('/')
+                router.replace('/offline')
             }
             setLoading(false)
         }

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -15,10 +15,12 @@ import { CacheUtil } from '@/utils/cache'
 export default function TemplatesPage() {
     const supabase = createClient()
     const router = useRouter()
-    const { 
-        setIsNewTemplateModalOpen, 
-        setIsEditTemplateModalOpen, 
-        setEditingTemplateId 
+    const {
+        setIsNewTemplateModalOpen,
+        setIsEditTemplateModalOpen,
+        setEditingTemplateId,
+        isNewTemplateModalOpen,
+        isEditTemplateModalOpen,
     } = useUIStore()
 
     const [templates, setTemplates] = useState<any[]>([])
@@ -28,7 +30,7 @@ export default function TemplatesPage() {
         async function fetchTemplates() {
             const { data: { user: networkUser } } = await supabase.auth.getUser()
             const user = networkUser || await CacheUtil.getAuthUser()
-            
+
             if (!user) {
                 router.push('/login')
                 return
@@ -50,7 +52,8 @@ export default function TemplatesPage() {
         }
 
         fetchTemplates()
-    }, [supabase, router])
+    // 모달이 닫힐 때(false로 변경) 목록을 다시 가져와 UI를 갱신한다.
+    }, [supabase, router, isNewTemplateModalOpen, isEditTemplateModalOpen])
 
     if (loading) {
         return (

--- a/src/app/trips/checklist/ChecklistClient.tsx
+++ b/src/app/trips/checklist/ChecklistClient.tsx
@@ -1335,7 +1335,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                             </select>
                             <button
                                 type="submit"
-                                disabled={!newItemName.trim()}
+                                disabled={!newItemName.trim() || !checklistId}
                                 className={css({ py: '10px', px: '20px', bg: 'brand.primary', color: 'white', fontWeight: '700', borderRadius: '12px', border: 'none', cursor: 'pointer', boxShadow: 'shadow.primary' })}
                             >
                                 추가

--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -407,30 +407,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                                     <UserPlus size={16} /> <span>동행자</span>
                                 </button>
 
-                                <button
-                                    onClick={handleDownload}
-                                    className={css({
-                                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px',
-                                        bg: isDownloaded ? 'rgba(46, 196, 182, 0.05)' : 'white',
-                                        color: isDownloaded ? 'brand.primary' : 'brand.ink',
-                                        px: '12px', h: '42px',
-                                        borderRadius: '8px', fontWeight: '700', fontSize: '13px',
-                                        border: '1px solid', borderColor: isDownloaded ? 'brand.primary' : 'brand.hairline',
-                                        whiteSpace: 'nowrap', transition: 'all 0.2s',
-                                        _hover: { bg: 'bg.softCotton', borderColor: 'brand.primary' },
-                                        _active: { transform: 'scale(0.92)' },
-                                        flex: 1
-                                    })}
-                                >
-                                    {isDownloading ? (
-                                        <Loader2 size={16} className={css({ animation: 'spin 1s linear infinite' })} />
-                                    ) : isDownloaded ? (
-                                        <CloudCheck size={16} />
-                                    ) : (
-                                        <CloudDownload size={16} />
-                                    )}
-                                    <span>{isDownloading ? '다운로드 중' : isDownloaded ? '다운로드됨' : '다운로드'}</span>
-                                </button>
+
 
                                 {userRole === 'owner' && (
                                     <button

--- a/src/app/trips/detail/TripClient.tsx
+++ b/src/app/trips/detail/TripClient.tsx
@@ -17,6 +17,7 @@ import { ExchangeService } from '@/services/ExternalApiService'
 import { CacheUtil } from '@/utils/cache'
 import { NotificationService } from '@/services/NotificationService'
 import { DownloadService } from '@/services/DownloadService'
+import { PlanPhotoStorageService } from '@/services/PlanPhotoStorageService'
 import { Download, CloudDownload, CloudCheck, Loader2 } from 'lucide-react'
 import TripDetailSkeleton from './TripDetailSkeleton'
 const CustomTimeDropdown = ({ timeDisplayMode, setTimeDisplayMode }: any) => {
@@ -250,6 +251,15 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
     const handleDeletePlan = async (planId: string) => {
         if (!confirm('이 일정을 삭제하시겠습니까? (연결된 정보도 함께 삭제됩니다)')) return
 
+        // Storage cleanup은 best-effort: 실패해도 plan DELETE는 계속 진행
+        if (tripId) {
+            try {
+                await PlanPhotoStorageService.cleanupPlanPhotos({ tripId, planId })
+            } catch (cleanupErr) {
+                console.warn('[TripClient] cleanupPlanPhotos failed (ignored)', cleanupErr)
+            }
+        }
+
         const { error } = await supabase.from('plans').delete().eq('id', planId)
         if (error) {
             alert('삭제에 실패했습니다.')
@@ -258,6 +268,16 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             fetchPlans() // 목록 리프레시
         }
     }
+
+    /** 백그라운드/on-demand 업로드 성공 시 plans 리스트 image_url 동기화 */
+    const handlePlanImageRecovered = useCallback((planId: string, newImageUrl: string) => {
+        setPlans(prev => prev.map(p => (
+            p.id === planId ? { ...p, image_url: newImageUrl } : p
+        )))
+        setSelectedPlanForDetail((cur: any) => (
+            cur && cur.id === planId ? { ...cur, image_url: newImageUrl } : cur
+        ))
+    }, [])
 
     const handleEditPlan = async (plan: any) => {
         // 편집을 위해, 해당 Plan에 연결된 url들도 같이 가져옵니다
@@ -475,6 +495,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                     onDelete={handleDeletePlan}
                     onDetail={handlePlanDetail}
                     onToggleVisit={handleToggleVisit}
+                    onPlanImageRecovered={handlePlanImageRecovered}
                 />
             )}
 
@@ -490,6 +511,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                     onEdit={handleEditPlan}
                     onDelete={handleDeletePlan}
                     onToggleVisit={handleToggleVisit}
+                    onPlanImageRecovered={handlePlanImageRecovered}
                 />
             )}
 
@@ -502,6 +524,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                     editData={editingPlan}
                     tripStartDate={trip?.start_date}
                     tripEndDate={trip?.end_date}
+                    onPlanImageUpdated={handlePlanImageRecovered}
                 />
             )}
             {tripId && (

--- a/src/components/common/OfflineBanner.tsx
+++ b/src/components/common/OfflineBanner.tsx
@@ -26,55 +26,5 @@ export default function OfflineBanner() {
         LifecycleService.initialize()
     }, [initializeNetworkListener])
 
-    if (!mounted || (isOnline && !isOfflineMode)) return null
-
-    return (
-        <div className={css({
-            bg: isOfflineMode ? 'brand.secondary' : 'brand.error',
-            color: 'white',
-            px: '20px',
-            py: '12px',
-            textAlign: 'center',
-            fontSize: '14px',
-            fontWeight: '700',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: '8px',
-            animation: 'fadeIn 0.3s ease-out',
-            zIndex: 1100,
-            position: 'relative',
-            boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
-        })}>
-            <div className={css({ display: 'flex', alignItems: 'center', gap: '8px' })}>
-                <WifiOff size={16} />
-                {isOfflineMode ? '현재 오프라인 모드로 동작 중입니다.' : '네트워크 연결이 끊어졌습니다.'}
-            </div>
-
-            {isOfflineMode && isOnline && (
-                <button
-                    onClick={() => {
-                        setOfflineMode(false)
-                        // 온라인 복귀 시 새로고침하여 최신 상태 반영
-                        window.location.reload() 
-                    }}
-                    className={css({
-                        mt: '4px',
-                        bg: 'brand.primary',
-                        color: 'white',
-                        border: 'none',
-                        px: '16px',
-                        py: '6px',
-                        borderRadius: '20px',
-                        fontSize: '12px',
-                        fontWeight: '800',
-                        cursor: 'pointer'
-                    })}
-                >
-                    온라인 모드로 복귀
-                </button>
-            )}
-        </div>
-    )
+    return null
 }

--- a/src/components/common/OfflinePromptModal.tsx
+++ b/src/components/common/OfflinePromptModal.tsx
@@ -27,16 +27,8 @@ export default function OfflinePromptModal() {
         setOfflineMode(true)
         setIsOpen(false)
         
-        // 현재 경로에 따라 오프라인 전용 페이지로 전환
-        if (pathname.includes('/trips/detail/')) {
-            const id = pathname.split('/').filter(Boolean).pop()
-            router.push(`/offline/trips/detail/?id=${id}&tab=plans`)
-        } else if (pathname.includes('/trips/checklist/')) {
-            const id = pathname.split('/').filter(Boolean).pop()
-            router.push(`/offline/trips/detail/?id=${id}&tab=checklist`)
-        } else {
-            router.push('/offline')
-        }
+        // 오프라인 모드 전환 시 항상 오프라인 홈으로 이동
+        router.push('/offline')
     }
 
     if (!isOpen) return null

--- a/src/components/common/PlanImage.tsx
+++ b/src/components/common/PlanImage.tsx
@@ -1,0 +1,455 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { ImageIcon } from 'lucide-react'
+import { css } from 'styled-system/css'
+import { useImageRecovery } from '@/hooks/useImageRecovery'
+import { canStoreNow } from '@/services/PlacePhotoService'
+
+/**
+ * PlanImage — Google Place Photo 영구 저장 컴포넌트
+ *
+ * 상태 머신 (6개):
+ *  - idle-empty        : image_url=null, photo_reference 있음, 신규(<5초). shimmer
+ *  - idle-placeholder  : image_url=null, 5초 경과 또는 photo_reference=null. static placeholder
+ *  - loading-img       : image_url 있음, onLoad/onError 대기. 빈 배경
+ *  - loading-recovery  : image_url 있음, onError 후 복구 API 호출 중. shimmer
+ *  - loaded            : 이미지 표시 (페이드인 1회)
+ *  - error-final       : 복구 실패 / 쿨다운 차단. static placeholder
+ *
+ * UX 설계 문서: _workspace/01b_ux_design.md
+ */
+
+type PlanImageState =
+    | 'idle-empty'
+    | 'idle-placeholder'
+    | 'loading-img'
+    | 'loading-recovery'
+    | 'loaded'
+    | 'error-final'
+
+export interface PlanImageProps {
+    planId: string
+    tripId: string
+    placeId?: string | null
+    imageUrl?: string | null
+    photoReference?: string | null
+    /** ISO 8601 문자열. 신규 생성 5초 이내인지 판정 */
+    createdAt?: string | null
+    variant: 'thumbnail' | 'hero'
+    /** plan.title 기반 (예: "{title} 장소 사진") */
+    alt: string
+    onRecovered?: (newUrl: string) => void
+    onRecoveryFailed?: () => void
+    /** 오프라인 모드 등에서 강제 비활성화 */
+    disableRecovery?: boolean
+    className?: string
+}
+
+const IDLE_EMPTY_TIMEOUT_MS = 5_000
+const SHIMMER_MIN_DURATION_MS = 400
+const FADE_IN_THUMBNAIL_MS = 240
+const FADE_IN_HERO_MS = 320
+
+const VARIANT_RADIUS: Record<PlanImageProps['variant'], string> = {
+    thumbnail: '12px',
+    hero: '0px',
+}
+
+const VARIANT_ICON_SIZE: Record<PlanImageProps['variant'], number> = {
+    thumbnail: 20,
+    hero: 32,
+}
+
+/** `prefers-reduced-motion: reduce` 감지 */
+function usePrefersReducedMotion(): boolean {
+    const [reduced, setReduced] = useState(false)
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.matchMedia) return
+        try {
+            const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+            setReduced(mq.matches)
+            const handler = (event: MediaQueryListEvent) => setReduced(event.matches)
+            if (typeof mq.addEventListener === 'function') {
+                mq.addEventListener('change', handler)
+                return () => mq.removeEventListener('change', handler)
+            }
+            // Safari legacy fallback
+            mq.addListener(handler)
+            return () => mq.removeListener(handler)
+        } catch (error) {
+            console.warn('[PlanImage] prefers-reduced-motion 감지 실패', error)
+            return undefined
+        }
+    }, [])
+
+    return reduced
+}
+
+/** createdAt 기준으로 신규(5초 이내) 여부와 남은 시간(ms) 계산 */
+function getNewnessInfo(createdAt: string | null | undefined): { isNew: boolean; remainingMs: number } {
+    if (!createdAt) return { isNew: false, remainingMs: 0 }
+    const created = new Date(createdAt).getTime()
+    if (Number.isNaN(created)) return { isNew: false, remainingMs: 0 }
+    const elapsed = Date.now() - created
+    if (elapsed >= IDLE_EMPTY_TIMEOUT_MS) return { isNew: false, remainingMs: 0 }
+    return { isNew: true, remainingMs: IDLE_EMPTY_TIMEOUT_MS - elapsed }
+}
+
+export function PlanImage(props: PlanImageProps) {
+    const {
+        planId,
+        tripId,
+        placeId,
+        imageUrl,
+        photoReference,
+        createdAt,
+        variant,
+        alt,
+        onRecovered,
+        onRecoveryFailed,
+        disableRecovery = false,
+        className,
+    } = props
+
+    const reducedMotion = usePrefersReducedMotion()
+    const { recover } = useImageRecovery()
+
+    /** 현재 렌더링 중인 URL (복구 후 갱신 시 변경) */
+    const [activeUrl, setActiveUrl] = useState<string | null>(imageUrl ?? null)
+    /** 신규 생성 5초 타임아웃 경과 여부 */
+    const [isNewnessExpired, setIsNewnessExpired] = useState<boolean>(() => {
+        return !getNewnessInfo(createdAt).isNew
+    })
+    /** 복구 시도 진행 중 여부 */
+    const [isRecovering, setIsRecovering] = useState(false)
+    /** 복구 시도 종료(성공/실패) 후 final 처리 여부 */
+    const [recoveryFailed, setRecoveryFailed] = useState(false)
+    /** 이미지 onLoad/onError 도달 여부 */
+    const [imgLoaded, setImgLoaded] = useState(false)
+    /** 자발 복구 요청 플래그 (image_url=null 케이스에서 shimmer 표시용) */
+    const [recoveryRequested, setRecoveryRequested] = useState(false)
+    /** 깜박임 방지: shimmer 표시 시작 시각 */
+    const recoveryStartedAtRef = useRef<number | null>(null)
+    /** 마운트 사이클 내 자발 트리거 1회 가드 */
+    const autoTriggerAttemptedRef = useRef(false)
+
+    /** 외부에서 imageUrl이 갱신되면 activeUrl 동기화 + 상태 리셋 */
+    useEffect(() => {
+        if (imageUrl === activeUrl) return
+        setActiveUrl(imageUrl ?? null)
+        setImgLoaded(false)
+        setRecoveryFailed(false)
+        setIsRecovering(false)
+        setRecoveryRequested(false)
+        recoveryStartedAtRef.current = null
+        autoTriggerAttemptedRef.current = false
+    }, [imageUrl, activeUrl])
+
+    /** createdAt 기반 idle-empty 타임아웃 처리 */
+    useEffect(() => {
+        const { isNew, remainingMs } = getNewnessInfo(createdAt)
+        if (!isNew) {
+            setIsNewnessExpired(true)
+            return
+        }
+        setIsNewnessExpired(false)
+        const timer = setTimeout(() => setIsNewnessExpired(true), remainingMs)
+        return () => clearTimeout(timer)
+    }, [createdAt])
+
+    /** 현재 상태 계산 (single source of truth) */
+    const state: PlanImageState = useMemo(() => {
+        if (recoveryFailed) return 'error-final'
+        if (isRecovering) return 'loading-recovery'
+        if (activeUrl) {
+            return imgLoaded ? 'loaded' : 'loading-img'
+        }
+        // image_url 없음 분기
+        if (disableRecovery) return 'idle-placeholder'
+        // 자발 복구가 예약/진행 중인 경우 → shimmer
+        if (recoveryRequested) return 'idle-empty'
+        if (!photoReference && !placeId) return 'idle-placeholder'
+        if (!photoReference) {
+            // photoReference는 없지만 placeId가 있어 서버 fallback 가능 — 신규 5초 동안만 shimmer
+            return isNewnessExpired ? 'idle-placeholder' : 'idle-empty'
+        }
+        if (isNewnessExpired) return 'idle-placeholder'
+        return 'idle-empty'
+    }, [activeUrl, imgLoaded, isRecovering, recoveryFailed, photoReference, placeId, disableRecovery, isNewnessExpired, recoveryRequested])
+
+    /** 이미지 onError → 복구 시도 트리거 */
+    const handleImgError = useCallback(async () => {
+        if (disableRecovery || !placeId) {
+            setRecoveryFailed(true)
+            onRecoveryFailed?.()
+            return
+        }
+        setIsRecovering(true)
+        recoveryStartedAtRef.current = Date.now()
+        try {
+            const result = await recover({ planId, tripId, placeId, photoReference })
+            // shimmer 최소 표시 시간 보장 (깜박임 방지)
+            const startedAt = recoveryStartedAtRef.current ?? Date.now()
+            const elapsed = Date.now() - startedAt
+            const wait = Math.max(0, SHIMMER_MIN_DURATION_MS - elapsed)
+            if (wait > 0) {
+                await new Promise<void>((resolve) => setTimeout(resolve, wait))
+            }
+            if (result?.imageUrl) {
+                setActiveUrl(result.imageUrl)
+                setImgLoaded(false)
+                setRecoveryFailed(false)
+                onRecovered?.(result.imageUrl)
+            } else {
+                setRecoveryFailed(true)
+                onRecoveryFailed?.()
+            }
+        } catch (error) {
+            // Zero Noise: 토스트 없이 콘솔 로그만
+            console.error('[PlanImage] recovery error', error)
+            setRecoveryFailed(true)
+            onRecoveryFailed?.()
+        } finally {
+            setIsRecovering(false)
+            recoveryStartedAtRef.current = null
+        }
+    }, [planId, tripId, placeId, photoReference, disableRecovery, recover, onRecovered, onRecoveryFailed])
+
+    /**
+     * image_url=null 자발 복구 트리거
+     * - 마운트 시점에 image_url=null && placeId 존재 시 자동으로 recover 호출
+     * - 단발성 보장 (autoTriggerAttemptedRef)
+     * - PlacePhotoService.canStoreNow + in-flight dedup으로 중복 차단
+     */
+    useEffect(() => {
+        if (disableRecovery) return
+        if (activeUrl) return
+        if (!placeId) return
+        if (!planId || !tripId) return
+        if (isRecovering || recoveryFailed) return
+        if (autoTriggerAttemptedRef.current) return
+        if (!canStoreNow(planId)) return
+
+        autoTriggerAttemptedRef.current = true
+
+        let cancelled = false
+        const run = async () => {
+            setIsRecovering(true)
+            setRecoveryRequested(true)
+            recoveryStartedAtRef.current = Date.now()
+            try {
+                const result = await recover({ planId, tripId, placeId, photoReference })
+                if (cancelled) return
+                const startedAt = recoveryStartedAtRef.current ?? Date.now()
+                const elapsed = Date.now() - startedAt
+                const wait = Math.max(0, SHIMMER_MIN_DURATION_MS - elapsed)
+                if (wait > 0) {
+                    await new Promise<void>((resolve) => setTimeout(resolve, wait))
+                }
+                if (cancelled) return
+                if (result?.imageUrl) {
+                    setActiveUrl(result.imageUrl)
+                    setImgLoaded(false)
+                    setRecoveryFailed(false)
+                    onRecovered?.(result.imageUrl)
+                } else {
+                    // 실패 시: photoReference 없으면 placeholder로 회귀(소프트), 있으면 error-final
+                    if (photoReference) {
+                        setRecoveryFailed(true)
+                        onRecoveryFailed?.()
+                    } else {
+                        setRecoveryRequested(false)
+                        onRecoveryFailed?.()
+                    }
+                }
+            } catch (error) {
+                console.error('[PlanImage] auto recovery error', error)
+                if (cancelled) return
+                setRecoveryFailed(true)
+                onRecoveryFailed?.()
+            } finally {
+                if (!cancelled) {
+                    setIsRecovering(false)
+                    recoveryStartedAtRef.current = null
+                }
+            }
+        }
+
+        void run()
+
+        return () => {
+            cancelled = true
+        }
+    }, [
+        activeUrl,
+        placeId,
+        planId,
+        tripId,
+        photoReference,
+        disableRecovery,
+        isRecovering,
+        recoveryFailed,
+        recover,
+        onRecovered,
+        onRecoveryFailed,
+    ])
+
+    /** 페이드인 duration (variant + reduced-motion 반영) */
+    const fadeInMs = reducedMotion ? 0 : variant === 'hero' ? FADE_IN_HERO_MS : FADE_IN_THUMBNAIL_MS
+
+    /** variant별 동적 스타일 (인라인 — Panda 정적 추출 보장) */
+    const containerInlineStyle = useMemo<React.CSSProperties>(
+        () => ({
+            borderRadius: VARIANT_RADIUS[variant],
+        }),
+        [variant],
+    )
+
+    /** loaded 상태일 때의 backgroundImage 동적 값 (인라인 처리) */
+    const loadedBackgroundStyle = useMemo<React.CSSProperties | undefined>(() => {
+        if (!activeUrl) return undefined
+        return { backgroundImage: `url("${activeUrl}")` }
+    }, [activeUrl])
+
+    return (
+        <div
+            className={[
+                css({
+                    position: 'relative',
+                    w: '100%',
+                    h: '100%',
+                    overflow: 'hidden',
+                    bg: 'bg.surfaceSoft',
+                }),
+                className,
+            ]
+                .filter(Boolean)
+                .join(' ')}
+            style={containerInlineStyle}
+            role={state === 'loaded' ? undefined : 'img'}
+            aria-label={state === 'loaded' ? undefined : getAriaLabel(state, alt)}
+            aria-busy={state === 'idle-empty' || state === 'loading-recovery' || state === 'loading-img'}
+        >
+            {/* 숨겨진 <img>로 로드/에러 감지 (loaded 상태에서만 backgroundImage 사용) */}
+            {activeUrl && !imgLoaded && !recoveryFailed && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                    key={activeUrl}
+                    src={activeUrl}
+                    alt=""
+                    aria-hidden="true"
+                    onLoad={() => setImgLoaded(true)}
+                    onError={handleImgError}
+                    className={css({
+                        position: 'absolute',
+                        width: '1px',
+                        height: '1px',
+                        opacity: 0,
+                        pointerEvents: 'none',
+                    })}
+                />
+            )}
+
+            <AnimatePresence mode="wait">
+                {(state === 'idle-empty' || state === 'loading-recovery') && (
+                    <motion.div
+                        key="shimmer"
+                        initial={reducedMotion ? false : { opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={reducedMotion ? undefined : { opacity: 0 }}
+                        transition={{ duration: reducedMotion ? 0 : 0.12, ease: 'easeOut' }}
+                        className={css({
+                            position: 'absolute',
+                            inset: 0,
+                            background:
+                                'linear-gradient(90deg, token(colors.bg.surfaceSoft) 25%, token(colors.brand.hairline) 50%, token(colors.bg.surfaceSoft) 75%)',
+                            backgroundSize: '200% 100%',
+                            animation: 'shimmer 2s infinite linear',
+                        })}
+                        style={reducedMotion ? { animation: 'none' } : undefined}
+                    />
+                )}
+
+                {(state === 'idle-placeholder' || state === 'error-final') && (
+                    <motion.div
+                        key="placeholder"
+                        initial={reducedMotion ? false : { opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={reducedMotion ? undefined : { opacity: 0 }}
+                        transition={{ duration: reducedMotion ? 0 : 0.16, ease: 'easeOut' }}
+                        className={css({
+                            position: 'absolute',
+                            inset: 0,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            bg: 'bg.surfaceSoft',
+                        })}
+                    >
+                        <ImageIcon
+                            size={VARIANT_ICON_SIZE[variant]}
+                            aria-hidden="true"
+                            className={css({ color: 'brand.muted' })}
+                        />
+                    </motion.div>
+                )}
+
+                {state === 'loaded' && activeUrl && (
+                    <motion.div
+                        key={`loaded-${activeUrl}`}
+                        initial={reducedMotion ? false : { opacity: 0, scale: 1.02 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={reducedMotion ? undefined : { opacity: 0 }}
+                        transition={{ duration: fadeInMs / 1000, ease: 'easeOut' }}
+                        className={css({
+                            position: 'absolute',
+                            inset: 0,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
+                            backgroundRepeat: 'no-repeat',
+                        })}
+                        style={loadedBackgroundStyle}
+                        role="img"
+                        aria-label={alt}
+                    />
+                )}
+
+                {state === 'loading-img' && (
+                    <motion.div
+                        key="loading-img"
+                        initial={false}
+                        animate={{ opacity: 1 }}
+                        exit={reducedMotion ? undefined : { opacity: 0 }}
+                        transition={{ duration: reducedMotion ? 0 : 0.12, ease: 'easeOut' }}
+                        className={css({
+                            position: 'absolute',
+                            inset: 0,
+                            bg: 'bg.surfaceSoft',
+                        })}
+                    />
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}
+
+function getAriaLabel(state: PlanImageState, alt: string): string {
+    switch (state) {
+        case 'idle-empty':
+            return '이미지 불러오는 중'
+        case 'loading-recovery':
+            return '이미지 복구 중'
+        case 'loading-img':
+            return '이미지 표시 준비 중'
+        case 'idle-placeholder':
+        case 'error-final':
+            return '장소 사진 없음'
+        default:
+            return alt
+    }
+}
+
+export default PlanImage

--- a/src/components/common/ToastContainer.tsx
+++ b/src/components/common/ToastContainer.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useToastStore, ToastType } from '@/stores/useToastStore'
+import { motion, AnimatePresence } from 'framer-motion'
+import { css } from 'styled-system/css'
+import { CheckCircle2, AlertCircle, Info, Loader2, X } from 'lucide-react'
+
+const getToastIcon = (type: ToastType) => {
+    switch (type) {
+        case 'success': return <CheckCircle2 size={18} className={css({ color: 'green.500' })} />
+        case 'error': return <AlertCircle size={18} className={css({ color: 'red.500' })} />
+        case 'loading': return <Loader2 size={18} className={css({ color: 'brand.primary', animation: 'spin 1s linear infinite' })} />
+        default: return <Info size={18} className={css({ color: 'blue.500' })} />
+    }
+}
+
+const getToastStyles = (type: ToastType) => {
+    return css({
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+        bg: 'white',
+        color: 'brand.ink',
+        px: '16px',
+        py: '12px',
+        borderRadius: '12px',
+        boxShadow: '0 8px 30px rgba(0,0,0,0.12)',
+        border: '1px solid',
+        borderColor: 'brand.hairline',
+        minW: '280px',
+        maxW: '90vw',
+        pointerEvents: 'auto',
+    })
+}
+
+export default function ToastContainer() {
+    const { toasts, removeToast } = useToastStore()
+
+    return (
+        <div className={css({
+            position: 'fixed',
+            bottom: 'max(24px, env(safe-area-inset-bottom) + 16px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 9999,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '10px',
+            pointerEvents: 'none',
+        })}>
+            <AnimatePresence>
+                {toasts.map((toast) => (
+                    <motion.div
+                        key={toast.id}
+                        initial={{ opacity: 0, y: 20, scale: 0.9 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.9, transition: { duration: 0.2 } }}
+                        className={getToastStyles(toast.type)}
+                    >
+                        {getToastIcon(toast.type)}
+                        <span className={css({ 
+                            fontSize: '14px', 
+                            fontWeight: '500',
+                            flex: 1,
+                            lineHeight: '1.4'
+                        })}>
+                            {toast.message}
+                        </span>
+                        {toast.type !== 'loading' && (
+                            <button 
+                                onClick={() => removeToast(toast.id)}
+                                className={css({ 
+                                    p: '4px',
+                                    borderRadius: '50%',
+                                    _hover: { bg: 'bg.surfaceSoft' },
+                                    color: 'brand.muted',
+                                    cursor: 'pointer'
+                                })}
+                            >
+                                <X size={14} />
+                            </button>
+                        )}
+                    </motion.div>
+                ))}
+            </AnimatePresence>
+
+            <style jsx global>{`
+                @keyframes spin {
+                    from { transform: rotate(0deg); }
+                    to { transform: rotate(360deg); }
+                }
+            `}</style>
+        </div>
+    )
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import { useRouter, usePathname } from 'next/navigation'
 import { css } from 'styled-system/css'
 import { createClient } from '@/utils/supabase/client'
-import { LogOut, Home, User, BookOpen, LogIn, UserPlus, ListTodo, ChevronLeft, ChevronDown, MessageSquareText } from 'lucide-react'
+import { LogOut, Home, User, BookOpen, LogIn, UserPlus, ListTodo, ChevronLeft, ChevronDown, MessageSquareText, WifiOff } from 'lucide-react'
 import { useUIStore } from '@/stores/useUIStore'
 import { useNetworkStore } from '@/stores/useNetworkStore'
 import { CacheUtil } from '@/utils/cache'
@@ -51,7 +51,8 @@ export default function Navbar() {
         isVisible: isBugReportVisible 
     } = useBugReport()
 
-    const { isOnline } = useNetworkStore()
+    const { isOnline, isOfflineMode } = useNetworkStore()
+    const isOffline = !isOnline || isOfflineMode
 
     useEffect(() => {
         const fetchUser = async () => {
@@ -141,6 +142,23 @@ export default function Navbar() {
                         <Image src="/logo.png" alt="온여정 로고" width={28} height={28} priority />
                         <span>온여정</span>
                     </Link>
+                    {isOffline && (
+                        <div className={css({ 
+                            display: 'flex', 
+                            alignItems: 'center', 
+                            gap: '4px', 
+                            bg: isOfflineMode ? 'brand.secondary' : 'brand.error', 
+                            color: 'white', 
+                            px: '10px', 
+                            py: '4px', 
+                            borderRadius: '12px', 
+                            fontSize: '11px', 
+                            fontWeight: '700' 
+                        })}>
+                            <WifiOff size={12} />
+                            {isOfflineMode ? '오프라인 모드' : '연결 끊김'}
+                        </div>
+                    )}
                 </div>
 
                 {/* 오른쪽: 메뉴 */}
@@ -243,6 +261,24 @@ export default function Navbar() {
                         <h1 className={css({ fontSize: '17px', fontWeight: 'bold', color: 'brand.ink', letterSpacing: '-0.01em' })}>
                             {pageTitle}
                         </h1>
+                        {isOffline && (
+                            <div className={css({ 
+                                display: 'flex', 
+                                alignItems: 'center', 
+                                gap: '4px', 
+                                bg: isOfflineMode ? 'brand.secondary' : 'brand.error', 
+                                color: 'white', 
+                                px: '8px', 
+                                py: '3px', 
+                                borderRadius: '10px', 
+                                fontSize: '10px', 
+                                fontWeight: '700',
+                                ml: '4px'
+                            })}>
+                                <WifiOff size={10} />
+                                {isOfflineMode ? '오프라인' : '연결 끊김'}
+                            </div>
+                        )}
                     </div>
                 )}
 

--- a/src/components/trips/NewPlanModal.tsx
+++ b/src/components/trips/NewPlanModal.tsx
@@ -6,8 +6,16 @@ import { css } from 'styled-system/css'
 import { X, MapPin, Clock, Calendar, Check, Search, ChevronRight, Loader2, Camera, Navigation, Map, Info, Compass, Bell } from 'lucide-react'
 import { useLoadScript, Autocomplete } from '@react-google-maps/api'
 import { LocationService, PlacePhotoService } from '@/services/ExternalApiService'
+import { uploadInBackground as uploadPlacePhotoInBackground } from '@/services/PlacePhotoService'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useScrollLock } from '@/hooks/useScrollLock'
+import type { Plan } from './PlanList'
+
+/**
+ * 편집 모드에서 NewPlanModal로 전달되는 plan 스냅샷.
+ * Plan의 부분 집합 + 옵셔널한 id를 허용한다.
+ */
+type EditDraft = Partial<Plan> & { id?: string }
 
 const libraries: ("places")[] = ["places"]
 
@@ -18,7 +26,12 @@ interface NewPlanModalProps {
     tripId: string
     tripStartDate?: string
     tripEndDate?: string
-    editData?: any
+    editData?: EditDraft
+    /**
+     * 백그라운드 업로드 완료 시 호출. (planId, newImageUrl).
+     * 부모가 plans 리스트의 해당 항목 image_url을 패치할 때 사용.
+     */
+    onPlanImageUpdated?: (planId: string, imageUrl: string) => void
 }
 
 // ── 핵심 타입 정의 ──
@@ -27,20 +40,24 @@ interface PlaceOption {
     address: string
     lat: number
     lng: number
+    /** 미리보기 URL (DB에 저장하지 않음) */
     photo?: string
+    /** Google photo_reference (영구 저장 키) */
+    photoReference?: string | null
     rating?: number
     type?: string
     googlePlaceId?: string
 }
 
-export default function NewPlanModal({ 
-    isOpen, 
-    onClose, 
-    onSuccess, 
-    tripId, 
-    tripStartDate = '', 
-    tripEndDate = '', 
-    editData 
+export default function NewPlanModal({
+    isOpen,
+    onClose,
+    onSuccess,
+    tripId,
+    tripStartDate = '',
+    tripEndDate = '',
+    editData,
+    onPlanImageUpdated,
 }: NewPlanModalProps) {
     const supabase = createClient()
     const [step, setStep] = useState(1) // 1: 장소검색, 2: 상세입력
@@ -118,6 +135,7 @@ export default function NewPlanModal({
                 lat: editData.location_lat || 0,
                 lng: editData.location_lng || 0,
                 photo: editData.image_url || undefined,
+                photoReference: editData.photo_reference ?? null,
                 googlePlaceId: editData.google_place_id || undefined,
             })
             
@@ -167,18 +185,23 @@ export default function NewPlanModal({
                 lat: place.geometry.location.lat(),
                 lng: place.geometry.location.lng(),
                 photo: undefined,
+                photoReference: null,
                 rating: place.rating,
                 type: place.types?.[0],
                 googlePlaceId: placeId
             })
             setStep(2)
 
-            // 서버사이드 API로 영구 사진 URL 비동기 조회
+            // 서버사이드 API로 미리보기 URL + photoReference(영구 저장 키) 동시 조회
             if (placeId) {
-                PlacePhotoService.getPhotoUrl(placeId).then(url => {
-                    if (url) {
-                        setSelectedPlace(prev => prev ? { ...prev, photo: url } : prev)
-                    }
+                PlacePhotoService.getPhoto(placeId).then(({ url, photoReference }) => {
+                    setSelectedPlace(prev => prev ? {
+                        ...prev,
+                        photo: url || prev.photo,
+                        photoReference: photoReference ?? prev.photoReference ?? null,
+                    } : prev)
+                }).catch(error => {
+                    console.warn('[NewPlanModal] photo metadata fetch failed', error)
                 })
             }
         }
@@ -199,17 +222,22 @@ export default function NewPlanModal({
                 lat: place.geometry.location.lat(),
                 lng: place.geometry.location.lng(),
                 photo: undefined,
+                photoReference: null,
                 rating: place.rating,
                 type: place.types?.[0],
                 googlePlaceId: placeId
             })
 
-            // 서버사이드 API로 영구 사진 URL 비동기 조회
+            // 서버사이드 API로 미리보기 URL + photoReference 조회
             if (placeId) {
-                PlacePhotoService.getPhotoUrl(placeId).then(url => {
-                    if (url) {
-                        setSelectedPlace(prev => prev ? { ...prev, photo: url } : prev)
-                    }
+                PlacePhotoService.getPhoto(placeId).then(({ url, photoReference }) => {
+                    setSelectedPlace(prev => prev ? {
+                        ...prev,
+                        photo: url || prev.photo,
+                        photoReference: photoReference ?? prev.photoReference ?? null,
+                    } : prev)
+                }).catch(error => {
+                    console.warn('[NewPlanModal] photo metadata fetch failed', error)
                 })
             }
         }
@@ -223,6 +251,7 @@ export default function NewPlanModal({
             lat: 0,
             lng: 0,
             photo: undefined,
+            photoReference: null,
             googlePlaceId: undefined
         })
         setStep(2)
@@ -258,7 +287,10 @@ export default function NewPlanModal({
             const locationToSave = customTitle.trim() ? selectedPlace.name : selectedPlace.address;
             const addressToSave = selectedPlace.address;
 
-            const planData = {
+            // 신규 흐름: image_url은 백그라운드 업로드 완료 시점에 채워짐.
+            // INSERT 시점에는 photo_reference(영구 저장 키)만 저장한다.
+            // 단, edit 모드에서 기존 image_url이 이미 Storage URL(영구)인 경우 보존한다.
+            const planData: Record<string, unknown> = {
                 trip_id: tripId,
                 title: titleToSave,
                 location: locationToSave,
@@ -266,7 +298,8 @@ export default function NewPlanModal({
                 location_lat: selectedPlace.lat || 0,
                 location_lng: selectedPlace.lng || 0,
                 google_place_id: selectedPlace.googlePlaceId,
-                image_url: selectedPlace.photo,
+                image_url: editData?.id ? editData.image_url ?? null : null,
+                photo_reference: selectedPlace.photoReference ?? null,
                 start_datetime_local: startStr,
                 end_datetime_local: endStr,
                 cost: cost ? parseFloat(cost) : 0,
@@ -275,19 +308,70 @@ export default function NewPlanModal({
                 timezone_string: tzData.timeZoneId || 'Asia/Seoul'
             }
 
-            let result;
+            let savedPlanId: string | null = null
             if (editData?.id) {
-                result = await supabase.from('plans').update(planData).eq('id', editData.id)
+                const result = await supabase
+                    .from('plans')
+                    .update(planData)
+                    .eq('id', editData.id)
+                    .select('id')
+                    .single()
+                if (result.error) throw result.error
+                savedPlanId = (result.data as { id?: string } | null)?.id ?? editData.id
             } else {
-                result = await supabase.from('plans').insert(planData)
+                const result = await supabase
+                    .from('plans')
+                    .insert(planData)
+                    .select('id')
+                    .single()
+                if (result.error) throw result.error
+                savedPlanId = (result.data as { id?: string } | null)?.id ?? null
             }
 
-            if (result.error) throw result.error
+            // 백그라운드 업로드 (fire-and-forget). photo_reference + placeId 모두 있을 때만 시도.
+            // 모달 close 이전에 시작해야 try/catch/finally가 의도대로 동작한다.
+            if (
+                savedPlanId &&
+                selectedPlace.photoReference &&
+                selectedPlace.googlePlaceId
+            ) {
+                try {
+                    uploadPlacePhotoInBackground(
+                        {
+                            planId: savedPlanId,
+                            tripId,
+                            placeId: selectedPlace.googlePlaceId,
+                            photoReference: selectedPlace.photoReference,
+                        },
+                        (imageUrl) => {
+                            // Zustand store가 plan-level에 없어, 부모에게 콜백으로 통지
+                            try {
+                                onPlanImageUpdated?.(savedPlanId as string, imageUrl)
+                            } catch (cbErr) {
+                                console.warn(
+                                    '[NewPlanModal] onPlanImageUpdated callback failed',
+                                    cbErr,
+                                )
+                            }
+                        },
+                    )
+                } catch (bgErr) {
+                    // Zero Noise: 백그라운드 업로드 실패는 토스트 없이 콘솔만
+                    console.warn('[NewPlanModal] background upload start failed', bgErr)
+                }
+            }
 
+            // 모든 sync 호출이 정상 종료된 뒤 모달을 닫는다.
+            // 이렇게 해야 INSERT/UPDATE 직후 발생할 수 있는 예외도 catch 블록에 도달하여
+            // 사용자에게 에러 메시지를 노출할 수 있다.
             onSuccess()
             onClose()
-        } catch (err: any) {
-            setError(err.message || '일정을 저장하는 중 오류가 발생했습니다.')
+        } catch (err: unknown) {
+            const message =
+                err instanceof Error
+                    ? err.message
+                    : '일정을 저장하는 중 오류가 발생했습니다.'
+            setError(message)
         } finally {
             setLoading(false)
         }

--- a/src/components/trips/PlanDetailModal.tsx
+++ b/src/components/trips/PlanDetailModal.tsx
@@ -12,6 +12,7 @@ import { useNetworkStore } from '@/stores/useNetworkStore'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useScrollLock } from '@/hooks/useScrollLock'
 import UrlPreviewCard from '@/components/common/UrlPreviewCard'
+import PlanImage from '@/components/common/PlanImage'
 // ── Main Modal ──
 interface PlanDetailModalProps {
     plan: any
@@ -24,11 +25,14 @@ interface PlanDetailModalProps {
     onEdit: (plan: any) => void
     onDelete: (id: string) => void
     onToggleVisit: (planId: string, isVisited: boolean) => void
+    /** PlanImage 복구 성공 시 호출. 부모(TripClient/RouteMapView) plans 동기화. */
+    onPlanImageRecovered?: (planId: string, newImageUrl: string) => void
 }
 
 export default function PlanDetailModal({
     plan, exchangeRates, formatLocalTime, formatKstTime, timeDisplayMode,
     userRole, onClose, onEdit, onDelete, onToggleVisit,
+    onPlanImageRecovered,
 }: PlanDetailModalProps) {
     const [tab, setTab] = useState<'info' | 'refs'>('info')
     const [mapError, setMapError] = useState(false)
@@ -123,24 +127,38 @@ export default function PlanDetailModal({
                 })}
             >
                 {/* ── 헤더 & 히어로 섹션 ── */}
-                <div className={css({ 
-                    position: 'relative', 
-                    h: plan.image_url ? { base: '240px', sm: '260px' } : { base: '140px', sm: '160px' },
+                <div className={css({
+                    position: 'relative',
+                    h: (plan.image_url || plan.photo_reference)
+                        ? { base: '240px', sm: '260px' }
+                        : { base: '140px', sm: '160px' },
                     flexShrink: 0,
                     overflow: 'hidden',
-                    bg: 'brand.primary',
+                    bg: 'bg.surfaceSoft',
                 })}>
-                    {plan.image_url && (
+                    {(plan.image_url || plan.photo_reference) && (
                         <>
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img 
-                                src={plan.image_url} 
-                                alt={plan.title} 
-                                className={css({ w: '100%', h: '100%', objectFit: 'cover' })} 
+                            <PlanImage
+                                planId={plan.id}
+                                tripId={plan.trip_id}
+                                placeId={plan.google_place_id}
+                                imageUrl={plan.image_url}
+                                photoReference={plan.photo_reference}
+                                createdAt={plan.created_at}
+                                variant="hero"
+                                alt={plan.title}
+                                onRecovered={(newUrl) => {
+                                    try {
+                                        onPlanImageRecovered?.(plan.id, newUrl)
+                                    } catch (err) {
+                                        console.warn('[PlanDetailModal] onPlanImageRecovered failed', err)
+                                    }
+                                }}
                             />
-                            <div className={css({ 
-                                position: 'absolute', inset: 0, 
-                                background: 'linear-gradient(to bottom, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0) 50%, rgba(0,0,0,0.7) 100%)' 
+                            <div className={css({
+                                position: 'absolute', inset: 0,
+                                background: 'linear-gradient(to bottom, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0) 50%, rgba(0,0,0,0.7) 100%)',
+                                pointerEvents: 'none',
                             })} />
                         </>
                     )}

--- a/src/components/trips/PlanList.tsx
+++ b/src/components/trips/PlanList.tsx
@@ -3,14 +3,18 @@
 import { css } from 'styled-system/css'
 import { Clock, CheckCircle2, Circle, Trash2, Edit3, Wallet, Bell, MapPin, FileText, Link2 } from 'lucide-react'
 import { getCurrencyFromTimezone, formatCurrency } from '@/utils/currency'
+import PlanImage from '@/components/common/PlanImage'
 
-interface Plan {
+export interface Plan {
     id: string
+    trip_id: string
     title: string
     location: string
     address: string
     lat: number
     lng: number
+    location_lat?: number
+    location_lng?: number
     visit_date?: string
     visit_time?: string
     start_datetime_local: string
@@ -18,14 +22,18 @@ interface Plan {
     alarm_minutes_before?: number
     cost: number
     memo: string
-    image_url: string
+    image_url: string | null
+    photo_reference?: string | null
+    google_place_id?: string | null
+    created_at?: string | null
     is_completed: boolean
     is_visited: boolean
     timezone_string: string
+    plan_urls?: Array<{ id?: string; url: string; title?: string | null }>
 }
 
 interface PlanListProps {
-    plans: any[]
+    plans: Plan[]
     exchangeRates: Record<string, number>
     activeDropdown: string | null
     setActiveDropdown: (id: string | null) => void
@@ -33,10 +41,12 @@ interface PlanListProps {
     timeDisplayMode: 'local' | 'kst' | 'both'
     formatLocalTime: (date: string) => string
     formatKstTime: (date: string, tz: string) => string
-    onEdit: (plan: any) => void
+    onEdit: (plan: Plan) => void
     onDelete: (id: string) => void
-    onDetail: (plan: any) => void
+    onDetail: (plan: Plan) => void
     onToggleVisit: (planId: string, isVisited: boolean) => void
+    /** PlanImage 복구 성공 시 호출. 부모가 plans 리스트 image_url을 동기화. */
+    onPlanImageRecovered?: (planId: string, newImageUrl: string) => void
 }
 
 export default function PlanList({
@@ -51,7 +61,8 @@ export default function PlanList({
     onEdit,
     onDelete,
     onDetail,
-    onToggleVisit
+    onToggleVisit,
+    onPlanImageRecovered,
 }: PlanListProps) {
     if (!plans || plans.length === 0) {
         return (
@@ -64,7 +75,7 @@ export default function PlanList({
     }
 
     // 날짜별 그룹화 (start_datetime_local 기준)
-    const groupedPlans = plans.reduce((groups: Record<string, any[]>, plan) => {
+    const groupedPlans = plans.reduce<Record<string, Plan[]>>((groups, plan) => {
         const date = plan.start_datetime_local.split('T')[0]
         if (!groups[date]) groups[date] = []
         groups[date].push(plan)
@@ -126,6 +137,7 @@ export default function PlanList({
                                     onDelete={onDelete}
                                     onDetail={onDetail}
                                     onToggleVisit={onToggleVisit}
+                                    onPlanImageRecovered={onPlanImageRecovered}
                                 />
                             </div>
                         ))}
@@ -146,18 +158,20 @@ function PlanCard({
     onEdit,
     onDelete,
     onDetail,
-    onToggleVisit
+    onToggleVisit,
+    onPlanImageRecovered,
 }: {
-    plan: any
+    plan: Plan
     exchangeRates: Record<string, number>
     userRole: 'owner' | 'editor' | 'viewer' | null
     timeDisplayMode: 'local' | 'kst' | 'both'
     formatLocalTime: (date: string) => string
     formatKstTime: (date: string, tz: string) => string
-    onEdit: (plan: any) => void
+    onEdit: (plan: Plan) => void
     onDelete: (id: string) => void
-    onDetail: (plan: any) => void
+    onDetail: (plan: Plan) => void
     onToggleVisit: (planId: string, isVisited: boolean) => void
+    onPlanImageRecovered?: (planId: string, newImageUrl: string) => void
 }) {
     const currency = getCurrencyFromTimezone(plan.timezone_string || 'Asia/Seoul')
     const rate = exchangeRates[currency.code]
@@ -177,17 +191,33 @@ function PlanCard({
                 _hover: { boxShadow: 'airbnbHover', borderColor: 'transparent', transform: 'translateY(-2px)' },
             })}
         >
-            {/* 왼쪽: 라운드 썸네일 */}
-            {plan.image_url && (
-                <div
-                    className={css({
-                        w: '68px', flexShrink: 0, borderRadius: '12px',
-                        backgroundSize: 'cover', backgroundPosition: 'center',
-                        alignSelf: 'stretch',
-                    })}
-                    style={{ backgroundImage: `url("${plan.image_url}")` }}
+            {/* 왼쪽: 라운드 썸네일 (PlanImage가 6개 상태 모두 처리) */}
+            <div
+                className={css({
+                    w: '68px',
+                    flexShrink: 0,
+                    alignSelf: 'stretch',
+                    minH: '68px',
+                })}
+            >
+                <PlanImage
+                    planId={plan.id}
+                    tripId={plan.trip_id}
+                    placeId={plan.google_place_id}
+                    imageUrl={plan.image_url}
+                    photoReference={plan.photo_reference}
+                    createdAt={plan.created_at}
+                    variant="thumbnail"
+                    alt={`${plan.title} 장소 사진`}
+                    onRecovered={(newUrl) => {
+                        try {
+                            onPlanImageRecovered?.(plan.id, newUrl)
+                        } catch (err) {
+                            console.warn('[PlanList] onPlanImageRecovered failed', err)
+                        }
+                    }}
                 />
-            )}
+            </div>
 
             {/* 오른쪽: 콘텐츠 */}
             <div className={css({ flex: 1, minW: 0, display: 'flex', flexDirection: 'column', gap: '6px' })}>
@@ -198,7 +228,7 @@ function PlanCard({
                         overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minW: 0,
                         textDecoration: plan.is_visited ? 'line-through' : 'none',
                     })}>{plan.title}</h4>
-                    {plan.alarm_minutes_before > 0 && (
+                    {(plan.alarm_minutes_before ?? 0) > 0 && (
                         <Bell size={13} className={css({ color: 'orange.500', flexShrink: 0 })} fill="currentColor" />
                     )}
                     {hasMemo && <FileText size={13} className={css({ color: 'brand.muted', flexShrink: 0 })} />}

--- a/src/components/trips/RouteMapView.tsx
+++ b/src/components/trips/RouteMapView.tsx
@@ -10,6 +10,7 @@ import { useNetworkStore } from '@/stores/useNetworkStore'
 import { collaboration } from '@/utils/collaboration'
 import { getCurrencyFromTimezone } from '@/utils/currency'
 import { ExchangeService } from '@/services/ExternalApiService'
+import { PlanPhotoStorageService } from '@/services/PlanPhotoStorageService'
 import RouteMapInfoModal from '@/components/trips/RouteMapInfoModal'
 import PlanDetailModal from '@/components/trips/PlanDetailModal'
 import NewPlanModal from '@/components/trips/NewPlanModal'
@@ -25,6 +26,7 @@ const MAP_CONTAINER_STYLE = { width: '100%', height: '100%' }
 
 interface Plan {
     id: string
+    trip_id?: string
     title: string
     location?: string
     address?: string
@@ -36,6 +38,9 @@ interface Plan {
     location_lng?: number
     google_place_id?: string
     timezone_string?: string
+    image_url?: string | null
+    photo_reference?: string | null
+    created_at?: string | null
 }
 
 interface RouteMapViewProps {
@@ -364,14 +369,32 @@ export default function RouteMapView({
     const handleDeletePlan = useCallback(
         async (planId: string) => {
             if (!confirm('이 일정을 삭제하시겠습니까?')) return
+            if (tripId) {
+                // best-effort: Storage cleanup 실패해도 plan DELETE는 계속 진행
+                try {
+                    await PlanPhotoStorageService.cleanupPlanPhotos({ tripId, planId })
+                } catch (cleanupErr) {
+                    console.warn('[RouteMapView] cleanupPlanPhotos failed (ignored)', cleanupErr)
+                }
+            }
             const { error } = await supabase.from('plans').delete().eq('id', planId)
             if (!error) {
                 setPlans(prev => prev.filter(p => p.id !== planId))
                 setDetailPlan(null)
             }
         },
-        [supabase]
+        [supabase, tripId]
     )
+
+    /** 백그라운드/on-demand 업로드 성공 시 plans 동기화 */
+    const handlePlanImageRecovered = useCallback((planId: string, newImageUrl: string) => {
+        setPlans(prev => prev.map(p => (
+            p.id === planId ? ({ ...p, image_url: newImageUrl } as Plan) : p
+        )))
+        setDetailPlan(cur => (
+            cur && cur.id === planId ? ({ ...cur, image_url: newImageUrl } as Plan) : cur
+        ))
+    }, [])
 
     // Offline fallback
     if (!isOnline) {
@@ -567,6 +590,7 @@ export default function RouteMapView({
                     onEdit={handleEditPlan}
                     onDelete={handleDeletePlan}
                     onToggleVisit={handleToggleVisit}
+                    onPlanImageRecovered={handlePlanImageRecovered}
                 />
             )}
 
@@ -580,6 +604,7 @@ export default function RouteMapView({
                     editData={editingPlan}
                     tripStartDate={tripStartDate}
                     tripEndDate={tripEndDate}
+                    onPlanImageUpdated={handlePlanImageRecovered}
                 />
             )}
 

--- a/src/components/trips/TripHeaderActions.tsx
+++ b/src/components/trips/TripHeaderActions.tsx
@@ -4,13 +4,14 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { css } from 'styled-system/css'
-import { Calendar, Users, Pencil, Trash2, Wallet, Loader2, Download, Check } from 'lucide-react'
+import { Calendar, Users, Pencil, Trash2, Wallet, Loader2, CloudDownload, CloudCheck } from 'lucide-react'
 import { getCurrencyFromTimezone, formatKRW } from '@/utils/currency'
 import { formatDate } from '@/utils/date'
 import { ExchangeService } from '@/services/ExternalApiService'
 import { DownloadService } from '@/services/DownloadService'
 import { Capacitor } from '@capacitor/core'
 import EditTripModal from './EditTripModal'
+import { useToastStore } from '@/stores/useToastStore'
 
 interface TripHeaderActionsProps {
     trip: {
@@ -29,6 +30,7 @@ interface TripHeaderActionsProps {
 export default function TripHeaderActions({ trip, onUpdate, isOffline = false }: TripHeaderActionsProps) {
     const router = useRouter()
     const supabase = createClient()
+    const toast = useToastStore()
 
     const [isOwner, setIsOwner] = useState(false)
     const [showEditModal, setShowEditModal] = useState(false)
@@ -61,12 +63,16 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
     const handleDownload = async () => {
         if (isDownloading) return
         setIsDownloading(true)
+        const loadingId = toast.loading('여행 정보를 다운로드하는 중입니다...')
         try {
             await DownloadService.downloadTrip(trip.id)
             setIsDownloaded(true)
+            toast.removeToast(loadingId)
+            toast.success('여행 정보가 성공적으로 다운로드되었습니다. 이제 오프라인에서도 확인할 수 있습니다!')
         } catch (error) {
             console.error('Download failed:', error)
-            alert('다운로드에 실패했습니다.')
+            toast.removeToast(loadingId)
+            toast.error('다운로드에 실패했습니다. 네트워크 상태를 확인해 주세요.')
         } finally {
             setIsDownloading(false)
         }
@@ -182,56 +188,59 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
                         {trip.destination} 여행
                     </h1>
 
-                    {isOwner && !isOffline && (
+                    {!isOffline && (
                         <div className={css({ display: 'flex', gap: '8px', flexShrink: 0 })}>
-                            {isNative && (
-                                <button
-                                    onClick={handleDownload}
-                                    disabled={isDownloading}
-                                    className={css({
-                                        display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                        p: '8px', bg: isDownloaded ? 'rgba(37, 99, 235, 0.1)' : 'white', 
-                                        color: isDownloaded ? 'brand.primary' : 'brand.muted', 
-                                        border: '1.5px solid', borderColor: isDownloaded ? 'brand.primary' : 'brand.border', 
-                                        borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s',
-                                        _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' },
-                                        _active: { transform: 'scale(0.92)' }
-                                    })}
-                                    title={isDownloaded ? "다운로드됨" : "오프라인 다운로드"}
-                                >
-                                    {isDownloading ? (
-                                        <Loader2 size={18} className={css({ animation: 'spin 1s linear infinite' })} />
-                                    ) : isDownloaded ? (
-                                        <Check size={18} />
-                                    ) : (
-                                        <Download size={18} />
-                                    )}
-                                </button>
+                            <button
+                                onClick={handleDownload}
+                                disabled={isDownloading}
+                                className={css({
+                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                    p: '8px', bg: isDownloaded ? 'rgba(46, 196, 182, 0.05)' : 'white', 
+                                    color: isDownloaded ? 'brand.primary' : 'brand.muted', 
+                                    border: '1.5px solid', borderColor: isDownloaded ? 'brand.primary' : 'brand.border', 
+                                    borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s',
+                                    _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' },
+                                    _active: { transform: 'scale(0.92)' }
+                                })}
+                                title={isDownloaded ? "다운로드됨" : "오프라인 다운로드"}
+                            >
+                                {isDownloading ? (
+                                    <Loader2 size={18} className={css({ animation: 'spin 1s linear infinite' })} />
+                                ) : isDownloaded ? (
+                                    <CloudCheck size={18} />
+                                ) : (
+                                    <CloudDownload size={18} />
+                                )}
+                            </button>
+
+                            {isOwner && (
+                                <>
+                                    <button
+                                        onClick={() => setShowEditModal(true)}
+                                        className={css({
+                                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                            p: '8px', bg: 'white', color: 'brand.muted', border: '1.5px solid', borderColor: 'brand.border', borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s', 
+                                            _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' }, 
+                                            _active: { transform: 'scale(0.92)' }
+                                        })}
+                                        title="여행 수정"
+                                    >
+                                        <Pencil size={18} />
+                                    </button>
+                                    <button
+                                        onClick={() => setShowDeleteConfirm(true)}
+                                        className={css({
+                                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                            p: '8px', bg: 'white', color: 'brand.muted', border: '1.5px solid', borderColor: 'brand.border', borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s', 
+                                            _hover: { bg: 'brand.errorLight', color: 'brand.error', borderColor: 'brand.error' }, 
+                                            _active: { transform: 'scale(0.92)' }
+                                        })}
+                                        title="여행 삭제"
+                                    >
+                                        <Trash2 size={18} />
+                                    </button>
+                                </>
                             )}
-                            <button
-                                onClick={() => setShowEditModal(true)}
-                                className={css({
-                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                    p: '8px', bg: 'white', color: 'brand.muted', border: '1.5px solid', borderColor: 'brand.border', borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s', 
-                                    _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' }, 
-                                    _active: { transform: 'scale(0.92)' }
-                                })}
-                                title="여행 수정"
-                            >
-                                <Pencil size={18} />
-                            </button>
-                            <button
-                                onClick={() => setShowDeleteConfirm(true)}
-                                className={css({
-                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                    p: '8px', bg: 'white', color: 'brand.muted', border: '1.5px solid', borderColor: 'brand.border', borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s', 
-                                    _hover: { bg: 'brand.errorLight', color: 'brand.error', borderColor: 'brand.error' }, 
-                                    _active: { transform: 'scale(0.92)' }
-                                })}
-                                title="여행 삭제"
-                            >
-                                <Trash2 size={18} />
-                            </button>
                         </div>
                     )}
                 </div>

--- a/src/hooks/useImageRecovery.ts
+++ b/src/hooks/useImageRecovery.ts
@@ -1,0 +1,88 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import { storePhoto, isStoring } from '@/services/PlacePhotoService'
+
+/**
+ * 이미지 복구 훅 — Google Place Photo 영구 저장 진입점.
+ *
+ * 책임:
+ *  - PlanImage(onError) 트리거 시 `POST /api/places/photo/store` 호출
+ *  - 모듈 스코프(PlacePhotoService)에 위임하여 in-flight dedup + cooldown 적용
+ *  - 성공 시 imageUrl 반환. 실패는 null 반환 (Zero Noise)
+ *  - 410 (photo_reference 만료) 시에도 null 반환 — 호출자(PlanImage)는
+ *    `error-final`로 자동 귀결됨
+ *
+ * 비고:
+ *  - Zustand store 갱신은 본 훅에서 직접 수행하지 않는다.
+ *    PlanImage의 onRecovered 콜백에서 호출자가 처리한다 (UX 설계 9.x 참조).
+ */
+
+export interface RecoverParams {
+    planId: string
+    tripId: string
+    placeId?: string | null
+    photoReference?: string | null
+}
+
+export interface RecoverResult {
+    imageUrl: string
+}
+
+export interface UseImageRecoveryReturn {
+    recover: (params: RecoverParams) => Promise<RecoverResult | null>
+    isRecovering: boolean
+    isRecoveringFor: (planId: string) => boolean
+}
+
+export function useImageRecovery(): UseImageRecoveryReturn {
+    const [isRecovering, setIsRecovering] = useState(false)
+    const inFlightRef = useRef<boolean>(false)
+
+    const recover = useCallback(
+        async (params: RecoverParams): Promise<RecoverResult | null> => {
+            const { planId, tripId, placeId, photoReference } = params
+
+            // 필수 필드 검증 — photoReference는 서버 fallback이 처리하므로 optional
+            if (!planId || !tripId || !placeId) {
+                return null
+            }
+
+            // 동일 훅 인스턴스 dedup (PlanImage가 한 카드에서 onError가 빠르게 두 번 발생할 수 있음)
+            if (inFlightRef.current) return null
+
+            inFlightRef.current = true
+            setIsRecovering(true)
+            try {
+                const result = await storePhoto({
+                    planId,
+                    tripId,
+                    placeId,
+                    photoReference,
+                })
+
+                if (result.ok) {
+                    return { imageUrl: result.imageUrl }
+                }
+                // 실패 — 모든 사유에 대해 null 반환. cooldown은 모듈 스코프가 관리.
+                return null
+            } catch (error) {
+                // 예외는 service에서 잡지만, 방어적으로 처리
+                console.error('[useImageRecovery] unexpected error', error)
+                return null
+            } finally {
+                inFlightRef.current = false
+                setIsRecovering(false)
+            }
+        },
+        [],
+    )
+
+    const isRecoveringFor = useCallback((planId: string) => {
+        return isStoring(planId)
+    }, [])
+
+    return { recover, isRecovering, isRecoveringFor }
+}
+
+export default useImageRecovery

--- a/src/hooks/useOTAUpdate.ts
+++ b/src/hooks/useOTAUpdate.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { CapacitorUpdater } from '@capgo/capacitor-updater';
 import { App } from '@capacitor/app';
 import { SplashScreen } from '@capacitor/splash-screen';
+import { Network } from '@capacitor/network';
 import { createClient } from '@/utils/supabase/client';
 
 const supabase = createClient();
@@ -16,7 +17,15 @@ export function useOTAUpdate() {
   useEffect(() => {
     const checkUpdate = async () => {
       try {
-        // 1. Notify that the current app is ready (prevent rollback)
+        // 1. Check network status - skip if offline
+        const networkStatus = await Network.getStatus();
+        if (!networkStatus.connected) {
+          console.log('Offline: Skipping OTA update check');
+          setStatus('idle');
+          return;
+        }
+
+        // 2. Notify that the current app is ready (prevent rollback)
         await CapacitorUpdater.notifyAppReady();
 
         setStatus('checking');

--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -41,12 +41,16 @@ export const DownloadService = {
             if (tripErr || !trip) throw new Error('Trip not found')
 
             // 2. 일정 정보 (Plan + PlanURLs)
+            //    NOTE: plans.image_url 은 영구 저장 전환(이슈 #184) 이후 Supabase Storage publicUrl만 들어간다.
+            //          만료 가능한 Google CDN URL 은 더 이상 image_url 에 저장되지 않으므로 캐시 안전.
+            //          단, photo_reference 만 있고 백그라운드 업로드가 미완료인 plan 은 image_url=null로 캐시되며
+            //          오프라인에서는 PlanImage 가 placeholder로 표시된다 (정상 동작).
             const { data: plans, error: plansErr } = await supabase
                 .from('plans')
                 .select('*, plan_urls(*)')
                 .eq('trip_id', tripId)
                 .order('start_datetime_local', { ascending: true })
-            
+
             if (plansErr) throw new Error('Plans fetch failed')
 
             // 3. 체크리스트 정보

--- a/src/services/ExternalApiService.ts
+++ b/src/services/ExternalApiService.ts
@@ -66,18 +66,35 @@ export const LocationService = {
 
 /**
  * Google Places 사진 서비스
+ *
+ * `getPhoto`: 미리보기 URL과 영구 저장에 필요한 `photoReference`를 동시에 반환.
  */
+export interface PlacePhotoResponse {
+  url: string | null;
+  photoReference: string | null;
+}
+
 export const PlacePhotoService = {
-  getPhotoUrl: async (placeId: string, maxwidth = 400): Promise<string | null> => {
+  /**
+   * 미리보기 URL + photoReference 동시 조회.
+   * NewPlanModal이 plans INSERT 시 `photo_reference` 컬럼에 저장하기 위한 용도.
+   */
+  getPhoto: async (
+    placeId: string,
+    maxwidth = 400,
+  ): Promise<PlacePhotoResponse> => {
     try {
-      const response = await apiService.get<{ url: string | null }>('/api/places/photo/', {
+      const response = await apiService.get<PlacePhotoResponse>('/api/places/photo/', {
         placeId,
         maxwidth: String(maxwidth),
       });
-      return response.data.url || null;
+      return {
+        url: response.data?.url ?? null,
+        photoReference: response.data?.photoReference ?? null,
+      };
     } catch (error) {
-      console.error('[PlacePhotoService] Failed to fetch photo URL:', error);
-      return null;
+      console.error('[PlacePhotoService] Failed to fetch photo metadata:', error);
+      return { url: null, photoReference: null };
     }
   }
 };

--- a/src/services/PlacePhotoService.ts
+++ b/src/services/PlacePhotoService.ts
@@ -1,0 +1,216 @@
+import { Capacitor, CapacitorHttp } from '@capacitor/core'
+
+/**
+ * PlacePhotoService
+ * - Google Place Photo의 영구 저장(Supabase Storage) 흐름 진입점.
+ * - 모듈 스코프에서 in-flight dedup과 cooldown을 관리하여 동일 plan에 대한
+ *   중복 호출을 차단한다.
+ *
+ * 주의:
+ *  - 직접 `POST /api/places/photo/store` 호출 (인증 쿠키 동반).
+ *  - 모바일(Capacitor) 환경에서는 CapacitorHttp 사용 (절대 경로).
+ *  - 실패는 silent (콘솔 로그만). 호출자(훅/모달)는 onRecovered 콜백을 통해
+ *    성공 시 상태를 갱신한다.
+ */
+
+export interface StorePhotoParams {
+    planId: string
+    tripId: string
+    placeId?: string | null
+    photoReference?: string | null
+}
+
+export interface StorePhotoResult {
+    /** Storage publicUrl (성공 시) */
+    imageUrl: string
+}
+
+/** 410 응답 시 사용. photo_reference 만료 */
+const PHOTO_REFERENCE_EXPIRED_COOLDOWN_MS = 24 * 60 * 60 * 1000 // 24h
+/** 그 외 5xx/네트워크 실패 시 사용 */
+const TRANSIENT_FAILURE_COOLDOWN_MS = 5 * 60 * 1000 // 5분
+
+const inFlight: Set<string> = new Set()
+const lastFailedAt: Map<string, { at: number; cooldownMs: number }> = new Map()
+
+function isCoolingDown(planId: string): boolean {
+    const entry = lastFailedAt.get(planId)
+    if (!entry) return false
+    if (Date.now() - entry.at >= entry.cooldownMs) {
+        lastFailedAt.delete(planId)
+        return false
+    }
+    return true
+}
+
+function getStoreUrl(): string {
+    const base = process.env.NEXT_PUBLIC_APP_URL || ''
+    if (Capacitor.isNativePlatform()) {
+        // Native: 절대 경로 필요
+        return `${base}/api/places/photo/store`
+    }
+    return '/api/places/photo/store'
+}
+
+/** in-flight + cooldown 체크 (사이드 이펙트 없음) */
+export function canStoreNow(planId: string): boolean {
+    if (!planId) return false
+    if (inFlight.has(planId)) return false
+    if (isCoolingDown(planId)) return false
+    return true
+}
+
+/** 진행 중 여부 (UI 표시용) */
+export function isStoring(planId: string): boolean {
+    return !!planId && inFlight.has(planId)
+}
+
+/**
+ * `POST /api/places/photo/store` 호출.
+ * - 성공: { imageUrl }
+ * - 410: photo_reference 만료 → 장기 cooldown 기록 후 'expired' 반환
+ * - 그 외 실패: 단기 cooldown 기록 후 'transient' 반환
+ *
+ * 호출자가 await 가능. 백그라운드 호출 측에서는 `void` 처리하여 fire-and-forget.
+ */
+export async function storePhoto(
+    params: StorePhotoParams,
+): Promise<
+    | { ok: true; imageUrl: string }
+    | { ok: false; reason: 'invalid' | 'cooldown' | 'expired' | 'transient' }
+> {
+    const { planId, tripId, placeId, photoReference } = params
+
+    // photoReference는 optional — 서버가 placeId로 Places Details fallback 수행
+    if (!planId || !tripId || !placeId) {
+        return { ok: false, reason: 'invalid' }
+    }
+    if (inFlight.has(planId)) {
+        return { ok: false, reason: 'cooldown' }
+    }
+    if (isCoolingDown(planId)) {
+        return { ok: false, reason: 'cooldown' }
+    }
+
+    inFlight.add(planId)
+    try {
+        const url = getStoreUrl()
+        const normalizedPhotoReference = photoReference ?? null
+        const body = JSON.stringify({
+            planId,
+            tripId,
+            placeId,
+            photoReference: normalizedPhotoReference,
+        })
+
+        let status = 0
+        let payload: StorePhotoResult | { error?: string } = {}
+
+        if (Capacitor.isNativePlatform()) {
+            try {
+                const res = await CapacitorHttp.request({
+                    url,
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    data: {
+                        planId,
+                        tripId,
+                        placeId,
+                        photoReference: normalizedPhotoReference,
+                    },
+                    connectTimeout: 15000,
+                    readTimeout: 15000,
+                })
+                status = res.status
+                payload = (res.data as StorePhotoResult) ?? {}
+            } catch (err) {
+                console.warn('[PlacePhotoService] native request failed', err)
+                lastFailedAt.set(planId, {
+                    at: Date.now(),
+                    cooldownMs: TRANSIENT_FAILURE_COOLDOWN_MS,
+                })
+                return { ok: false, reason: 'transient' }
+            }
+        } else {
+            try {
+                const controller = new AbortController()
+                const timer = setTimeout(() => controller.abort(), 15000)
+                let res: Response
+                try {
+                    res = await fetch(url, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body,
+                        credentials: 'same-origin',
+                        signal: controller.signal,
+                    })
+                } finally {
+                    clearTimeout(timer)
+                }
+                status = res.status
+                payload = await res.json().catch(() => ({}))
+            } catch (err) {
+                console.warn('[PlacePhotoService] fetch failed', err)
+                lastFailedAt.set(planId, {
+                    at: Date.now(),
+                    cooldownMs: TRANSIENT_FAILURE_COOLDOWN_MS,
+                })
+                return { ok: false, reason: 'transient' }
+            }
+        }
+
+        if (status === 200 && (payload as StorePhotoResult).imageUrl) {
+            return { ok: true, imageUrl: (payload as StorePhotoResult).imageUrl }
+        }
+
+        if (status === 410) {
+            lastFailedAt.set(planId, {
+                at: Date.now(),
+                cooldownMs: PHOTO_REFERENCE_EXPIRED_COOLDOWN_MS,
+            })
+            return { ok: false, reason: 'expired' }
+        }
+
+        lastFailedAt.set(planId, {
+            at: Date.now(),
+            cooldownMs: TRANSIENT_FAILURE_COOLDOWN_MS,
+        })
+        return { ok: false, reason: 'transient' }
+    } finally {
+        inFlight.delete(planId)
+    }
+}
+
+/**
+ * 백그라운드 업로드 (fire-and-forget).
+ * - await 하지 않음. 호출자는 즉시 다음 동작으로 진행 가능.
+ * - 성공 시 `onSuccess` 콜백을 통해 imageUrl 전달.
+ * - 실패는 silent (콘솔 로그만).
+ */
+export function uploadInBackground(
+    params: StorePhotoParams,
+    onSuccess?: (imageUrl: string) => void,
+): void {
+    if (!canStoreNow(params.planId)) return
+    storePhoto(params)
+        .then(result => {
+            if (result.ok && onSuccess) {
+                try {
+                    onSuccess(result.imageUrl)
+                } catch (err) {
+                    console.warn('[PlacePhotoService] onSuccess callback failed', err)
+                }
+            }
+        })
+        .catch(err => {
+            // Zero Noise: 토스트 없이 콘솔 로그만
+            console.warn('[PlacePhotoService] background upload failed', err)
+        })
+}
+
+export const PlacePhotoStoreService = {
+    storePhoto,
+    uploadInBackground,
+    canStoreNow,
+    isStoring,
+}

--- a/src/services/PlanPhotoStorageService.ts
+++ b/src/services/PlanPhotoStorageService.ts
@@ -1,0 +1,103 @@
+import { createClient } from '@/utils/supabase/client'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * PlanPhotoStorageService
+ * - place-photos 버킷 내 plan 관련 객체의 cleanup을 담당.
+ * - plan 삭제 흐름에서 best-effort로 호출하며, 실패해도 plan 삭제 자체는 진행한다.
+ *
+ * 경로 규칙: place-photos/{user_id}/{trip_id}/{plan_id}_{placeIdHash8}.jpg
+ *
+ * 권한: RLS에 의해 본인 폴더(user_id == auth.uid()) 객체만 삭제 가능.
+ */
+class PlanPhotoStorageServiceImpl {
+    private static instance: PlanPhotoStorageServiceImpl
+    private readonly bucket = 'place-photos'
+
+    private constructor() {}
+
+    static getInstance(): PlanPhotoStorageServiceImpl {
+        if (!PlanPhotoStorageServiceImpl.instance) {
+            PlanPhotoStorageServiceImpl.instance = new PlanPhotoStorageServiceImpl()
+        }
+        return PlanPhotoStorageServiceImpl.instance
+    }
+
+    /**
+     * plan 삭제 전후로 호출. {user_id}/{trip_id}/ 폴더에서 {plan_id}_ 로 시작하는 객체를 일괄 삭제.
+     *
+     * @param params.tripId  trip id (경로 구성에 필요)
+     * @param params.planId  plan id (파일명 접두어)
+     * @returns 삭제된 객체 수 (실패 시 0)
+     *
+     * 실패는 best-effort: 절대 throw 하지 않음. 호출 측 plan DELETE는 계속 진행.
+     */
+    async cleanupPlanPhotos(params: { tripId: string; planId: string }): Promise<number> {
+        const { tripId, planId } = params
+        if (!tripId || !planId) {
+            return 0
+        }
+
+        try {
+            const supabase: SupabaseClient = createClient()
+
+            // 1) 현재 사용자 식별
+            const {
+                data: { user },
+                error: authError,
+            } = await supabase.auth.getUser()
+            if (authError || !user) {
+                console.warn('[PlanPhotoStorageService] cleanup skipped: unauthenticated')
+                return 0
+            }
+
+            const folder = `${user.id}/${tripId}`
+
+            // 2) 폴더 내 객체 목록 조회
+            const { data: list, error: listError } = await supabase.storage
+                .from(this.bucket)
+                .list(folder, { limit: 100 })
+
+            if (listError) {
+                console.warn(
+                    '[PlanPhotoStorageService] list failed:',
+                    listError.message
+                )
+                return 0
+            }
+            if (!list || list.length === 0) {
+                return 0
+            }
+
+            // 3) {plan_id}_ 로 시작하는 객체만 필터
+            const targets = list
+                .filter(obj => obj?.name?.startsWith(`${planId}_`))
+                .map(obj => `${folder}/${obj.name}`)
+
+            if (targets.length === 0) {
+                return 0
+            }
+
+            // 4) 삭제 (RLS에 의해 본인 폴더만 삭제 가능)
+            const { data: removed, error: removeError } = await supabase.storage
+                .from(this.bucket)
+                .remove(targets)
+
+            if (removeError) {
+                console.warn(
+                    '[PlanPhotoStorageService] remove failed:',
+                    removeError.message
+                )
+                return 0
+            }
+
+            return removed?.length ?? 0
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : 'Unknown error'
+            console.warn('[PlanPhotoStorageService] cleanup error:', message)
+            return 0
+        }
+    }
+}
+
+export const PlanPhotoStorageService = PlanPhotoStorageServiceImpl.getInstance()

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+
+export type ToastType = 'success' | 'error' | 'info' | 'loading'
+
+interface Toast {
+    id: string
+    message: string
+    type: ToastType
+    duration?: number
+}
+
+interface ToastState {
+    toasts: Toast[]
+    addToast: (message: string, type?: ToastType, duration?: number) => string
+    removeToast: (id: string) => void
+    success: (message: string, duration?: number) => string
+    error: (message: string, duration?: number) => string
+    info: (message: string, duration?: number) => string
+    loading: (message: string) => string
+}
+
+export const useToastStore = create<ToastState>((set, get) => ({
+    toasts: [],
+    addToast: (message, type = 'info', duration = 3000) => {
+        const id = Math.random().toString(36).substring(2, 9)
+        const newToast = { id, message, type, duration }
+        
+        set((state) => ({ toasts: [...state.toasts, newToast] }))
+
+        if (type !== 'loading') {
+            setTimeout(() => {
+                get().removeToast(id)
+            }, duration)
+        }
+
+        return id
+    },
+    removeToast: (id) => {
+        set((state) => ({
+            toasts: state.toasts.filter((t) => t.id !== id)
+        }))
+    },
+    success: (message, duration) => get().addToast(message, 'success', duration),
+    error: (message, duration) => get().addToast(message, 'error', duration),
+    info: (message, duration) => get().addToast(message, 'info', duration),
+    loading: (message) => get().addToast(message, 'loading', 0),
+}))

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/add_photo_reference_to_plans.sql
+++ b/supabase/add_photo_reference_to_plans.sql
@@ -1,0 +1,8 @@
+-- plans 테이블에 photo_reference 컬럼 추가
+-- Google Places photo_reference 토큰을 보존하여 on-demand 복구 및 백그라운드 업로드의 키로 사용
+
+ALTER TABLE public.plans
+  ADD COLUMN IF NOT EXISTS photo_reference TEXT;
+
+COMMENT ON COLUMN public.plans.photo_reference IS
+  'Google Places photo_reference 토큰. on-demand 갱신 및 백그라운드 업로드에 사용.';

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,413 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "travel-pack"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. Leave unset today to preserve local behaviour. The implicit default
+# flips to `false` on 2026-05-30 to match the new cloud default, and the field is removed in
+# 2026-10-30 once the always-revoked behaviour is permanent. Set to `false` to opt in early.
+# auto_expose_new_tables = false
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/create_place_photos_bucket.sql
+++ b/supabase/create_place_photos_bucket.sql
@@ -1,0 +1,51 @@
+-- place-photos Storage 버킷 + RLS 정책
+-- 경로 규칙: place-photos/{user_id}/{trip_id}/{plan_id}_{placeIdHash8}.jpg
+-- SELECT: 누구나(public) / INSERT, UPDATE, DELETE: 본인 폴더만(auth.uid())
+
+-- 1) 버킷 생성 (public)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('place-photos', 'place-photos', true)
+ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public;
+
+-- 2) RLS 정책: 기존 정책 제거 후 재생성 (idempotent)
+DROP POLICY IF EXISTS "place_photos_select_public" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_insert_own" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_update_own" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_delete_own" ON storage.objects;
+
+-- 2-1) SELECT: 누구나 (public 버킷이므로 모든 사용자가 조회 가능)
+CREATE POLICY "place_photos_select_public"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'place-photos');
+
+-- 2-2) INSERT: 본인 폴더에만 업로드 가능
+CREATE POLICY "place_photos_insert_own"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 2-3) UPDATE: 본인 폴더 객체만 수정 가능
+CREATE POLICY "place_photos_update_own"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+)
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 2-4) DELETE: 본인 폴더 객체만 삭제 가능
+CREATE POLICY "place_photos_delete_own"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);

--- a/supabase/migrations/20260309000001_initial_schema.sql
+++ b/supabase/migrations/20260309000001_initial_schema.sql
@@ -1,0 +1,408 @@
+-- 1. Create profiles table linked to auth.users
+CREATE TABLE public.profiles (
+  id uuid references auth.users on delete cascade not null primary key,
+  email text,
+  nickname text,
+  auth_provider text,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Enable RLS on profiles
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own profile." ON public.profiles FOR SELECT USING (auth.uid() = id);
+CREATE POLICY "Users can update own profile." ON public.profiles FOR UPDATE USING (auth.uid() = id);
+
+-- 2. Create trips table
+CREATE TABLE public.trips (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references public.profiles(id) on delete cascade not null,
+  destination text not null,
+  start_date date not null,
+  end_date date not null,
+  adults_count integer default 1,
+  children_count integer default 0,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.trips ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own trips." ON public.trips FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own trips." ON public.trips FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own trips." ON public.trips FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own trips." ON public.trips FOR DELETE USING (auth.uid() = user_id);
+
+-- 3. Create plans table
+CREATE TABLE public.plans (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  title text not null,
+  location text,
+  cost numeric default 0,
+  memo text,
+  start_datetime_local timestamp without time zone not null,
+  end_datetime_local timestamp without time zone not null,
+  timezone_string text not null,
+  alarm_minutes_before integer,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.plans ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage plans for their trips" ON public.plans
+  FOR ALL USING (trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid()));
+
+-- 4. Create plan_urls table
+CREATE TABLE public.plan_urls (
+  id uuid default gen_random_uuid() primary key,
+  plan_id uuid references public.plans(id) on delete cascade not null,
+  url text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.plan_urls ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage plan urls for their trips" ON public.plan_urls
+  FOR ALL USING (plan_id IN (SELECT id FROM public.plans WHERE trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid())));
+
+-- 5. Checklist Templates
+CREATE TABLE public.checklist_templates (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references public.profiles(id) on delete cascade, -- null means public template
+  title text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.checklist_templates ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view public or own templates" ON public.checklist_templates
+  FOR SELECT USING (user_id IS NULL OR user_id = auth.uid());
+CREATE POLICY "Users can insert own templates" ON public.checklist_templates
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own templates" ON public.checklist_templates
+  FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own templates" ON public.checklist_templates
+  FOR DELETE USING (auth.uid() = user_id);
+
+CREATE TABLE public.checklist_template_items (
+  id uuid default gen_random_uuid() primary key,
+  template_id uuid references public.checklist_templates(id) on delete cascade not null,
+  item_name text not null,
+  category text default '기타' not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.checklist_template_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view public or own template items" ON public.checklist_template_items
+  FOR SELECT USING (
+    template_id IN (
+      SELECT id FROM public.checklist_templates WHERE user_id IS NULL OR user_id = auth.uid()
+    )
+  );
+CREATE POLICY "Users can manage own template items" ON public.checklist_template_items
+  FOR ALL USING (
+    template_id IN (
+      SELECT id FROM public.checklist_templates WHERE user_id = auth.uid()
+    )
+  );
+
+-- 6. Trip Checklists
+CREATE TABLE public.checklists (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  title text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.checklists ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage checklists for their trips" ON public.checklists
+  FOR ALL USING (trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid()));
+
+CREATE TABLE public.checklist_items (
+  id uuid default gen_random_uuid() primary key,
+  checklist_id uuid references public.checklists(id) on delete cascade not null,
+  item_name text not null,
+  category text default '기타' not null,
+  is_checked boolean default false not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.checklist_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage checklist items for their trips" ON public.checklist_items
+  FOR ALL USING (checklist_id IN (SELECT id FROM public.checklists WHERE trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid())));
+
+-- 7. Function to handle new user insertion automatically
+CREATE OR REPLACE FUNCTION public.handle_new_user() 
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, nickname, auth_provider)
+  VALUES (
+    new.id,
+    new.email,
+    new.raw_user_meta_data->>'full_name',
+    new.raw_app_meta_data->>'provider'
+  );
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger to call handle_new_user
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE PROCEDURE public.handle_new_user();
+-- 1. Create trip_members table
+CREATE TABLE public.trip_members (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) on delete cascade, -- Null if pending invite
+  invited_email text not null,
+  role text check (role in ('owner', 'editor', 'viewer')) default 'editor' not null,
+  status text check (status in ('pending', 'accepted')) default 'pending' not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.trip_members ENABLE ROW LEVEL SECURITY;
+
+-- 2. Create trip_shares table
+CREATE TABLE public.trip_shares (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  share_token text unique not null,
+  share_type text check (share_type in ('public', 'password')) default 'public' not null,
+  password_hash text,
+  expires_at timestamp with time zone,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.trip_shares ENABLE ROW LEVEL SECURITY;
+
+-- 3. Revise RLS Policies for trips
+-- Allow owners and members to select trips
+DROP POLICY IF EXISTS "Users can view own trips." ON public.trips;
+CREATE POLICY "Users can view trips they own or are members of." ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = public.trips.id AND user_id = auth.uid())
+  );
+
+-- Allow owners to update
+DROP POLICY IF EXISTS "Users can update own trips." ON public.trips;
+CREATE POLICY "Owners can update their trips." ON public.trips
+  FOR UPDATE USING (auth.uid() = user_id);
+
+-- Allow owners to delete
+DROP POLICY IF EXISTS "Users can delete own trips." ON public.trips;
+CREATE POLICY "Owners can delete their trips." ON public.trips
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- 4. Revise RLS Policies for plans
+DROP POLICY IF EXISTS "Users can manage plans for their trips" ON public.plans;
+CREATE POLICY "Users with edit permission can manage plans" ON public.plans
+  FOR ALL USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    )
+  )
+  WITH CHECK (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    )
+  );
+
+-- Allow viewers and shared link users to view plans
+CREATE POLICY "Viewers can select plans" ON public.plans
+  FOR SELECT USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_shares WHERE share_type = 'public' -- basic check, more logic needed in app for password
+    )
+  );
+
+-- 5. Revise RLS Policies for checklists and items (Same pattern as plans)
+DROP POLICY IF EXISTS "Users can manage checklists for their trips" ON public.checklists;
+CREATE POLICY "Users with edit permission can manage checklists" ON public.checklists
+  FOR ALL USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can manage checklist items for their trips" ON public.checklist_items;
+CREATE POLICY "Users with edit permission can manage checklist items" ON public.checklist_items
+  FOR ALL USING (
+    checklist_id IN (
+      SELECT id FROM public.checklists WHERE trip_id IN (
+        SELECT id FROM public.trips WHERE user_id = auth.uid()
+        UNION
+        SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+      )
+    )
+  );
+
+-- 6. Policies for trip_members
+CREATE POLICY "Users can see members of trips they belong to" ON public.trip_members
+  FOR SELECT USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Owners can manage members" ON public.trip_members
+  FOR ALL USING (
+    trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid())
+  );
+-- Add missing RLS policies for trip_shares
+CREATE POLICY "Owners can manage share links" ON public.trip_shares
+  FOR ALL USING (
+    trip_id IN (SELECT id FROM public.trips WHERE user_id = auth.uid())
+  );
+
+-- Allow anyone to select share links by token (for public/password access)
+CREATE POLICY "Anyone can select share link by token" ON public.trip_shares
+  FOR SELECT USING (true);
+-- 1. Create security functions to break recursion
+CREATE OR REPLACE FUNCTION public.check_is_trip_owner(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trips
+    WHERE id = _trip_id AND user_id = _user_id
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_trip_member(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_members
+    WHERE trip_id = _trip_id AND user_id = _user_id AND status = 'accepted'
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_trip_editor(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_members
+    WHERE trip_id = _trip_id AND user_id = _user_id AND status = 'accepted' AND role IN ('owner', 'editor')
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- 2. Update Trips Policies
+DROP POLICY IF EXISTS "Users can view trips they own or are members of." ON public.trips;
+CREATE POLICY "Users can view trips they own or are members of." ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR public.check_is_trip_member(id, auth.uid())
+  );
+
+-- 3. Update Trip Members Policies
+DROP POLICY IF EXISTS "Users can see members of trips they belong to" ON public.trip_members;
+CREATE POLICY "Users can see members of trips they belong to" ON public.trip_members
+  FOR SELECT USING (
+    user_id = auth.uid() OR 
+    invited_email = (auth.jwt() ->> 'email') OR
+    public.check_is_trip_owner(trip_id, auth.uid()) OR
+    public.check_is_trip_member(trip_id, auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Owners can manage members" ON public.trip_members;
+CREATE POLICY "Owners can manage members" ON public.trip_members
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid())
+  );
+
+-- 4. Update Trip Shares Policies
+DROP POLICY IF EXISTS "Owners can manage share links" ON public.trip_shares;
+CREATE POLICY "Owners can manage share links" ON public.trip_shares
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid())
+  );
+
+-- 5. Update Plans Policies
+DROP POLICY IF EXISTS "Users with edit permission can manage plans" ON public.plans;
+CREATE POLICY "Users with edit permission can manage plans" ON public.plans
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_editor(trip_id, auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Viewers can select plans" ON public.plans;
+CREATE POLICY "Viewers can select plans" ON public.plans
+  FOR SELECT USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_member(trip_id, auth.uid()) OR
+    EXISTS (SELECT 1 FROM public.trip_shares WHERE trip_id = public.plans.trip_id AND share_type = 'public')
+  );
+
+-- 6. Update Checklists Policies
+DROP POLICY IF EXISTS "Users with edit permission can manage checklists" ON public.checklists;
+CREATE POLICY "Users with edit permission can manage checklists" ON public.checklists
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_editor(trip_id, auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Users with edit permission can manage checklist items" ON public.checklist_items;
+CREATE POLICY "Users with edit permission can manage checklist items" ON public.checklist_items
+  FOR ALL USING (
+    checklist_id IN (
+      SELECT id FROM public.checklists 
+      WHERE public.check_is_trip_owner(trip_id, auth.uid()) OR public.check_is_trip_editor(trip_id, auth.uid())
+    )
+  );
+-- Allow anyone to select trip basic info if a public share link exists
+DROP POLICY IF EXISTS "Users can view trips they own or are members of." ON public.trips;
+CREATE POLICY "Users can view trips via owner, member or public share" ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    public.check_is_trip_member(id, auth.uid()) OR
+    EXISTS (SELECT 1 FROM public.trip_shares WHERE trip_id = public.trips.id AND share_type = 'public')
+  );
+-- Create a function to check if a trip has any public share link
+CREATE OR REPLACE FUNCTION public.check_is_public_trip(_trip_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_shares
+    WHERE trip_id = _trip_id AND share_type = 'public'
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- Update trips SELECT policy
+DROP POLICY IF EXISTS "Users can view trips via owner, member or public share" ON public.trips;
+CREATE POLICY "Users can view trips via owner, member or public share" ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    public.check_is_trip_member(id, auth.uid()) OR
+    public.check_is_public_trip(id)
+  );
+-- Final RLS fix for trips and shares to ensure guest access
+-- 1. Ensure trip_shares is truly public for SELECT
+DROP POLICY IF EXISTS "Anyone can select share link by token" ON public.trip_shares;
+CREATE POLICY "Public select trip_shares" ON public.trip_shares
+  FOR SELECT USING (true);
+
+-- 2. Ensure trips is readable if a public share link exists
+DROP POLICY IF EXISTS "Users can view trips via owner, member or public share" ON public.trips;
+CREATE POLICY "Public select trips if shared" ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    public.check_is_trip_member(id, auth.uid()) OR
+    EXISTS (SELECT 1 FROM public.trip_shares ts WHERE ts.trip_id = id AND ts.share_type = 'public')
+  );
+
+-- 3. Ensure plans are also readable
+DROP POLICY IF EXISTS "Viewers can select plans" ON public.plans;
+CREATE POLICY "Public select plans if shared" ON public.plans
+  FOR SELECT USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_member(trip_id, auth.uid()) OR
+    EXISTS (SELECT 1 FROM public.trip_shares ts WHERE ts.trip_id = trip_id AND ts.share_type = 'public')
+  );

--- a/supabase/migrations/20260309000002_add_unique_trip_members.sql
+++ b/supabase/migrations/20260309000002_add_unique_trip_members.sql
@@ -1,0 +1,5 @@
+-- trip_members 테이블에 중복 초대 방지를 위한 유니크 제약 조건 추가
+
+-- 같은 여행(trip_id)에 같은 이메일(invited_email)이 중복 등록되지 않도록 합니다.
+ALTER TABLE public.trip_members 
+ADD CONSTRAINT trip_members_trip_id_invited_email_key UNIQUE (trip_id, invited_email);

--- a/supabase/migrations/20260320000001_collaboration_and_sharing.sql
+++ b/supabase/migrations/20260320000001_collaboration_and_sharing.sql
@@ -1,0 +1,136 @@
+-- ==========================================
+-- Nexvoy Collaboration & Sharing System
+-- Consolidated Database Patch
+-- ==========================================
+
+-- 1. Create Tables (if not exists)
+CREATE TABLE IF NOT EXISTS public.trip_members (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) on delete cascade,
+  invited_email text not null,
+  role text check (role in ('owner', 'editor', 'viewer')) default 'editor' not null,
+  status text check (status in ('pending', 'accepted')) default 'pending' not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+CREATE TABLE IF NOT EXISTS public.trip_shares (
+  id uuid default gen_random_uuid() primary key,
+  trip_id uuid references public.trips(id) on delete cascade not null,
+  share_token text unique not null,
+  share_type text check (share_type in ('public', 'password')) default 'public' not null,
+  password_hash text,
+  expires_at timestamp with time zone,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Enable RLS
+ALTER TABLE public.trip_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.trip_shares ENABLE ROW LEVEL SECURITY;
+
+-- 2. Security Functions (to break recursion and handle guest access)
+CREATE OR REPLACE FUNCTION public.check_is_trip_owner(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trips
+    WHERE id = _trip_id AND user_id = _user_id
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_trip_member(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_members
+    WHERE trip_id = _trip_id AND user_id = _user_id AND status = 'accepted'
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_trip_editor(_trip_id uuid, _user_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_members
+    WHERE trip_id = _trip_id AND user_id = _user_id AND status = 'accepted' AND role IN ('owner', 'editor')
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.check_is_public_trip(_trip_id uuid)
+RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.trip_shares
+    WHERE trip_id = _trip_id AND share_type = 'public'
+  );
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- 3. Comprehensive RLS Policies
+
+-- [TRIPS]
+DROP POLICY IF EXISTS "Users can view own trips." ON public.trips;
+DROP POLICY IF EXISTS "Users can view trips they own or are members of." ON public.trips;
+DROP POLICY IF EXISTS "Users can view trips via owner, member or public share" ON public.trips;
+DROP POLICY IF EXISTS "Public select trips if shared" ON public.trips;
+DROP POLICY IF EXISTS "Access trips by owner, member, or public share" ON public.trips;
+
+CREATE POLICY "Access trips by owner, member, or public share" ON public.trips
+  FOR SELECT USING (
+    auth.uid() = user_id OR 
+    public.check_is_trip_member(id, auth.uid()) OR
+    public.check_is_public_trip(id)
+  );
+
+-- [TRIP_SHARES]
+DROP POLICY IF EXISTS "Anyone can select share link by token" ON public.trip_shares;
+DROP POLICY IF EXISTS "Owners can manage share links" ON public.trip_shares;
+DROP POLICY IF EXISTS "Public select trip_shares" ON public.trip_shares;
+DROP POLICY IF EXISTS "Public select shares" ON public.trip_shares;
+DROP POLICY IF EXISTS "Manage shares as owner" ON public.trip_shares;
+
+CREATE POLICY "Public select shares" ON public.trip_shares FOR SELECT USING (true);
+CREATE POLICY "Manage shares as owner" ON public.trip_shares FOR ALL USING (public.check_is_trip_owner(trip_id, auth.uid()));
+
+-- [TRIP_MEMBERS]
+DROP POLICY IF EXISTS "Users can see members of trips they belong to" ON public.trip_members;
+DROP POLICY IF EXISTS "Owners can manage members" ON public.trip_members;
+DROP POLICY IF EXISTS "Select members if related" ON public.trip_members;
+DROP POLICY IF EXISTS "Manage members as owner" ON public.trip_members;
+DROP POLICY IF EXISTS "Invited users can accept invitations" ON public.trip_members;
+
+CREATE POLICY "Select members if related" ON public.trip_members
+  FOR SELECT USING (
+    user_id = auth.uid() OR 
+    invited_email = (auth.jwt() ->> 'email') OR
+    public.check_is_trip_owner(trip_id, auth.uid()) OR
+    public.check_is_trip_member(trip_id, auth.uid())
+  );
+
+CREATE POLICY "Manage members as owner" ON public.trip_members
+  FOR ALL USING (public.check_is_trip_owner(trip_id, auth.uid()));
+
+CREATE POLICY "Invited users can accept invitations" ON public.trip_members
+  FOR UPDATE 
+  USING (
+    invited_email = (auth.jwt() ->> 'email') AND status = 'pending'
+  )
+  WITH CHECK (
+    user_id = auth.uid() AND status = 'accepted'
+  );
+
+-- [PLANS]
+DROP POLICY IF EXISTS "Users can manage plans for their trips" ON public.plans;
+DROP POLICY IF EXISTS "Users with edit permission can manage plans" ON public.plans;
+DROP POLICY IF EXISTS "Viewers can select plans" ON public.plans;
+DROP POLICY IF EXISTS "Public select plans if shared" ON public.plans;
+DROP POLICY IF EXISTS "Select plans if shared or related" ON public.plans;
+DROP POLICY IF EXISTS "Manage plans if editor or owner" ON public.plans;
+
+CREATE POLICY "Select plans if shared or related" ON public.plans
+  FOR SELECT USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_member(trip_id, auth.uid()) OR
+    public.check_is_public_trip(trip_id)
+  );
+
+CREATE POLICY "Manage plans if editor or owner" ON public.plans
+  FOR ALL USING (
+    public.check_is_trip_owner(trip_id, auth.uid()) OR 
+    public.check_is_trip_editor(trip_id, auth.uid())
+  );

--- a/supabase/migrations/20260320000002_user_devices.sql
+++ b/supabase/migrations/20260320000002_user_devices.sql
@@ -1,0 +1,24 @@
+-- Create user_devices table for Push Notifications
+CREATE TABLE IF NOT EXISTS public.user_devices (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    fcm_token TEXT UNIQUE NOT NULL,
+    platform TEXT,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE public.user_devices ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+-- 1. Users can insert/upsert their own device tokens
+CREATE POLICY "Users can manage their own device tokens" 
+ON public.user_devices 
+FOR ALL 
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_user_devices_user_id ON public.user_devices(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_devices_fcm_token ON public.user_devices(fcm_token);

--- a/supabase/migrations/20260324000001_fix_plan_urls_rls.sql
+++ b/supabase/migrations/20260324000001_fix_plan_urls_rls.sql
@@ -1,0 +1,36 @@
+-- 1. 기존 '소유자 전용' 정책 제거
+DROP POLICY IF EXISTS "Users can manage plan urls for their trips" ON public.plan_urls;
+
+-- 2. 조회(SELECT) 정책 추가: 여행 소유자, 멤버(Accepted), 또는 공개 공유 링크 대상에게 허용
+CREATE POLICY "Allow members and public to view plan urls" ON public.plan_urls
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id AND (
+        public.check_is_trip_owner(p.trip_id, auth.uid()) OR 
+        public.check_is_trip_member(p.trip_id, auth.uid()) OR
+        EXISTS (SELECT 1 FROM public.trip_shares ts WHERE ts.trip_id = p.trip_id AND ts.share_type = 'public')
+      )
+    )
+  );
+
+-- 3. 관리(ALL) 정책 추가: 소유자 또는 편집자(Owner, Editor) 권한을 가진 사용자에게 허용
+CREATE POLICY "Allow editors to manage plan urls" ON public.plan_urls
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id AND (
+        public.check_is_trip_owner(p.trip_id, auth.uid()) OR 
+        public.check_is_trip_editor(p.trip_id, auth.uid())
+      )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id AND (
+        public.check_is_trip_owner(p.trip_id, auth.uid()) OR 
+        public.check_is_trip_editor(p.trip_id, auth.uid())
+      )
+    )
+  );

--- a/supabase/migrations/20260325000001_alarm_sent_at_and_rpc.sql
+++ b/supabase/migrations/20260325000001_alarm_sent_at_and_rpc.sql
@@ -1,0 +1,44 @@
+-- Add alarm_sent_at column to public.plans table
+ALTER TABLE public.plans
+ADD COLUMN IF NOT EXISTS alarm_sent_at TIMESTAMP WITH TIME ZONE;
+
+-- Create an index to optimize searching for unsent alarms
+CREATE INDEX IF NOT EXISTS idx_plans_alarm_minutes_before_sent_at 
+ON public.plans (alarm_minutes_before, alarm_sent_at) 
+WHERE alarm_minutes_before IS NOT NULL AND alarm_sent_at IS NULL;
+
+-- RPC to get pending alarms
+CREATE OR REPLACE FUNCTION get_pending_alarms()
+RETURNS TABLE (
+  plan_id UUID,
+  title TEXT,
+  location TEXT,
+  user_id UUID,
+  email TEXT,
+  timezone_string TEXT,
+  fcm_tokens TEXT[],
+  trip_destination TEXT
+) LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    p.id, 
+    p.title, 
+    p.location, 
+    t.user_id, 
+    pr.email, 
+    p.timezone_string, 
+    array_agg(DISTINCT d.fcm_token) FILTER (WHERE d.fcm_token IS NOT NULL) as fcm_tokens,
+    t.destination
+  FROM public.plans p
+  JOIN public.trips t ON p.trip_id = t.id
+  JOIN public.profiles pr ON t.user_id = pr.id
+  LEFT JOIN public.user_devices d ON t.user_id = d.user_id
+  WHERE 
+    p.alarm_minutes_before IS NOT NULL 
+    AND p.alarm_sent_at IS NULL
+    AND (now() AT TIME ZONE p.timezone_string) >= (p.start_datetime_local - (p.alarm_minutes_before || ' minutes')::interval)
+    AND p.start_datetime_local > (now() AT TIME ZONE p.timezone_string - interval '1 day')
+  GROUP BY p.id, p.title, p.location, t.user_id, pr.email, p.timezone_string, t.destination;
+END;
+$$;

--- a/supabase/migrations/20260325000002_setup_cron_job.sql
+++ b/supabase/migrations/20260325000002_setup_cron_job.sql
@@ -1,0 +1,11 @@
+-- 1. pg_cron 확장 활성화 (이미 되어 있을 수 있음)
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- 2. 기존 동일 이름의 크론 잡 삭제 (존재할 경우에만)
+SELECT cron.unschedule(jobid) 
+FROM cron.job 
+WHERE jobname = 'check-pending-alarms-cron';
+
+-- 3. 크론 잡은 운영 환경에서만 등록
+-- 로컬/테스트 환경에서는 적용하지 않음 (Edge Function URL과 service_role 키가 환경별로 다름)
+-- 운영 적용 시 Supabase 대시보드 또는 별도 스크립트로 수동 등록할 것

--- a/supabase/migrations/20260330000001_push_notification_trigger.sql
+++ b/supabase/migrations/20260330000001_push_notification_trigger.sql
@@ -1,0 +1,60 @@
+-- 1. Enable pg_net extension (if not already enabled)
+-- CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- 2. Function to trigger the Edge Function
+CREATE OR REPLACE FUNCTION public.handle_new_plan_notification()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_tokens TEXT[];
+    trip_name TEXT;
+    payload JSONB;
+BEGIN
+    -- Get trip destination for the message
+    SELECT destination INTO trip_name FROM public.trips WHERE id = NEW.trip_id;
+
+    -- 1. Find all members of the trip except the one who created the plan
+    -- 2. Join with user_devices to get their FCM tokens
+    SELECT array_agg(d.fcm_token)
+    INTO target_tokens
+    FROM public.trip_members m
+    JOIN public.user_devices d ON m.user_id = d.user_id
+    WHERE m.trip_id = NEW.trip_id
+      AND m.status = 'accepted'
+      AND m.user_id != auth.uid(); -- Don't notify the sender
+
+    -- If no tokens found, exit
+    IF target_tokens IS NULL OR array_length(target_tokens, 1) = 0 THEN
+        RETURN NEW;
+    END IF;
+
+    -- Prepare the payload for the Edge Function
+    payload := jsonb_build_object(
+        'tokens', target_tokens,
+        'title', '새로운 일정이 추가되었습니다!',
+        'body', '[' || trip_name || '] 여행에 "' || NEW.title || '" 일정이 등록되었습니다.',
+        'data', jsonb_build_object('tripId', NEW.trip_id::text)
+    );
+
+    -- Edge Function 호출 (운영 환경에서만 실제 동작)
+    -- 로컬/테스트 환경에서는 pg_net 미설치 시 함수 정의만 적용되고 호출은 skip됨
+    IF current_setting('app.env', true) != 'local' THEN
+      PERFORM
+        net.http_post(
+          url := current_setting('app.supabase_functions_url', true) || '/send-push-notification',
+          headers := jsonb_build_object(
+              'Content-Type', 'application/json',
+              'Authorization', 'Bearer ' || current_setting('app.service_role_key', true)
+          ),
+          body := payload
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 3. Create the Trigger
+DROP TRIGGER IF EXISTS on_plan_created ON public.plans;
+CREATE TRIGGER on_plan_created
+    AFTER INSERT ON public.plans
+    FOR EACH ROW EXECUTE FUNCTION public.handle_new_plan_notification();

--- a/supabase/migrations/20260330000002_trip_invitation_trigger.sql
+++ b/supabase/migrations/20260330000002_trip_invitation_trigger.sql
@@ -1,0 +1,67 @@
+-- 여행 초대 알림을 위한 트리거 및 함수
+CREATE OR REPLACE FUNCTION public.handle_trip_invitation_notification()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_tokens TEXT[];
+    inviter_name TEXT;
+    trip_title TEXT;
+    payload JSONB;
+BEGIN
+    -- 1. 초대한 사람의 닉네임 가져오기 (trips 테이블의 소유자)
+    -- 주의: 초대 액션을 수행한 사람이 반드시 소유자라고 가정 (현재 RLS 정책상 초대 권한은 소유자에게 있음)
+    SELECT p.nickname INTO inviter_name 
+    FROM public.trips t
+    JOIN public.profiles p ON t.user_id = p.id
+    WHERE t.id = NEW.trip_id;
+
+    -- 2. 여행 목적지 가져오기
+    SELECT destination INTO trip_title FROM public.trips WHERE id = NEW.trip_id;
+
+    -- 3. 초대받은 이메일과 일치하는 사용자의 FCM 토큰 가져오기
+    -- (이미 가입된 유저일 경우에만 알림 발송 가능)
+    SELECT array_agg(d.fcm_token)
+    INTO target_tokens
+    FROM public.profiles p
+    JOIN public.user_devices d ON p.id = d.user_id
+    WHERE p.email = NEW.invited_email;
+
+    -- 토큰이 없으면 종료
+    IF target_tokens IS NULL OR array_length(target_tokens, 1) = 0 THEN
+        RETURN NEW;
+    END IF;
+
+    -- 4. 페이로드 준비
+    payload := jsonb_build_object(
+        'tokens', target_tokens,
+        'title', '새로운 여행 초대!',
+        'body', inviter_name || '님이 "' || trip_title || '" 여행에 초대했습니다.',
+        'data', jsonb_build_object(
+            'tripId', NEW.trip_id::text,
+            'type', 'invitation'
+        )
+    );
+
+    -- 5. Edge Function 호출 (운영 환경에서만 실제 동작)
+    IF current_setting('app.env', true) != 'local' THEN
+      PERFORM
+        net.http_post(
+          url := current_setting('app.supabase_functions_url', true) || '/send-push-notification',
+          headers := jsonb_build_object(
+              'Content-Type', 'application/json',
+              'Authorization', 'Bearer ' || current_setting('app.service_role_key', true)
+          ),
+          body := payload
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 트리거 생성
+DROP TRIGGER IF EXISTS on_trip_invitation ON public.trip_members;
+CREATE TRIGGER on_trip_invitation
+    AFTER INSERT ON public.trip_members
+    FOR EACH ROW
+    WHEN (NEW.status = 'pending')
+    EXECUTE FUNCTION public.handle_trip_invitation_notification();

--- a/supabase/migrations/20260330000003_checklist_collaboration.sql
+++ b/supabase/migrations/20260330000003_checklist_collaboration.sql
@@ -1,0 +1,42 @@
+-- 1. checklist_items 테이블 구조 확장
+ALTER TABLE public.checklist_items 
+ADD COLUMN IF NOT EXISTS assignment_type text check (assignment_type in ('anyone', 'specific', 'everyone')) default 'anyone' NOT NULL,
+ADD COLUMN IF NOT EXISTS assigned_user_id uuid references public.profiles(id);
+
+-- 2. 개별 체크 기록을 위한 checklist_item_user_checks 테이블 신설
+CREATE TABLE IF NOT EXISTS public.checklist_item_user_checks (
+  id uuid default gen_random_uuid() primary key,
+  item_id uuid references public.checklist_items(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) on delete cascade not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  unique(item_id, user_id)
+);
+
+-- 3. RLS 설정 (기존 checklist_items와 동일한 로직 적용)
+ALTER TABLE public.checklist_item_user_checks ENABLE ROW LEVEL SECURITY;
+
+-- 3-1. 사용자가 조회 권한을 가진 여행의 체크리스트 항목이면 열람 가능
+DROP POLICY IF EXISTS "Users can view user checks for accessible trips" ON public.checklist_item_user_checks;
+CREATE POLICY "Users can view user checks for accessible trips" ON public.checklist_item_user_checks
+  FOR SELECT USING (
+    item_id IN (
+      SELECT id FROM public.checklist_items 
+      WHERE checklist_id IN (
+        SELECT id FROM public.checklists 
+        WHERE trip_id IN (
+          SELECT id FROM public.trips WHERE user_id = auth.uid()
+          UNION
+          SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid()
+        )
+      )
+    )
+  );
+
+-- 3-2. 사용자가 본인의 체크 내역을 관리(추가/삭제) 가능
+DROP POLICY IF EXISTS "Users can manage their own checks" ON public.checklist_item_user_checks;
+CREATE POLICY "Users can manage their own checks" ON public.checklist_item_user_checks
+  FOR ALL USING (auth.uid() = user_id);
+
+-- 4. 특정인(assigned_user_id) 외 다른 사용자의 checklist_items 업데이트 제한을 위한 정책 보완
+-- 이 부분은 애플리케이션 레벨(UI)에서 주로 제어하며, DB 레벨 정책은 기존의 "편집 권한 소유자"를 유지하되
+-- 필요한 경우 트리거 등으로 보조할 수 있으나, 이번 개선에서는 애플리케이션 로직을 우선 적용합니다.

--- a/supabase/migrations/20260412000001_plans_address_image_url.sql
+++ b/supabase/migrations/20260412000001_plans_address_image_url.sql
@@ -1,0 +1,9 @@
+-- plans 테이블에 누락된 address 및 image_url 컬럼 추가
+-- user의 요청에 따라 상세 주소 및 구글 맵 이미지 URL 저장 공간 확보
+
+ALTER TABLE public.plans 
+ADD COLUMN IF NOT EXISTS address TEXT,
+ADD COLUMN IF NOT EXISTS image_url TEXT;
+
+COMMENT ON COLUMN public.plans.address IS '일정의 상세 주소 정보';
+COMMENT ON COLUMN public.plans.image_url IS '일정의 대표 이미지 (구글 맵 제공 URL 등)';

--- a/supabase/migrations/20260502000001_trip_invitation_links.sql
+++ b/supabase/migrations/20260502000001_trip_invitation_links.sql
@@ -1,0 +1,174 @@
+-- 1. Create table for invitation links
+CREATE TABLE IF NOT EXISTS public.trip_invitation_links (
+    id uuid default gen_random_uuid() primary key,
+    trip_id uuid references public.trips(id) on delete cascade not null,
+    token text unique not null,
+    expires_at timestamp with time zone not null,
+    created_by uuid references public.profiles(id) on delete cascade not null,
+    created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+ALTER TABLE public.trip_invitation_links ENABLE ROW LEVEL SECURITY;
+
+-- Allow owners/editors to create and view links
+CREATE POLICY "Users can manage invitation links for their trips" ON public.trip_invitation_links
+  FOR ALL USING (
+    trip_id IN (
+      SELECT id FROM public.trips WHERE user_id = auth.uid()
+      UNION
+      SELECT trip_id FROM public.trip_members WHERE user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    )
+  );
+
+-- Allow anyone to view a link by token
+CREATE POLICY "Anyone can select invitation link by token" ON public.trip_invitation_links
+  FOR SELECT USING (true);
+
+
+-- 2. RPC to generate invitation link
+CREATE OR REPLACE FUNCTION public.generate_invitation_link(p_trip_id uuid)
+RETURNS text AS $$
+DECLARE
+    new_token text;
+BEGIN
+    -- Check if user has permission (owner or editor)
+    IF NOT EXISTS (
+        SELECT 1 FROM public.trips WHERE id = p_trip_id AND user_id = auth.uid()
+        UNION
+        SELECT 1 FROM public.trip_members WHERE trip_id = p_trip_id AND user_id = auth.uid() AND (role = 'owner' OR role = 'editor')
+    ) THEN
+        RAISE EXCEPTION '권한이 없습니다.';
+    END IF;
+
+    -- Generate a simple random token
+    new_token := encode(gen_random_bytes(16), 'hex');
+
+    INSERT INTO public.trip_invitation_links (trip_id, token, expires_at, created_by)
+    VALUES (p_trip_id, new_token, now() + interval '6 hours', auth.uid());
+
+    RETURN new_token;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- 3. RPC to get trip summary by token
+CREATE OR REPLACE FUNCTION public.get_trip_summary_by_token(p_token text)
+RETURNS jsonb AS $$
+DECLARE
+    link_record RECORD;
+    trip_summary jsonb;
+BEGIN
+    SELECT * INTO link_record FROM public.trip_invitation_links WHERE token = p_token;
+    
+    IF NOT FOUND THEN
+        RAISE EXCEPTION '유효하지 않은 링크입니다.';
+    END IF;
+
+    IF link_record.expires_at < now() THEN
+        RAISE EXCEPTION '만료된 링크입니다.';
+    END IF;
+
+    -- Get trip details
+    SELECT jsonb_build_object(
+        'trip_id', t.id,
+        'destination', t.destination,
+        'start_date', t.start_date,
+        'end_date', t.end_date,
+        'owner_nickname', p.nickname,
+        'member_count', (SELECT count(*) FROM public.trip_members WHERE trip_id = t.id AND status = 'accepted') + 1 -- owner + accepted members
+    ) INTO trip_summary
+    FROM public.trips t
+    JOIN public.profiles p ON t.user_id = p.id
+    WHERE t.id = link_record.trip_id;
+
+    RETURN trip_summary;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- 4. RPC to join trip via token
+CREATE OR REPLACE FUNCTION public.join_trip_via_token(p_token text)
+RETURNS uuid AS $$
+DECLARE
+    link_record RECORD;
+    user_email text;
+    user_nickname text;
+    trip_owner_id uuid;
+    target_tokens TEXT[];
+    payload JSONB;
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION '로그인이 필요합니다.';
+    END IF;
+
+    SELECT * INTO link_record FROM public.trip_invitation_links WHERE token = p_token;
+    
+    IF NOT FOUND THEN
+        RAISE EXCEPTION '유효하지 않은 링크입니다.';
+    END IF;
+
+    IF link_record.expires_at < now() THEN
+        RAISE EXCEPTION '만료된 링크입니다.';
+    END IF;
+
+    -- Check if user is the owner
+    IF EXISTS (SELECT 1 FROM public.trips WHERE id = link_record.trip_id AND user_id = auth.uid()) THEN
+        RETURN link_record.trip_id; -- Already owner
+    END IF;
+
+    -- Check if user is already a member
+    IF EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = link_record.trip_id AND user_id = auth.uid() AND status = 'accepted') THEN
+        RETURN link_record.trip_id; -- Already a member
+    END IF;
+
+    -- Update or insert member
+    SELECT email, nickname INTO user_email, user_nickname FROM public.profiles WHERE id = auth.uid();
+
+    IF EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = link_record.trip_id AND user_id = auth.uid()) THEN
+        UPDATE public.trip_members 
+        SET status = 'accepted', role = 'editor'
+        WHERE trip_id = link_record.trip_id AND user_id = auth.uid();
+    ELSIF EXISTS (SELECT 1 FROM public.trip_members WHERE trip_id = link_record.trip_id AND invited_email = user_email) THEN
+        UPDATE public.trip_members 
+        SET status = 'accepted', role = 'editor', user_id = auth.uid()
+        WHERE trip_id = link_record.trip_id AND invited_email = user_email;
+    ELSE
+        INSERT INTO public.trip_members (trip_id, user_id, invited_email, role, status)
+        VALUES (link_record.trip_id, auth.uid(), user_email, 'editor', 'accepted');
+    END IF;
+
+    -- Send notification to trip owner
+    SELECT user_id INTO trip_owner_id FROM public.trips WHERE id = link_record.trip_id;
+    
+    SELECT array_agg(d.fcm_token)
+    INTO target_tokens
+    FROM public.user_devices d
+    WHERE d.user_id = trip_owner_id;
+
+    IF target_tokens IS NOT NULL AND array_length(target_tokens, 1) > 0 THEN
+        payload := jsonb_build_object(
+            'tokens', target_tokens,
+            'title', '새로운 동행자 참여!',
+            'body', user_nickname || '님이 초대 링크를 통해 여정에 참여했습니다.',
+            'data', jsonb_build_object(
+                'tripId', link_record.trip_id::text,
+                'type', 'join'
+            )
+        );
+
+        IF current_setting('app.env', true) != 'local' THEN
+          PERFORM
+            net.http_post(
+              url := current_setting('app.supabase_functions_url', true) || '/send-push-notification',
+              headers := jsonb_build_object(
+                  'Content-Type', 'application/json',
+                  'Authorization', 'Bearer ' || current_setting('app.service_role_key', true)
+              ),
+              body := payload
+            );
+        END IF;
+    END IF;
+
+    RETURN link_record.trip_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20260527000001_plans_photo_reference.sql
+++ b/supabase/migrations/20260527000001_plans_photo_reference.sql
@@ -1,0 +1,8 @@
+-- plans 테이블에 photo_reference 컬럼 추가
+-- Google Places photo_reference 토큰을 보존하여 on-demand 복구 및 백그라운드 업로드의 키로 사용
+
+ALTER TABLE public.plans
+  ADD COLUMN IF NOT EXISTS photo_reference TEXT;
+
+COMMENT ON COLUMN public.plans.photo_reference IS
+  'Google Places photo_reference 토큰. on-demand 갱신 및 백그라운드 업로드에 사용.';

--- a/supabase/migrations/20260527000002_place_photos_bucket.sql
+++ b/supabase/migrations/20260527000002_place_photos_bucket.sql
@@ -1,0 +1,51 @@
+-- place-photos Storage 버킷 + RLS 정책
+-- 경로 규칙: place-photos/{user_id}/{trip_id}/{plan_id}_{placeIdHash8}.jpg
+-- SELECT: 누구나(public) / INSERT, UPDATE, DELETE: 본인 폴더만(auth.uid())
+
+-- 1) 버킷 생성 (public)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('place-photos', 'place-photos', true)
+ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public;
+
+-- 2) RLS 정책: 기존 정책 제거 후 재생성 (idempotent)
+DROP POLICY IF EXISTS "place_photos_select_public" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_insert_own" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_update_own" ON storage.objects;
+DROP POLICY IF EXISTS "place_photos_delete_own" ON storage.objects;
+
+-- 2-1) SELECT: 누구나 (public 버킷이므로 모든 사용자가 조회 가능)
+CREATE POLICY "place_photos_select_public"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'place-photos');
+
+-- 2-2) INSERT: 본인 폴더에만 업로드 가능
+CREATE POLICY "place_photos_insert_own"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 2-3) UPDATE: 본인 폴더 객체만 수정 가능
+CREATE POLICY "place_photos_update_own"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+)
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 2-4) DELETE: 본인 폴더 객체만 삭제 가능
+CREATE POLICY "place_photos_delete_own"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);

--- a/supabase/migrations/20260610000001_checklist_items_is_private.sql
+++ b/supabase/migrations/20260610000001_checklist_items_is_private.sql
@@ -1,0 +1,4 @@
+-- checklist_items.is_private 컬럼 추가
+-- 운영 DB에는 이미 존재하나 로컬 마이그레이션에 누락된 스키마 드리프트 수정
+ALTER TABLE checklist_items
+  ADD COLUMN IF NOT EXISTS is_private BOOLEAN NOT NULL DEFAULT FALSE;

--- a/supabase/migrations/20260610000002_schema_drift_template_checklist.sql
+++ b/supabase/migrations/20260610000002_schema_drift_template_checklist.sql
@@ -1,0 +1,8 @@
+-- 누락 컬럼 보정: 운영 DB에 존재하나 로컬 마이그레이션에 미반영된 스키마 드리프트 수정
+-- checklist_template_items.is_private: 템플릿 아이템 비공개 여부
+ALTER TABLE checklist_template_items
+  ADD COLUMN IF NOT EXISTS is_private BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- checklist_items.source_template_name: 템플릿 불러오기 시 출처 템플릿명 (중복 필터 기준)
+ALTER TABLE checklist_items
+  ADD COLUMN IF NOT EXISTS source_template_name TEXT;


### PR DESCRIPTION
## Release 요약

develop → main 릴리즈 PR.
Playwright E2E 테스트 인프라 전체 구축 및 GitHub Actions CI 통합 작업을 포함한다.

## 포함된 변경 (9 commits)

### E2E 테스트 인프라 (Phase 1~3) — #191
- Playwright 설치 및 설정 (`playwright.config.ts`)
- 인증 픽스처 (`e2e/fixtures/auth.ts`) — Supabase 세션 쿠키 주입
- 테스트 헬퍼 (`e2e/helpers/supabase.ts`, `seed.ts`)
- 스모크 테스트 4개 (`e2e/smoke.spec.ts`)
- `scripts/dev-e2e.mjs` — `.env.local` 무수정 환경변수 주입

### DB 마이그레이션 보정 — #194, #196
- `checklist_items.is_private` 누락 컬럼 추가
- `checklist_template_items.is_private`, `checklist_items.source_template_name` 누락 컬럼 보정

### E2E 여행 시나리오 — #198
- 여행 생성 → 체크리스트 E2E (`e2e/trips.spec.ts`)
- 템플릿 생성 → 아이템 추가 → 여행 적용 E2E (`e2e/templates.spec.ts`)

### E2E 버그 수정 — #200, #202
- 체크리스트 race condition 수정 (`checklistId` null 시 silent fail)
- 템플릿 목록 갱신 타이밍 수정

### Google Maps API mock — #202
- `e2e/helpers/google-maps-mock.ts` — `page.route()` 인터셉트 방식
- 실제 API 호출 0건, 운영 코드 무수정

### GitHub Actions CI 통합 — #203
- `.github/workflows/e2e.yml` — PR/push 시 E2E 자동 실행
- Supabase 로컬 인스턴스 Docker 기동 → 마이그레이션 자동 적용
- `supabase/seed.sql` 빈 파일 추가

## 검증 결과

- E2E 9개 테스트 전부 통과 (로컬)
- `pnpm build` 성공
- `pnpm build:mobile` 성공

## Test plan

- [ ] CI 워크플로우가 이 PR에서 자동 실행되어 통과하는지 확인
- [ ] main 머지 후 운영 배포 이상 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)