### PR TITLE
fix(checklist): break checklist item RLS recursion

### DIFF
--- a/apps/web/app/trips/checklist/ChecklistClient.tsx
+++ b/apps/web/app/trips/checklist/ChecklistClient.tsx
@@ -429,13 +429,15 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                 return
             }
 
-            let { data: checklists } = await supabase
+            let { data: checklists, error: checklistsError } = await supabase
                 .from('checklists')
-                .select('id, title')
+                .select('id, title, created_at')
                 .eq('trip_id', tripId)
-                .limit(1)
+                .order('created_at', { ascending: true })
+            if (checklistsError) throw checklistsError
 
-            let currentChecklistId = checklists?.[0]?.id
+            let checklistRows = checklists ?? []
+            let currentChecklistId = checklistRows[0]?.id
 
             if (!currentChecklistId) {
                 const { data: newChecklist } = await supabase
@@ -446,17 +448,21 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
 
                 if (newChecklist) {
                     currentChecklistId = newChecklist.id
+                    checklistRows = [newChecklist]
                 }
             }
 
             if (currentChecklistId) {
-                setChecklistId(currentChecklistId)
+                const checklistIds = checklistRows.map((checklist: any) => checklist.id)
 
                 const [tripRes, itemsRes, membersRes] = await Promise.all([
                     supabase.from('trips').select('*, profiles(nickname, email)').eq('id', tripId).single(),
-                    supabase.from('checklist_items').select('*').eq('checklist_id', currentChecklistId).order('created_at', { ascending: true }),
+                    checklistIds.length > 0
+                        ? supabase.from('checklist_items').select('*').in('checklist_id', checklistIds).order('created_at', { ascending: true })
+                        : Promise.resolve({ data: [], error: null }),
                     supabase.from('trip_members').select('user_id, invited_email, role, status, profiles(nickname, email)').eq('trip_id', tripId).eq('status', 'accepted'),
                 ])
+                if (itemsRes.error) throw itemsRes.error
 
                 if (tripRes.data) {
                     setTripInfo(tripRes.data)
@@ -464,6 +470,10 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                 }
                 
                 if (itemsRes.data) {
+                    const checklistIdWithItems = checklistIds.find((id: string) =>
+                        itemsRes.data.some((item: any) => item.checklist_id === id)
+                    )
+                    setChecklistId(checklistIdWithItems ?? currentChecklistId)
                     setItems(itemsRes.data)
                     // 명시적 다운로드 정책에 따라 자동 저장은 제거
                     

--- a/supabase/migrations/20260623000006_fix_checklist_item_rls_recursion.sql
+++ b/supabase/migrations/20260623000006_fix_checklist_item_rls_recursion.sql
@@ -1,0 +1,154 @@
+-- Break recursive RLS between checklist_items, checklist_item_assignees,
+-- and checklist_item_user_checks. Policy predicates must not query tables
+-- whose policies query back into checklist_items.
+
+CREATE OR REPLACE FUNCTION public.check_can_view_checklist(_checklist_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.checklists c
+    WHERE c.id = _checklist_id
+      AND (
+        public.check_is_trip_owner(c.trip_id, _user_id)
+        OR public.check_is_trip_member(c.trip_id, _user_id)
+        OR public.check_is_public_trip(c.trip_id)
+      )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_can_manage_checklist(_checklist_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.checklists c
+    WHERE c.id = _checklist_id
+      AND (
+        public.check_is_trip_owner(c.trip_id, _user_id)
+        OR public.check_is_trip_editor(c.trip_id, _user_id)
+      )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_can_view_checklist_item(_item_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.checklist_items ci
+    WHERE ci.id = _item_id
+      AND public.check_can_view_checklist(ci.checklist_id, _user_id)
+      AND (
+        COALESCE(ci.is_private, false) = false
+        OR ci.assigned_user_id = _user_id
+        OR EXISTS (
+          SELECT 1
+          FROM public.checklist_item_assignees a
+          WHERE a.item_id = ci.id
+            AND a.user_id = _user_id
+        )
+      )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_can_manage_checklist_item(_item_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.checklist_items ci
+    WHERE ci.id = _item_id
+      AND public.check_can_manage_checklist(ci.checklist_id, _user_id)
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.check_can_view_checklist(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_can_manage_checklist(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.check_can_view_checklist_item(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_can_manage_checklist_item(uuid, uuid) TO authenticated;
+
+-- checklist_items ------------------------------------------------------------
+DROP POLICY IF EXISTS "Users can manage checklist items for their trips" ON public.checklist_items;
+DROP POLICY IF EXISTS "Users with edit permission can manage checklist items" ON public.checklist_items;
+DROP POLICY IF EXISTS "Select checklist items if shared or related" ON public.checklist_items;
+DROP POLICY IF EXISTS "Manage checklist items if editor or owner" ON public.checklist_items;
+DROP POLICY IF EXISTS "Select checklist items by helper" ON public.checklist_items;
+DROP POLICY IF EXISTS "Insert checklist items by checklist helper" ON public.checklist_items;
+DROP POLICY IF EXISTS "Update checklist items by helper" ON public.checklist_items;
+DROP POLICY IF EXISTS "Delete checklist items by helper" ON public.checklist_items;
+
+CREATE POLICY "Select checklist items by helper"
+  ON public.checklist_items
+  FOR SELECT
+  USING (public.check_can_view_checklist_item(id, auth.uid()));
+
+CREATE POLICY "Insert checklist items by checklist helper"
+  ON public.checklist_items
+  FOR INSERT
+  WITH CHECK (public.check_can_manage_checklist(checklist_id, auth.uid()));
+
+CREATE POLICY "Update checklist items by helper"
+  ON public.checklist_items
+  FOR UPDATE
+  USING (public.check_can_manage_checklist_item(id, auth.uid()))
+  WITH CHECK (public.check_can_manage_checklist(checklist_id, auth.uid()));
+
+CREATE POLICY "Delete checklist items by helper"
+  ON public.checklist_items
+  FOR DELETE
+  USING (public.check_can_manage_checklist_item(id, auth.uid()));
+
+-- checklist_item_assignees ---------------------------------------------------
+DROP POLICY IF EXISTS "Users can view assignees for accessible checklist items" ON public.checklist_item_assignees;
+DROP POLICY IF EXISTS "Editors can manage assignees for checklist items" ON public.checklist_item_assignees;
+DROP POLICY IF EXISTS "Select checklist item assignees by helper" ON public.checklist_item_assignees;
+DROP POLICY IF EXISTS "Manage checklist item assignees by helper" ON public.checklist_item_assignees;
+
+CREATE POLICY "Select checklist item assignees by helper"
+  ON public.checklist_item_assignees
+  FOR SELECT
+  USING (public.check_can_view_checklist_item(item_id, auth.uid()));
+
+CREATE POLICY "Manage checklist item assignees by helper"
+  ON public.checklist_item_assignees
+  FOR ALL
+  USING (public.check_can_manage_checklist_item(item_id, auth.uid()))
+  WITH CHECK (public.check_can_manage_checklist_item(item_id, auth.uid()));
+
+-- checklist_item_user_checks -------------------------------------------------
+DROP POLICY IF EXISTS "Users can view user checks for accessible trips" ON public.checklist_item_user_checks;
+DROP POLICY IF EXISTS "Users can manage their own checks" ON public.checklist_item_user_checks;
+DROP POLICY IF EXISTS "Users can view user checks for accessible checklist items" ON public.checklist_item_user_checks;
+DROP POLICY IF EXISTS "Users can manage own checks for accessible checklist items" ON public.checklist_item_user_checks;
+DROP POLICY IF EXISTS "Select checklist item user checks by helper" ON public.checklist_item_user_checks;
+DROP POLICY IF EXISTS "Manage own checklist item user checks by helper" ON public.checklist_item_user_checks;
+
+CREATE POLICY "Select checklist item user checks by helper"
+  ON public.checklist_item_user_checks
+  FOR SELECT
+  USING (public.check_can_view_checklist_item(item_id, auth.uid()));
+
+CREATE POLICY "Manage own checklist item user checks by helper"
+  ON public.checklist_item_user_checks
+  FOR ALL
+  USING (
+    user_id = auth.uid()
+    AND public.check_can_view_checklist_item(item_id, auth.uid())
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    AND public.check_can_view_checklist_item(item_id, auth.uid())
+  );


### PR DESCRIPTION
## Summary
- Break recursive RLS between checklist items, assignees, and per-user checks using security-definer access helpers.
- Load all checklists for a trip and aggregate their items so older registered checklist items remain visible even if duplicate empty checklists exist.

## Test plan
- [x] pnpm --filter nexvoy-web build
- [x] Verified in production-connected local environment after applying `20260623000006_fix_checklist_item_rls_recursion.sql`

## Notes
- Generated Playwright artifacts remain untracked and are not included.


Made with [Cursor](https://cursor.com)