### PR TITLE
feat(mobile): 여행 상세·체크리스트·회원가입·프로필 화면 구현 (P2-4~P2-6)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -8,6 +8,7 @@
  * - 세션 자동 리다이렉트는 Root _layout 의 auth gate 가 담당. 이 화면은 폼만 책임.
  */
 import { useEffect, useState } from 'react'
+import { useRouter } from 'expo-router'
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -33,6 +34,7 @@ WebBrowser.maybeCompleteAuthSession()
 const REMEMBERED_EMAIL_KEY = 'rememberedEmail'
 
 export default function LoginScreen() {
+  const router = useRouter()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [rememberEmail, setRememberEmail] = useState(false)
@@ -267,7 +269,7 @@ export default function LoginScreen() {
 
             <View style={styles.signupRow}>
               <Text style={styles.signupText}>계정이 없으신가요? </Text>
-              <Pressable>
+              <Pressable onPress={() => router.push('/(auth)/signup')}>
                 <Text style={styles.signupLink}>회원가입하기</Text>
               </Pressable>
             </View>

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,0 +1,403 @@
+/**
+ * 회원가입 화면 (nexvoy-app)
+ *
+ * login.tsx 의 디자인 언어를 그대로 계승. 닉네임(선택)·이메일·비밀번호·확인 필드.
+ * 제출 후 Supabase 인증 메일 발송 → 성공 화면으로 전환.
+ * 세션 생성은 이메일 인증 후 딥링크 콜백에서 처리.
+ */
+import { useState } from 'react'
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { Ionicons } from '@expo/vector-icons'
+import { useRouter } from 'expo-router'
+import { supabase } from '@/lib/supabase'
+import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
+
+export default function SignupScreen() {
+  const router = useRouter()
+  const [nickname, setNickname] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+
+  const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  const isPasswordValid = password.length >= 6
+  const isConfirmValid = password === confirmPassword && isPasswordValid
+  const canSubmit = isEmailValid && isPasswordValid && isConfirmValid && !loading
+
+  const handleSignup = async () => {
+    if (!canSubmit) return
+    setLoading(true)
+    setError(null)
+
+    const { error: signUpError } = await supabase.auth.signUp({
+      email: email.trim(),
+      password,
+      options: {
+        data: { full_name: nickname.trim() || null },
+        emailRedirectTo: 'onvoy://auth/callback',
+      },
+    })
+
+    setLoading(false)
+
+    if (signUpError) {
+      if (signUpError.message.includes('already registered')) {
+        setError('이미 가입된 이메일 주소예요. 로그인을 시도해 보세요.')
+      } else {
+        setError(signUpError.message)
+      }
+      return
+    }
+
+    setDone(true)
+  }
+
+  if (done) {
+    return (
+      <SafeAreaView style={styles.screen} edges={['top', 'bottom']}>
+        <View style={styles.successContainer}>
+          <View style={styles.successIllust}>
+            <Ionicons name="mail-outline" size={40} color={colors.brand.primary} />
+          </View>
+          <Text style={styles.successTitle}>인증 메일을 보냈어요!</Text>
+          <Text style={styles.successDesc}>
+            <Text style={styles.successEmail}>{email}</Text>
+            {'\n'}로 인증 링크를 보냈어요.{'\n'}
+            메일함을 확인하고 링크를 눌러 가입을 완료해 주세요.
+          </Text>
+          <Pressable
+            onPress={() => router.back()}
+            style={({ pressed }) => [
+              styles.backToLoginBtn,
+              pressed && styles.pressedSoft,
+            ]}
+          >
+            <Text style={styles.backToLoginBtnText}>로그인으로 돌아가기</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  return (
+    <SafeAreaView style={styles.screen} edges={['top', 'bottom']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollBody}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.card}>
+            <View style={styles.header}>
+              <View style={styles.brandRow}>
+                <Text style={styles.brandName}>온여정</Text>
+              </View>
+              <Text style={styles.title}>온여정에 오신 걸{'\n'}환영해요!</Text>
+              <Text style={styles.subtitle}>
+                소중한 여행의 모든 순간을 함께 기록해요.
+              </Text>
+            </View>
+
+            <View style={styles.formZone}>
+              <View style={styles.inputGroup}>
+                {/* 닉네임 (선택) */}
+                <View style={[styles.inputCell, styles.inputCellDivider]}>
+                  <Text style={styles.inputLabel}>닉네임 (선택)</Text>
+                  <TextInput
+                    style={styles.textInput}
+                    value={nickname}
+                    onChangeText={setNickname}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder="여행자 이름"
+                    placeholderTextColor={colors.brand.mutedSoft}
+                    returnKeyType="next"
+                  />
+                </View>
+
+                {/* 이메일 */}
+                <View style={[styles.inputCell, styles.inputCellDivider]}>
+                  <Text style={styles.inputLabel}>이메일</Text>
+                  <TextInput
+                    style={styles.textInput}
+                    value={email}
+                    onChangeText={setEmail}
+                    keyboardType="email-address"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder="you@example.com"
+                    placeholderTextColor={colors.brand.mutedSoft}
+                    returnKeyType="next"
+                  />
+                </View>
+
+                {/* 비밀번호 */}
+                <View style={[styles.inputCell, styles.inputCellDivider]}>
+                  <Text style={styles.inputLabel}>비밀번호</Text>
+                  <TextInput
+                    style={styles.textInput}
+                    value={password}
+                    onChangeText={setPassword}
+                    secureTextEntry
+                    placeholder="6자 이상"
+                    placeholderTextColor={colors.brand.mutedSoft}
+                    returnKeyType="next"
+                  />
+                </View>
+
+                {/* 비밀번호 확인 */}
+                <View style={styles.inputCell}>
+                  <Text style={styles.inputLabel}>비밀번호 확인</Text>
+                  <TextInput
+                    style={styles.textInput}
+                    value={confirmPassword}
+                    onChangeText={setConfirmPassword}
+                    secureTextEntry
+                    placeholder="비밀번호를 다시 입력하세요"
+                    placeholderTextColor={colors.brand.mutedSoft}
+                    returnKeyType="done"
+                    onSubmitEditing={handleSignup}
+                  />
+                </View>
+              </View>
+
+              {/* 비밀번호 불일치 인라인 경고 */}
+              {confirmPassword.length > 0 && !isConfirmValid && (
+                <Text style={styles.fieldError}>
+                  비밀번호가 일치하지 않아요.
+                </Text>
+              )}
+
+              {/* 서버 에러 */}
+              {error && (
+                <View style={styles.errorBox}>
+                  <Text style={styles.errorText}>{error}</Text>
+                </View>
+              )}
+
+              <Pressable
+                onPress={handleSignup}
+                disabled={!canSubmit}
+                style={({ pressed }) => [
+                  styles.submitBtn,
+                  pressed && canSubmit && styles.pressedSoft,
+                  !canSubmit && styles.submitBtnDisabled,
+                ]}
+              >
+                {loading ? (
+                  <ActivityIndicator color={colors.bg.canvas} />
+                ) : (
+                  <Text style={styles.submitBtnText}>계정 만들기</Text>
+                )}
+              </Pressable>
+            </View>
+
+            <View style={styles.loginRow}>
+              <Text style={styles.loginText}>이미 계정이 있으신가요? </Text>
+              <Pressable onPress={() => router.back()}>
+                <Text style={styles.loginLink}>로그인하기</Text>
+              </Pressable>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  screen: {
+    flex: 1,
+    backgroundColor: colors.bg.canvas,
+  },
+  scrollBody: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.xl,
+  },
+  card: {
+    width: '100%',
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: spacing.xl,
+  },
+  brandRow: {
+    marginBottom: spacing.lg,
+  },
+  brandName: {
+    fontSize: fontSizes.xl,
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+    letterSpacing: -0.4,
+  },
+  title: {
+    fontSize: fontSizes['3xl'],
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+    marginBottom: spacing.md,
+    letterSpacing: -0.8,
+    textAlign: 'center',
+    lineHeight: 38,
+  },
+  subtitle: {
+    fontSize: fontSizes.base,
+    color: colors.brand.muted,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  formZone: {
+    flexDirection: 'column',
+  },
+  inputGroup: {
+    borderWidth: 1,
+    borderColor: colors.brand.border,
+    borderRadius: radii.md,
+    overflow: 'hidden',
+    marginBottom: spacing.base,
+  },
+  inputCell: {
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.base,
+  },
+  inputCellDivider: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.brand.border,
+  },
+  inputLabel: {
+    fontSize: fontSizes.xs,
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: spacing.xxs,
+  },
+  textInput: {
+    fontSize: fontSizes.md,
+    color: colors.brand.ink,
+    padding: 0,
+  },
+  fieldError: {
+    fontSize: fontSizes.sm,
+    color: colors.brand.error,
+    marginTop: -spacing.sm,
+    marginBottom: spacing.base,
+    paddingHorizontal: spacing.xs,
+  },
+  errorBox: {
+    padding: spacing.md,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.error,
+    backgroundColor: colors.bg.surfaceSoft,
+    marginBottom: spacing.base,
+  },
+  errorText: {
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.medium,
+    color: colors.brand.error,
+  },
+  submitBtn: {
+    paddingVertical: spacing.base,
+    borderRadius: radii.md,
+    backgroundColor: colors.brand.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 52,
+    marginBottom: spacing.lg,
+  },
+  submitBtnDisabled: {
+    opacity: 0.45,
+  },
+  submitBtnText: {
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.bold,
+    color: colors.bg.canvas,
+  },
+  pressedSoft: {
+    opacity: 0.92,
+    transform: [{ scale: 0.98 }],
+  },
+  loginRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: spacing.lg,
+    paddingTop: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.brand.border,
+  },
+  loginText: {
+    fontSize: fontSizes.md,
+    color: colors.brand.muted,
+  },
+  loginLink: {
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+    textDecorationLine: 'underline',
+  },
+  // 성공 화면
+  successContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+    gap: spacing.lg,
+  },
+  successIllust: {
+    width: 88,
+    height: 88,
+    borderRadius: radii.full,
+    backgroundColor: colors.bg.surfaceSoft,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.sm,
+  },
+  successTitle: {
+    fontSize: fontSizes['2xl'],
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+    letterSpacing: -0.5,
+  },
+  successDesc: {
+    fontSize: fontSizes.base,
+    color: colors.brand.muted,
+    textAlign: 'center',
+    lineHeight: 26,
+  },
+  successEmail: {
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+  },
+  backToLoginBtn: {
+    paddingVertical: spacing.base,
+    paddingHorizontal: spacing.xl,
+    borderRadius: radii.md,
+    backgroundColor: colors.brand.primary,
+    marginTop: spacing.sm,
+  },
+  backToLoginBtnText: {
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.bold,
+    color: colors.bg.canvas,
+  },
+})

