### PR TITLE
fix(web): preserve trip and plan visibility

### DIFF
--- a/apps/web/app/HomeClient.tsx
+++ b/apps/web/app/HomeClient.tsx
@@ -321,7 +321,9 @@ export default function HomeClient() {
                 .from('checklists')
                 .select('id, trip_id')
                 .in('trip_id', tripIds)
-            if (checklistsError) throw checklistsError
+            if (checklistsError) {
+                console.warn('Checklist progress fetch failed; rendering trips without progress', checklistsError)
+            }
 
             ;(checklistRows || []).forEach((checklist: any) => {
                 checklistsByTrip.set(checklist.trip_id, [
@@ -336,7 +338,9 @@ export default function HomeClient() {
                     .from('checklist_items')
                     .select('id, checklist_id, is_checked')
                     .in('checklist_id', checklistIds)
-                if (itemsError) throw itemsError
+                if (itemsError) {
+                    console.warn('Checklist item progress fetch failed; rendering trips without item progress', itemsError)
+                }
 
                 ;(itemRows || []).forEach((item: any) => {
                     itemsByChecklist.set(item.checklist_id, [

--- a/apps/web/app/trips/detail/TripClient.tsx
+++ b/apps/web/app/trips/detail/TripClient.tsx
@@ -207,13 +207,38 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                 return
             }
 
-            const { data, error } = await supabase
+            const { data: planRows, error: plansError } = await supabase
                 .from('plans')
-                .select('*, plan_urls(*)')
+                .select('*')
                 .eq('trip_id', tripId)
                 .order('start_datetime_local', { ascending: true })
+            if (plansError) throw plansError
 
-            if (data && !error) {
+            const planIds = (planRows || []).map((plan: any) => plan.id)
+            let urlsByPlan = new Map<string, any[]>()
+            if (planIds.length > 0) {
+                const { data: urlRows, error: urlsError } = await supabase
+                    .from('plan_urls')
+                    .select('*')
+                    .in('plan_id', planIds)
+                if (urlsError) {
+                    console.warn('Plan URL fetch failed; rendering plans without attached URLs', urlsError)
+                } else {
+                    ;(urlRows || []).forEach((url: any) => {
+                        urlsByPlan.set(url.plan_id, [
+                            ...(urlsByPlan.get(url.plan_id) || []),
+                            url,
+                        ])
+                    })
+                }
+            }
+
+            const data = (planRows || []).map((plan: any) => ({
+                ...plan,
+                plan_urls: urlsByPlan.get(plan.id) || [],
+            }))
+
+            if (data) {
                 setPlans(data)
                 // 명시적 다운로드 정책에 따라 자동 저장은 제거하고 알림만 예약
                 NotificationService.scheduleOfflineReminders(data)
@@ -223,8 +248,6 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                 if (bundle) {
                     DownloadService.downloadTrip(tripId)
                 }
-            } else {
-                throw new Error("Failed to fetch")
             }
         } catch (err) {
             console.error('fetchPlans Error:', err)

--- a/supabase/migrations/20260623000005_restore_plan_visibility.sql
+++ b/supabase/migrations/20260623000005_restore_plan_visibility.sql
@@ -1,0 +1,79 @@
+-- Restore trip plan visibility after checklist/RLS rollout.
+-- Existing trip detail screens read plans and plan_urls directly, so these
+-- policies must stay aligned with trips/checklists access rules.
+
+-- Plans ----------------------------------------------------------------------
+DROP POLICY IF EXISTS "Users can manage plans for their trips" ON public.plans;
+DROP POLICY IF EXISTS "Users with edit permission can manage plans" ON public.plans;
+DROP POLICY IF EXISTS "Viewers can select plans" ON public.plans;
+DROP POLICY IF EXISTS "Public select plans if shared" ON public.plans;
+DROP POLICY IF EXISTS "Select plans if shared or related" ON public.plans;
+DROP POLICY IF EXISTS "Manage plans if editor or owner" ON public.plans;
+
+CREATE POLICY "Select plans if shared or related"
+  ON public.plans
+  FOR SELECT
+  USING (
+    public.check_is_trip_owner(trip_id, auth.uid())
+    OR public.check_is_trip_member(trip_id, auth.uid())
+    OR public.check_is_public_trip(trip_id)
+  );
+
+CREATE POLICY "Manage plans if editor or owner"
+  ON public.plans
+  FOR ALL
+  USING (
+    public.check_is_trip_owner(trip_id, auth.uid())
+    OR public.check_is_trip_editor(trip_id, auth.uid())
+  )
+  WITH CHECK (
+    public.check_is_trip_owner(trip_id, auth.uid())
+    OR public.check_is_trip_editor(trip_id, auth.uid())
+  );
+
+-- Plan URLs ------------------------------------------------------------------
+DROP POLICY IF EXISTS "Users can manage plan urls for their trips" ON public.plan_urls;
+DROP POLICY IF EXISTS "Allow members and public to view plan urls" ON public.plan_urls;
+DROP POLICY IF EXISTS "Allow editors to manage plan urls" ON public.plan_urls;
+
+CREATE POLICY "Allow members and public to view plan urls"
+  ON public.plan_urls
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id
+        AND (
+          public.check_is_trip_owner(p.trip_id, auth.uid())
+          OR public.check_is_trip_member(p.trip_id, auth.uid())
+          OR public.check_is_public_trip(p.trip_id)
+        )
+    )
+  );
+
+CREATE POLICY "Allow editors to manage plan urls"
+  ON public.plan_urls
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id
+        AND (
+          public.check_is_trip_owner(p.trip_id, auth.uid())
+          OR public.check_is_trip_editor(p.trip_id, auth.uid())
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.plans p
+      WHERE p.id = public.plan_urls.plan_id
+        AND (
+          public.check_is_trip_owner(p.trip_id, auth.uid())
+          OR public.check_is_trip_editor(p.trip_id, auth.uid())
+        )
+    )
+  );


### PR DESCRIPTION
## Summary
- Render trip cards even when checklist progress queries fail, so related-data RLS issues do not hide existing trips.
- Fetch plans separately from plan URLs and render plans even if URL attachment lookup fails.
- Add a Supabase migration restoring `plans` and `plan_urls` visibility policies in line with trip access rules.

## Test plan
- [x] pnpm --filter nexvoy-web build

## Notes
- Generated Playwright artifacts remain untracked and are not included.
- `20260623000005_restore_plan_visibility.sql` has already been applied to the production DB during verification.


Made with [Cursor](https://cursor.com)