### PR TITLE
feat(mobile): 기본 UI 컴포넌트 구현 (Button / Card / Screen)

### DIFF
--- a/apps/mobile/components/ui/Button.tsx
+++ b/apps/mobile/components/ui/Button.tsx
@@ -1,0 +1,160 @@
+/**
+ * Button — 버튼 Atom (nexvoy-app)
+ *
+ * login `submitBtn`/`emailEntryBtn`, home `emptyCta` 의 사실상 표준을 컴포넌트화.
+ *
+ * - Pressable 기반 (TouchableOpacity 아님). pressed 시 opacity/scale 트랜스폼.
+ * - variant: primary(채움) / secondary(테두리) / ghost(투명).
+ * - loading 시 라벨 숨기고 ActivityIndicator + 터치 무효.
+ * - 정적 스타일은 StyleSheet.create, variant/size/press/disabled 분기는 인라인 style 로 분리.
+ * - a11y: accessibilityRole="button", accessibilityState={{ disabled, busy }}, 최소 44pt 터치.
+ */
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native'
+import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost'
+type ButtonSize = 'sm' | 'md' | 'lg'
+
+interface ButtonProps {
+  label: string
+  onPress: () => void
+  /** 기본 'primary' */
+  variant?: ButtonVariant
+  /** 기본 'md' */
+  size?: ButtonSize
+  disabled?: boolean
+  /** true → ActivityIndicator 표시, onPress 불가 */
+  loading?: boolean
+  /** 기본 true */
+  fullWidth?: boolean
+  accessibilityLabel?: string
+}
+
+const sizeStyles: Record<
+  ButtonSize,
+  { paddingVertical: number; paddingHorizontal: number; minHeight: number; fontSize: number }
+> = {
+  sm: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    minHeight: 44,
+    fontSize: fontSizes.sm,
+  },
+  md: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    minHeight: 48,
+    fontSize: fontSizes.base,
+  },
+  lg: {
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    minHeight: 52,
+    fontSize: fontSizes.base,
+  },
+}
+
+const variantContainer: Record<ButtonVariant, ViewStyle> = {
+  primary: {
+    backgroundColor: colors.brand.primary,
+  },
+  secondary: {
+    backgroundColor: 'transparent',
+    borderWidth: 1.5,
+    borderColor: colors.brand.primary,
+  },
+  ghost: {
+    backgroundColor: 'transparent',
+  },
+}
+
+const variantTextColor: Record<ButtonVariant, string> = {
+  primary: colors.bg.canvas,
+  secondary: colors.brand.primary,
+  ghost: colors.brand.primary,
+}
+
+export function Button({
+  label,
+  onPress,
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  loading = false,
+  fullWidth = true,
+  accessibilityLabel,
+}: ButtonProps) {
+  const isInactive = disabled || loading
+  const sz = sizeStyles[size]
+
+  // 동적 분기(variant/size/fullWidth)는 인라인 style 로 분리 (정적/동적 분리 원칙)
+  const containerStyle: StyleProp<ViewStyle> = [
+    styles.base,
+    {
+      paddingVertical: sz.paddingVertical,
+      paddingHorizontal: sz.paddingHorizontal,
+      minHeight: sz.minHeight,
+      alignSelf: fullWidth ? 'stretch' : 'flex-start',
+    },
+    variantContainer[variant],
+  ]
+
+  const labelStyle: StyleProp<TextStyle> = [
+    styles.label,
+    { fontSize: sz.fontSize, color: variantTextColor[variant] },
+  ]
+
+  const indicatorColor =
+    variant === 'primary' ? colors.bg.canvas : colors.brand.primary
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={isInactive}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityState={{ disabled: isInactive, busy: loading }}
+      style={({ pressed }) => [
+        containerStyle,
+        pressed && !isInactive ? styles.pressed : null,
+        disabled ? styles.disabled : null,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator color={indicatorColor} />
+      ) : (
+        <Text style={labelStyle} numberOfLines={1}>
+          {label}
+        </Text>
+      )}
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  base: {
+    borderRadius: radii.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+  },
+  label: {
+    fontWeight: fontWeights.bold,
+  },
+  pressed: {
+    opacity: 0.92,
+    transform: [{ scale: 0.98 }],
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+})

--- a/apps/mobile/components/ui/Card.tsx
+++ b/apps/mobile/components/ui/Card.tsx
@@ -1,0 +1,74 @@
+/**
+ * Card — 카드 컨테이너 Atom (nexvoy-app)
+ *
+ * home `tripCard`(canvas + 1px border + radius + shadows.card) 패턴을 추출.
+ *
+ * - onPress 가 있으면 Pressable, 없으면 View 로 렌더.
+ * - elevated=true → RN 어댑터 `shadows.card` 스프레드(ADR-009: 문자열 shadow 직접 import 금지).
+ * - 정적 스타일은 StyleSheet.create, padding/press 등 런타임 분기는 인라인 style 로 분리.
+ */
+import type { ReactNode } from 'react'
+import {
+  Pressable,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native'
+import { colors, radii, shadows, spacing } from '@/theme'
+
+interface CardProps {
+  children: ReactNode
+  /** 있으면 Pressable, 없으면 View */
+  onPress?: () => void
+  /** true → shadows.card 적용, false(기본) → border만 */
+  elevated?: boolean
+  /** 기본 'md' */
+  padding?: keyof typeof spacing
+  style?: StyleProp<ViewStyle>
+}
+
+export function Card({
+  children,
+  onPress,
+  elevated = false,
+  padding = 'md',
+  style,
+}: CardProps) {
+  // 동적 값(padding 토큰 선택, shadow 스프레드)은 인라인 style 로 분리
+  const baseStyle: StyleProp<ViewStyle> = [
+    styles.card,
+    { padding: spacing[padding] },
+    elevated ? shadows.card : null,
+    style,
+  ]
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        style={({ pressed }) => [
+          baseStyle,
+          pressed ? styles.pressed : null,
+        ]}
+      >
+        {children}
+      </Pressable>
+    )
+  }
+
+  return <View style={baseStyle}>{children}</View>
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.bg.canvas,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.border,
+  },
+  pressed: {
+    transform: [{ scale: 0.99 }],
+  },
+})