--- a/apps/mobile/app/(tabs)/checklist.tsx
+++ b/apps/mobile/app/(tabs)/checklist.tsx
@@ -1,29 +1,279 @@
-import { StyleSheet, Text, View } from 'react-native'
+/**
+ * 체크리스트 탭 — 여행 선택 + 준비물 목록 + 체크 토글.
+ * @nexvoy/core 의 getTripsByUser / getChecklistByTrip / toggleChecklistItem 사용(ADR-010).
+ * 여행 칩 선택 → 체크리스트 로드. 낙관적 업데이트 + 실패 시 롤백.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { colors, fontSizes, fontWeights, spacing } from '@/theme'
+import { Ionicons } from '@expo/vector-icons'
+import { getTripsByUser, getChecklistByTrip, toggleChecklistItem } from '@nexvoy/core'
+import type { Trip, Checklist, ChecklistItem } from '@nexvoy/types'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/lib/auth-context'
+import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
 
 export default function ChecklistScreen() {
+  const { session } = useAuth()
+  const [trips, setTrips] = useState<Trip[]>([])
+  const [selectedTripId, setSelectedTripId] = useState<string | null>(null)
+  const [checklist, setChecklist] = useState<Checklist | null>(null)
+  const [items, setItems] = useState<ChecklistItem[]>([])
+  const [tripsLoading, setTripsLoading] = useState(true)
+  const [checklistLoading, setChecklistLoading] = useState(false)
+
+  const loadTrips = useCallback(async () => {
+    if (!session?.user) return
+    setTripsLoading(true)
+    try {
+      const data = await getTripsByUser(supabase, session.user.id)
+      setTrips(data)
+      if (data.length > 0) {
+        setSelectedTripId((prev) => prev ?? data[0].id)
+      }
+    } catch {
+      setTrips([])
+    } finally {
+      setTripsLoading(false)
+    }
+  }, [session?.user])
+
+  const loadChecklist = useCallback(async (tripId: string) => {
+    setChecklistLoading(true)
+    setChecklist(null)
+    setItems([])
+    try {
+      const result = await getChecklistByTrip(supabase, tripId)
+      if (result) {
+        setChecklist(result.checklist)
+        setItems(result.items)
+      }
+    } catch {
+      // 빈 상태 유지
+    } finally {
+      setChecklistLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadTrips()
+  }, [loadTrips])
+
+  useEffect(() => {
+    if (selectedTripId) {
+      loadChecklist(selectedTripId)
+    }
+  }, [selectedTripId, loadChecklist])
+
+  const handleToggle = useCallback(async (item: ChecklistItem) => {
+    const next = !item.is_checked
+    setItems((prev) =>
+      prev.map((i) => (i.id === item.id ? { ...i, is_checked: next } : i))
+    )
+    try {
+      await toggleChecklistItem(supabase, item.id, next)
+    } catch {
+      setItems((prev) =>
+        prev.map((i) =>
+          i.id === item.id ? { ...i, is_checked: item.is_checked } : i
+        )
+      )
+      Alert.alert('오류', '저장에 실패했어요. 다시 시도해 주세요.')
+    }
+  }, [])
+
+  if (tripsLoading) {
+    return (
+      <SafeAreaView style={styles.screen} edges={['top']}>
+        <ScreenHeader />
+        <View style={styles.centerFill}>
+          <ActivityIndicator size="large" color={colors.brand.primary} />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  if (trips.length === 0) {
+    return (
+      <SafeAreaView style={styles.screen} edges={['top']}>
+        <ScreenHeader />
+        <View style={styles.emptyState}>
+          <View style={styles.emptyIllust}>
+            <Ionicons name="map-outline" size={36} color={colors.brand.mutedSoft} />
+          </View>
+          <Text style={styles.emptyTitle}>여행을 먼저 만들어보세요</Text>
+          <Text style={styles.emptyDesc}>
+            여행을 만들면 준비물 체크리스트를 관리할 수 있어요.
+          </Text>
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  const pendingItems = items.filter((i) => !i.is_checked)
+  const doneItems = items.filter((i) => i.is_checked)
+  const totalCount = items.length
+  const doneCount = doneItems.length
+  const progressPct = totalCount > 0 ? doneCount / totalCount : 0
+
   return (
     <SafeAreaView style={styles.screen} edges={['top']}>
-      <View style={styles.header}>
-        <Text style={styles.title}>체크리스트</Text>
-      </View>
-      <View style={styles.emptyState}>
-        <Text style={styles.emptyIcon}>☑️</Text>
-        <Text style={styles.emptyTitle}>준비물이 없어요</Text>
-        <Text style={styles.emptyDesc}>
-          여행을 선택하면 준비물 목록이 여기에 표시됩니다.
-        </Text>
-      </View>
+      <ScreenHeader />
+
+      {/* 여행 선택 칩 */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chipList}
+        style={styles.chipScroll}
+      >
+        {trips.map((trip) => {
+          const selected = trip.id === selectedTripId
+          return (
+            <Pressable
+              key={trip.id}
+              onPress={() => setSelectedTripId(trip.id)}
+              style={[styles.chip, selected && styles.chipSelected]}
+              accessibilityRole="tab"
+              accessibilityState={{ selected }}
+              accessibilityLabel={trip.destination}
+            >
+              <Text
+                style={[styles.chipText, selected && styles.chipTextSelected]}
+                numberOfLines={1}
+              >
+                {trip.destination}
+              </Text>
+            </Pressable>
+          )
+        })}
+      </ScrollView>
+
+      {checklistLoading ? (
+        <View style={styles.centerFill}>
+          <ActivityIndicator size="large" color={colors.brand.primary} />
+        </View>
+      ) : checklist === null ? (
+        <View style={styles.emptyState}>
+          <View style={styles.emptyIllust}>
+            <Ionicons
+              name="checkbox-outline"
+              size={36}
+              color={colors.brand.mutedSoft}
+            />
+          </View>
+          <Text style={styles.emptyTitle}>이 여행에 체크리스트가 없어요</Text>
+          <Text style={styles.emptyDesc}>
+            체크리스트를 추가하면 준비물을 관리할 수 있어요.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView
+          style={styles.contentScroll}
+          contentContainerStyle={styles.contentBody}
+        >
+          {/* 완료율 */}
+          <View style={styles.progressSection}>
+            <Text style={styles.progressLabel}>
+              {doneCount} / {totalCount} 완료
+            </Text>
+            <View style={styles.progressTrack}>
+              <View
+                style={[
+                  styles.progressFill,
+                  { width: `${Math.round(progressPct * 100)}%` },
+                ]}
+              />
+            </View>
+          </View>
+
+          {/* 미완료 항목 */}
+          {pendingItems.length > 0 && (
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>
+                남은 항목 ({pendingItems.length})
+              </Text>
+              {pendingItems.map((item) => (
+                <ItemRow key={item.id} item={item} onToggle={handleToggle} />
+              ))}
+            </View>
+          )}
+
+          {/* 완료 항목 */}
+          {doneItems.length > 0 && (
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>완료 ({doneItems.length})</Text>
+              {doneItems.map((item) => (
+                <ItemRow
+                  key={item.id}
+                  item={item}
+                  onToggle={handleToggle}
+                  done
+                />
+              ))}
+            </View>
+          )}
+        </ScrollView>
+      )}
     </SafeAreaView>
   )
 }
 
+function ScreenHeader() {
+  return (
+    <View style={styles.header}>
+      <Text style={styles.title}>체크리스트</Text>
+    </View>
+  )
+}
+
+interface ItemRowProps {
+  item: ChecklistItem
+  onToggle: (item: ChecklistItem) => void
+  done?: boolean
+}
+
+function ItemRow({ item, onToggle, done = false }: ItemRowProps) {
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.itemRow, pressed && { opacity: 0.7 }]}
+      onPress={() => onToggle(item)}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: done }}
+      accessibilityLabel={item.item_name}
+    >
+      <View style={[styles.checkbox, done && styles.checkboxChecked]}>
+        {done && (
+          <Ionicons name="checkmark" size={12} color={colors.bg.canvas} />
+        )}
+      </View>
+      <View style={styles.itemContent}>
+        <Text
+          style={[styles.itemName, done && styles.itemNameDone]}
+          numberOfLines={2}
+        >
+          {item.item_name}
+        </Text>
+        {item.category.length > 0 ? (
+          <Text style={styles.itemCategory} numberOfLines={1}>
+            {item.category}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  )
+}
+
 const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: colors.bg.canvas,
-  },
+  screen: { flex: 1, backgroundColor: colors.bg.canvas },
   header: {
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.base,
@@ -36,26 +286,137 @@ const styles = StyleSheet.create({
     color: colors.brand.ink,
     letterSpacing: -0.5,
   },
+  centerFill: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  // 여행 칩
+  chipScroll: {
+    flexGrow: 0,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.brand.border,
+  },
+  chipList: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  chip: {
+    borderRadius: radii.full,
+    borderWidth: 1,
+    borderColor: colors.brand.border,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    backgroundColor: colors.bg.canvas,
+  },
+  chipSelected: {
+    backgroundColor: colors.brand.primary,
+    borderColor: colors.brand.primary,
+  },
+  chipText: {
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.medium,
+    color: colors.brand.muted,
+    maxWidth: 120,
+  },
+  chipTextSelected: { color: colors.bg.canvas },
+  // 빈 상태
   emptyState: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: spacing.xl,
-    gap: spacing.md,
+    gap: spacing.base,
   },
-  emptyIcon: {
-    fontSize: 48,
-    marginBottom: spacing.sm,
+  emptyIllust: {
+    width: 80,
+    height: 80,
+    borderRadius: radii.full,
+    backgroundColor: colors.bg.surfaceSoft,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.xs,
   },
   emptyTitle: {
     fontSize: fontSizes.lg,
     fontWeight: fontWeights.semibold,
     color: colors.brand.ink,
+    textAlign: 'center',
   },
   emptyDesc: {
     fontSize: fontSizes.sm,
     color: colors.brand.muted,
     textAlign: 'center',
     lineHeight: 20,
+  },
+  // 콘텐츠
+  contentScroll: { flex: 1 },
+  contentBody: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.xxxl,
+    gap: spacing.lg,
+  },
+  // 완료율
+  progressSection: { gap: spacing.sm },
+  progressLabel: {
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.medium,
+    color: colors.brand.muted,
+  },
+  progressTrack: {
+    height: 6,
+    borderRadius: radii.full,
+    backgroundColor: colors.bg.surfaceSoft,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: radii.full,
+    backgroundColor: colors.brand.primary,
+  },
+  // 섹션
+  section: { gap: spacing.sm },
+  sectionLabel: {
+    fontSize: fontSizes.xs,
+    fontWeight: fontWeights.semibold,
+    color: colors.brand.muted,
+    letterSpacing: 0.5,
+    marginBottom: spacing.xs,
+  },
+  // 아이템 행
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.bg.canvas,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.border,
+    padding: spacing.md,
+    gap: spacing.md,
+  },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: radii.xs,
+    borderWidth: 2,
+    borderColor: colors.brand.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkboxChecked: {
+    backgroundColor: colors.brand.primary,
+    borderColor: colors.brand.primary,
+  },
+  itemContent: { flex: 1, gap: spacing.xxs },
+  itemName: {
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.medium,
+    color: colors.brand.ink,
+  },
+  itemNameDone: {
+    color: colors.brand.muted,
+    textDecorationLine: 'line-through',
+  },
+  itemCategory: {
+    fontSize: fontSizes.xs,
+    color: colors.brand.mutedSoft,
   },
 })

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import {
   View,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { useRouter } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
 import { getTripsByUser, formatDate } from '@nexvoy/core'
 import type { Trip } from '@nexvoy/types'
@@ -22,6 +23,7 @@ import { colors, fontSizes, fontWeights, radii, spacing, shadows } from '@/theme
 
 export default function HomeScreen() {
   const { session } = useAuth()
+  const router = useRouter()
   const [trips, setTrips] = useState<Trip[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -45,6 +47,7 @@ export default function HomeScreen() {
 
   const renderTrip = ({ item }: { item: Trip }) => (
     <Pressable
+      onPress={() => router.push({ pathname: '/trip/[id]', params: { id: item.id } })}
       style={({ pressed }) => [
         styles.tripCard,
         pressed && { opacity: 0.92, transform: [{ scale: 0.99 }] },

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -1,40 +1,145 @@
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+/**
+ * 프로필 탭 — 사용자 정보 표시 + 로그아웃.
+ * @nexvoy/core 의 getProfile 쿼리를 supabase client 주입하여 사용(ADR-010).
+ * avatar_url 미설정 시 닉네임/이메일 이니셜 원형으로 대체.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { Ionicons } from '@expo/vector-icons'
+import { getProfile } from '@nexvoy/core'
+import type { Profile } from '@nexvoy/types'
 import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/lib/auth-context'
 import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
 
+function getInitial(nickname: string | null, email: string | null): string {
+  const src = nickname?.trim() || email?.trim() || '?'
+  return src[0].toUpperCase()
+}
+
+function formatJoinedDate(createdAt: string): string {
+  const [year, month, day] = createdAt.slice(0, 10).split('-')
+  return `${year}년 ${Number(month)}월 ${Number(day)}일 가입`
+}
+
 export default function ProfileScreen() {
-  const handleSignOut = async () => {
-    await supabase.auth.signOut()
+  const { session, signOut } = useAuth()
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const loadProfile = useCallback(async () => {
+    if (!session?.user) return
+    setLoading(true)
+    try {
+      const data = await getProfile(supabase, session.user.id)
+      setProfile(data)
+    } catch {
+      // 로드 실패 시 session 기본값으로 표시
+    } finally {
+      setLoading(false)
+    }
+  }, [session?.user])
+
+  useEffect(() => {
+    loadProfile()
+  }, [loadProfile])
+
+  const handleSignOut = () => {
+    Alert.alert('로그아웃', '정말 로그아웃 하시겠어요?', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '로그아웃',
+        style: 'destructive',
+        onPress: signOut,
+      },
+    ])
   }
+
+  const displayName = profile?.nickname || session?.user?.email?.split('@')[0] || '여행자'
+  const displayEmail = profile?.email || session?.user?.email || ''
+  const initial = getInitial(profile?.nickname ?? null, displayEmail)
+  const isGoogle = profile?.auth_provider === 'google'
 
   return (
     <SafeAreaView style={styles.screen} edges={['top']}>
       <View style={styles.header}>
         <Text style={styles.title}>프로필</Text>
       </View>
-      <View style={styles.body}>
-        <View style={styles.card}>
-          <View style={styles.avatar}>
-            <Text style={styles.avatarText}>👤</Text>
-          </View>
-          <Text style={styles.name}>여행자</Text>
-          <Text style={styles.email}>로그인 정보를 불러오는 중...</Text>
-        </View>
 
-        <TouchableOpacity style={styles.signOutBtn} onPress={handleSignOut}>
-          <Text style={styles.signOutText}>로그아웃</Text>
-        </TouchableOpacity>
-      </View>
+      {loading ? (
+        <View style={styles.centerFill}>
+          <ActivityIndicator size="large" color={colors.brand.primary} />
+        </View>
+      ) : (
+        <View style={styles.body}>
+          {/* 아바타 + 이름 */}
+          <View style={styles.heroCard}>
+            <View style={styles.avatar}>
+              <Text style={styles.avatarInitial}>{initial}</Text>
+            </View>
+            <Text style={styles.displayName}>{displayName}</Text>
+            <Text style={styles.displayEmail}>{displayEmail}</Text>
+
+            {/* 가입 경로 배지 */}
+            <View style={styles.providerBadge}>
+              <Ionicons
+                name={isGoogle ? 'logo-google' : 'mail-outline'}
+                size={13}
+                color={colors.brand.muted}
+              />
+              <Text style={styles.providerText}>
+                {isGoogle ? 'Google 계정' : '이메일 계정'}
+              </Text>
+            </View>
+          </View>
+
+          {/* 정보 행 */}
+          <View style={styles.infoSection}>
+            {profile?.created_at ? (
+              <View style={styles.infoRow}>
+                <Ionicons
+                  name="calendar-outline"
+                  size={16}
+                  color={colors.brand.mutedSoft}
+                />
+                <Text style={styles.infoText}>
+                  {formatJoinedDate(profile.created_at)}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+
+          {/* 로그아웃 */}
+          <Pressable
+            onPress={handleSignOut}
+            style={({ pressed }) => [
+              styles.signOutBtn,
+              pressed && { opacity: 0.7 },
+            ]}
+          >
+            <Ionicons
+              name="log-out-outline"
+              size={18}
+              color={colors.brand.error}
+            />
+            <Text style={styles.signOutText}>로그아웃</Text>
+          </Pressable>
+        </View>
+      )}
     </SafeAreaView>
   )
 }
 
 const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: colors.bg.canvas,
-  },
+  screen: { flex: 1, backgroundColor: colors.bg.canvas },
   header: {
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.base,
@@ -47,46 +152,93 @@ const styles = StyleSheet.create({
     color: colors.brand.ink,
     letterSpacing: -0.5,
   },
+  centerFill: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   body: {
     flex: 1,
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.xl,
-    gap: spacing.xl,
+    gap: spacing.lg,
   },
-  card: {
+  // 아바타 히어로 카드
+  heroCard: {
     alignItems: 'center',
     paddingVertical: spacing.xl,
     backgroundColor: colors.bg.surfaceSoft,
     borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: colors.brand.border,
     gap: spacing.sm,
   },
   avatar: {
     width: 72,
     height: 72,
-    borderRadius: 36,
-    backgroundColor: colors.bg.canvas,
+    borderRadius: radii.full,
+    backgroundColor: colors.brand.primary,
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: spacing.sm,
   },
-  avatarText: {
-    fontSize: 36,
+  avatarInitial: {
+    fontSize: fontSizes['2xl'],
+    fontWeight: fontWeights.bold,
+    color: colors.bg.canvas,
   },
-  name: {
+  displayName: {
     fontSize: fontSizes.lg,
     fontWeight: fontWeights.bold,
     color: colors.brand.ink,
   },
-  email: {
+  displayEmail: {
     fontSize: fontSizes.sm,
     color: colors.brand.muted,
   },
+  providerBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xxs,
+    borderRadius: radii.full,
+    backgroundColor: colors.bg.canvas,
+    borderWidth: 1,
+    borderColor: colors.brand.border,
+  },
+  providerText: {
+    fontSize: fontSizes.xs,
+    color: colors.brand.muted,
+  },
+  // 정보 행
+  infoSection: {
+    gap: spacing.sm,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.base,
+    backgroundColor: colors.bg.surfaceSoft,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.border,
+  },
+  infoText: {
+    fontSize: fontSizes.sm,
+    color: colors.brand.muted,
+  },
+  // 로그아웃
   signOutBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
     paddingVertical: spacing.base,
     borderRadius: radii.md,
     borderWidth: 1,
     borderColor: colors.brand.error,
-    alignItems: 'center',
+    marginTop: 'auto',
+    marginBottom: spacing.lg,
   },
   signOutText: {
     fontSize: fontSizes.base,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -89,6 +89,7 @@ function RootNavigator() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(auth)" />
       <Stack.Screen name="(tabs)" />
+      <Stack.Screen name="trip/[id]" options={{ headerShown: false }} />
     </Stack>
   )
 }

--- a/apps/mobile/app/trip/[id].tsx
+++ b/apps/mobile/app/trip/[id].tsx
@@ -1,0 +1,427 @@
+/**
+ * 여행 상세 화면 — Trip 메타 + 날짜별 일정 타임라인.
+ * @nexvoy/core 의 getTripWithPlans 를 supabase client 주입하여 사용(ADR-010).
+ * loading / error / data 3-상태 분기. 디자인 토큰은 @/theme 사용.
+ *
+ * 날짜/시간 표기는 `new Date()` 생성자 파싱 금지(TZ 왜곡 방지) — 문자열 슬라이싱으로 처리.
+ * 단, "N박 M일" 일수 계산은 자정 고정 date 문자열 차이라 안전하게 Date 연산 사용.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { Ionicons } from '@expo/vector-icons'
+import { getTripWithPlans, formatDate } from '@nexvoy/core'
+import type { Plan, Trip } from '@nexvoy/types'
+import { Card } from '@/components/ui'
+import { supabase } from '@/lib/supabase'
+import {
+  colors,
+  fontSizes,
+  fontWeights,
+  radii,
+  spacing,
+} from '@/theme'
+
+// ─── 날짜/시간 파싱 유틸 (파일 로컬, new Date() 생성자 금지) ───────────────────
+
+/** "2024-06-19 14:30:00" → "14:30" */
+function parseTime(dt: string): string {
+  return dt.replace(' ', 'T').split('T')[1]?.slice(0, 5) ?? ''
+}
+
+/** "2024-06-19 14:30:00" → "2024-06-19" */
+function parseDate(dt: string): string {
+  return dt.split(' ')[0] ?? dt
+}
+
+/** "2024-06-19" → "6월 19일" */
+function formatSectionDate(dateStr: string): string {
+  const [, m, d] = dateStr.split('-')
+  return `${Number(m)}월 ${Number(d)}일`
+}
+
+/**
+ * "N박 M일" 라벨. start/end 모두 YYYY-MM-DD(자정 고정)이라 Date 차이 연산 안전.
+ * nights<=0(당일/이상치)이면 "당일" 처리.
+ */
+function formatDuration(startDate: string, endDate: string): string {
+  const nights = Math.round(
+    (new Date(endDate).getTime() - new Date(startDate).getTime()) / 86400000
+  )
+  if (nights <= 0) return '당일'
+  return `${nights}박 ${nights + 1}일`
+}
+
+// ─── Plan 날짜 그룹화 ─────────────────────────────────────────────────────────
+
+interface PlanGroup {
+  date: string // YYYY-MM-DD
+  plans: Plan[]
+}
+
+/** plans 는 start_datetime_local 오름차순(쿼리 보장) → 순회하며 날짜 파트로 그룹화. */
+function groupPlansByDate(plans: Plan[]): PlanGroup[] {
+  const groups: PlanGroup[] = []
+  for (const plan of plans) {
+    const date = parseDate(plan.start_datetime_local)
+    const last = groups[groups.length - 1]
+    if (last && last.date === date) {
+      last.plans.push(plan)
+    } else {
+      groups.push({ date, plans: [plan] })
+    }
+  }
+  return groups
+}
+
+// ─── 화면 ─────────────────────────────────────────────────────────────────────
+
+export default function TripDetailScreen() {
+  const router = useRouter()
+  const { id } = useLocalSearchParams<{ id: string }>()
+
+  const [trip, setTrip] = useState<Trip | null>(null)
+  const [plans, setPlans] = useState<Plan[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  const loadTrip = useCallback(async () => {
+    if (!id) {
+      setError(true)
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(false)
+    try {
+      const data = await getTripWithPlans(supabase, id)
+      setTrip(data.trip)
+      setPlans(data.plans)
+    } catch {
+      // 상세는 특정 trip 이 필수 → 에러를 명시(빈 목록 흡수 X)
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => {
+    loadTrip()
+  }, [loadTrip])
+
+  const groups = groupPlansByDate(plans)
+
+  return (
+    <SafeAreaView style={styles.screen} edges={['top']}>
+      {/* 헤더 (고정) */}
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="뒤로 가기"
+          hitSlop={12}
+          style={({ pressed }) => [styles.backButton, pressed && styles.pressedFade]}
+        >
+          <Ionicons name="chevron-back" size={24} color={colors.brand.ink} />
+        </Pressable>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {trip?.destination ?? ''}
+        </Text>
+      </View>
+
+      {loading ? (
+        <View style={styles.centerFill}>
+          <ActivityIndicator size="large" color={colors.brand.primary} />
+        </View>
+      ) : error || !trip ? (
+        <View style={styles.centerFill}>
+          <Ionicons
+            name="alert-circle-outline"
+            size={40}
+            color={colors.brand.mutedSoft}
+          />
+          <Text style={styles.errorTitle}>여행 정보를 불러오지 못했어요</Text>
+          <Pressable
+            onPress={loadTrip}
+            accessibilityRole="button"
+            style={({ pressed }) => [pressed && styles.pressedFade]}
+          >
+            <Text style={styles.retryText}>다시 시도</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.body}>
+          {/* 메타 섹션 (평면형) */}
+          <View style={styles.meta}>
+            <Text
+              style={styles.destination}
+              accessibilityRole="header"
+              numberOfLines={2}
+            >
+              {trip.destination}
+            </Text>
+            <View style={styles.metaRow}>
+              <Ionicons
+                name="calendar-outline"
+                size={14}
+                color={colors.brand.muted}
+              />
+              <Text style={styles.metaText}>
+                {formatDate(trip.start_date)} ~ {formatDate(trip.end_date)} ·{' '}
+                {formatDuration(trip.start_date, trip.end_date)}
+              </Text>
+            </View>
+            {trip.adults_count > 0 || trip.children_count > 0 ? (
+              <View style={styles.metaRow}>
+                <Ionicons
+                  name="person-outline"
+                  size={14}
+                  color={colors.brand.muted}
+                />
+                <Text style={styles.metaTextSmall}>
+                  성인 {trip.adults_count}
+                  {trip.children_count > 0 ? ` · 아동 ${trip.children_count}` : ''}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+
+          <View style={styles.divider} />
+
+          {/* 일정 타임라인 */}
+          {groups.length > 0 ? (
+            groups.map((group) => (
+              <View key={group.date} style={styles.section}>
+                <Text style={styles.sectionHeader} accessibilityRole="header">
+                  {formatSectionDate(group.date)}
+                </Text>
+                {group.plans.map((plan) => (
+                  <View key={plan.id} style={styles.timelineRow}>
+                    {/* 레일: 세로선 + dot (장식 → a11y 제외) */}
+                    <View
+                      style={styles.rail}
+                      importantForAccessibility="no"
+                      accessibilityElementsHidden
+                    >
+                      <View style={styles.railLine} />
+                      <View style={styles.dot} />
+                    </View>
+                    {/* 시간 + Plan Card */}
+                    <View style={styles.timelineContent}>
+                      <Text style={styles.timeLabel}>
+                        {parseTime(plan.start_datetime_local)}
+                      </Text>
+                      <Card elevated padding="md" style={styles.planCard}>
+                        <Text style={styles.planTitle} numberOfLines={2}>
+                          {plan.title}
+                        </Text>
+                        {plan.location ? (
+                          <View style={styles.planLocationRow}>
+                            <Ionicons
+                              name="location-outline"
+                              size={13}
+                              color={colors.brand.muted}
+                            />
+                            <Text style={styles.planLocation} numberOfLines={1}>
+                              {plan.location}
+                            </Text>
+                          </View>
+                        ) : null}
+                      </Card>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            ))
+          ) : (
+            <View style={styles.emptyState}>
+              <View style={styles.emptyIllust}>
+                <Ionicons
+                  name="calendar-outline"
+                  size={40}
+                  color={colors.brand.primary}
+                />
+              </View>
+              <Text style={styles.emptyTitle}>아직 등록된 일정이 없어요</Text>
+              <Text style={styles.emptyDesc}>
+                첫 일정을 추가해 여정을 그려보세요.
+              </Text>
+            </View>
+          )}
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  )
+}
+
+const RAIL_WIDTH = 24
+const DOT_SIZE = 8
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.bg.canvas },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.brand.border,
+    gap: spacing.xs,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: fontSizes.lg,
+    fontWeight: fontWeights.semibold,
+    color: colors.brand.ink,
+  },
+  pressedFade: { opacity: 0.7 },
+  centerFill: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.md,
+    paddingHorizontal: spacing.xl,
+  },
+  errorTitle: {
+    fontSize: fontSizes.md,
+    color: colors.brand.muted,
+    textAlign: 'center',
+  },
+  retryText: {
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.semibold,
+    color: colors.brand.primary,
+  },
+  body: {
+    paddingBottom: spacing.xxxl,
+  },
+  meta: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.base,
+    gap: spacing.xs,
+  },
+  destination: {
+    fontSize: fontSizes['4xl'],
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+    letterSpacing: -0.5,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.xxs,
+  },
+  metaText: {
+    fontSize: fontSizes.md,
+    color: colors.brand.muted,
+  },
+  metaTextSmall: {
+    fontSize: fontSizes.sm,
+    color: colors.brand.muted,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.brand.hairlineSoft,
+    marginHorizontal: spacing.lg,
+  },
+  section: {
+    paddingHorizontal: spacing.lg,
+    marginTop: spacing.lg,
+  },
+  sectionHeader: {
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.semibold,
+    color: colors.brand.ink,
+    marginBottom: spacing.sm,
+  },
+  timelineRow: {
+    flexDirection: 'row',
+  },
+  rail: {
+    width: RAIL_WIDTH,
+    alignItems: 'center',
+  },
+  railLine: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    width: 1,
+    backgroundColor: colors.brand.border,
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: radii.full,
+    backgroundColor: colors.brand.mutedSoft,
+    marginTop: spacing.xs,
+  },
+  timelineContent: {
+    flex: 1,
+    paddingBottom: spacing.md,
+    gap: spacing.xs,
+  },
+  timeLabel: {
+    fontSize: fontSizes.sm,
+    color: colors.brand.muted,
+  },
+  planCard: {
+    gap: spacing.xs,
+  },
+  planTitle: {
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.semibold,
+    color: colors.brand.ink,
+  },
+  planLocationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  planLocation: {
+    flex: 1,
+    fontSize: fontSizes.sm,
+    color: colors.brand.muted,
+  },
+  emptyState: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.xxl,
+    gap: spacing.base,
+  },
+  emptyIllust: {
+    width: 96,
+    height: 96,
+    borderRadius: radii.full,
+    backgroundColor: colors.bg.surfaceSoft,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyTitle: {
+    fontSize: fontSizes.lg,
+    fontWeight: fontWeights.semibold,
+    color: colors.brand.ink,
+  },
+  emptyDesc: {
+    fontSize: fontSizes.md,
+    color: colors.brand.muted,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+})

--- a/docs/develop-context/e2e-testing-guide.md
+++ b/docs/develop-context/e2e-testing-guide.md
@@ -44,7 +44,6 @@
 > - 운영 DB가 아닌 **별도 테스트/로컬 Supabase 인스턴스** 사용을 강력히 권장.
 > - service_role 키·비밀번호·토큰은 **테스트 코드나 픽스처에 하드코딩 금지**, 환경변수(`.env.test.local` 등, gitignore 처리)로만 주입.
 > - 테스트 데이터에 **실제 고객/임직원 정보 사용 금지** — 시드 데이터로 격리.
-> - 기준: 야놀자그룹 AI 보안 가이드 https://yanoljagroup.atlassian.net/wiki/spaces/Compliance/pages/2451412038/AI
 
 ### 3.2 Google Maps API
 - E2E에서 실제 호출 시 비용·쿼터 발생 → **mock** 처리하거나 **테스트 전용 키** 분리.

--- a/packages/core/src/supabase/queries.ts
+++ b/packages/core/src/supabase/queries.ts
@@ -101,6 +101,18 @@ export async function getChecklistByTrip(
   return { checklist, items: items ?? [] }
 }
 
+export async function toggleChecklistItem(
+  sb: SupabaseClient,
+  itemId: string,
+  isChecked: boolean
+): Promise<void> {
+  const { error } = await sb
+    .from('checklist_items')
+    .update({ is_checked: isChecked })
+    .eq('id', itemId)
+  if (error) throw error
+}
+
 // ─── Templates ────────────────────────────────────────────────────────────────
 
 export async function getTemplates(


### PR DESCRIPTION
## Summary

### P2-4: 여행 상세 화면 + 홈 네비게이션 연결
- **여행 상세 화면** (`app/trip/[id].tsx`): `getTripWithPlans` 쿼리로 trip + plans 병렬 로드. 커스텀 헤더, 평면형 메타(날짜·N박M일·인원), 날짜별 Plans 타임라인(레일 + elevated Card), 4-상태 분기
- **Root Stack 등록** (`app/_layout.tsx`): `trip/[id]` 스크린 추가
- **홈 네비게이션 연결** (`(tabs)/index.tsx`): 여행 카드 `onPress` → `/trip/[id]` push

### P2-5: 체크리스트 화면 구현
- **체크리스트 탭** (`(tabs)/checklist.tsx`): 수평 스크롤 여행 칩 선택 → 체크리스트 로드. 미완료/완료 섹션 분리 + 완료율 프로그레스 바
- **낙관적 업데이트**: 체크 토글 즉시 반영 → 실패 시 롤백 + Alert
- **`toggleChecklistItem` 헬퍼** (`@nexvoy/core/queries.ts`): ADR-010 레이어 준수

### P2-6a: 회원가입 화면 구현
- **회원가입 화면** (`(auth)/signup.tsx`): 닉네임(선택)/이메일/비밀번호/확인 폼. `supabase.auth.signUp` + `emailRedirectTo: onvoy://auth/callback`. 성공 시 인증 메일 안내 화면 전환
- **로그인 연결** (`(auth)/login.tsx`): '회원가입하기' Pressable에 `router.push('/(auth)/signup')` 연결

### P2-6b: 프로필 화면 구현
- **프로필 탭** (`(tabs)/profile.tsx`): `getProfile` 쿼리로 실제 사용자 데이터 로드. 이니셜 아바타(brand.primary 원형), 닉네임·이메일·가입 경로 배지(Google/이메일)·가입일 표시
- **로그아웃**: Alert 확인 → `signOut` (`TouchableOpacity` → `Pressable` 교체)

## Test plan
- [x] `pnpm --filter nexvoy-app typecheck` 통과
- [x] `pnpm --filter @nexvoy/core typecheck` 통과
- [x] `pnpm --filter nexvoy-web build` 통과 (web 회귀 없음)
- [x] Reviewer PASS
- [x] QA PASS

Resolves #224
Resolves #226
Resolves #227
Resolves #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)