--- a/apps/mobile/components/ui/Screen.tsx
+++ b/apps/mobile/components/ui/Screen.tsx
@@ -1,0 +1,89 @@
+/**
+ * Screen — 화면 래퍼 Layout primitive (nexvoy-app)
+ *
+ * 세 화면(login / home / checklist)이 공통으로 반복하던
+ * `SafeAreaView + bg.canvas + edges + paddingHorizontal` 패턴을 컴포넌트로 추출.
+ *
+ * - 토큰은 `@/theme`에서만 import (design-tokens 직접 import 금지).
+ * - 정적 스타일은 StyleSheet.create, 런타임 값(backgroundColor 등)은 인라인 style로 분리.
+ * - scroll=true → ScrollView(폼/긴 콘텐츠), false(기본) → View.
+ *   긴 목록(FlatList)은 scroll=false로 두고 자식에서 직접 렌더(스크롤 중첩 금지).
+ */
+import type { ReactNode } from 'react'
+import {
+  ScrollView,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native'
+import { SafeAreaView, type Edge } from 'react-native-safe-area-context'
+import { colors, spacing } from '@/theme'
+
+interface ScreenProps {
+  children: ReactNode
+  /** true → ScrollView, false(기본) → View */
+  scroll?: boolean
+  /** true(기본) → horizontal spacing.md 패딩 */
+  padded?: boolean
+  /** SafeAreaView edges, 기본 ['top'] */
+  edges?: Edge[]
+  /** 기본 colors.bg.canvas */
+  backgroundColor?: string
+  /** scroll=true 시 ScrollView contentContainerStyle 에 병합 전달 */
+  contentContainerStyle?: StyleProp<ViewStyle>
+  style?: StyleProp<ViewStyle>
+}
+
+const DEFAULT_EDGES: Edge[] = ['top']
+
+export function Screen({
+  children,
+  scroll = false,
+  padded = true,
+  edges = DEFAULT_EDGES,
+  backgroundColor = colors.bg.canvas,
+  contentContainerStyle,
+  style,
+}: ScreenProps) {
+  // 동적 값(backgroundColor)은 인라인 style 로 분리 (정적/동적 분리 원칙)
+  const paddingStyle = padded ? styles.padded : null
+
+  return (
+    <SafeAreaView
+      edges={edges}
+      style={[styles.root, { backgroundColor }, style]}
+    >
+      {scroll ? (
+        <ScrollView
+          style={styles.flex}
+          contentContainerStyle={[
+            styles.scrollContent,
+            paddingStyle,
+            contentContainerStyle,
+          ]}
+          keyboardShouldPersistTaps="handled"
+        >
+          {children}
+        </ScrollView>
+      ) : (
+        <View style={[styles.flex, paddingStyle]}>{children}</View>
+      )}
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+  padded: {
+    paddingHorizontal: spacing.md,
+  },
+})

--- a/apps/mobile/components/ui/index.ts
+++ b/apps/mobile/components/ui/index.ts
@@ -1,0 +1,7 @@
+/**
+ * 공통 UI 컴포넌트 배럴 export (nexvoy-app)
+ * 화면 코드는 `@/components/ui` 에서 가져온다.
+ */
+export { Button } from './Button'
+export { Card } from './Card'
+export { Screen } from './Screen'


### PR DESCRIPTION
## Summary
- `Button`: Pressable 기반, primary/secondary/ghost variant × sm/md/lg size, disabled/loading 상태, 접근성(accessibilityRole, accessibilityState) 적용
- `Card`: default(border) / elevated(shadows.card) variant, onPress 유무로 Pressable/View 분기
- `Screen`: SafeAreaView 래퍼, scroll prop으로 ScrollView/View 분기, padded/edges/contentContainerStyle 지원
- 모든 디자인 토큰은 `@/theme` 경유 (`@nexvoy/design-tokens` 직접 import 금지, ADR-009 준수)

## Test plan
- [x] `pnpm --filter nexvoy-app typecheck` 통과 (타입 오류 0건)
- [x] `pnpm --filter nexvoy-app build` 통과 (web/ios/android 3 플랫폼 번들 생성)
- [x] Reviewer PASS (토큰 사용, Pressable 피드백, 접근성, 타입 안전성 검증)
- [ ] 기존 화면(login/home/checklist) 마이그레이션은 후속 이슈로 분리

Resolves #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)