### PR TITLE
Improve template management

### DIFF
--- a/apps/mobile/app/templates/[id].tsx
+++ b/apps/mobile/app/templates/[id].tsx
@@ -8,7 +8,7 @@
  *
  * loading / notfound / form 3-상태 분기. category 는 빈 문자열로 저장(웹 동형).
  */
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Alert,
@@ -27,12 +27,18 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import {
   getChecklistCategories,
   getTemplateWithItems,
+  getTemplateShares,
+  getProfileByEmail,
+  shareTemplate,
+  updateTemplateShareRole,
+  removeTemplateShare,
   updateTemplate,
   replaceTemplateItems,
   deleteTemplate,
 } from '@nexvoy/core'
-import type { ChecklistCategory } from '@nexvoy/types'
+import type { ChecklistCategory, ChecklistTemplateShareRole, ChecklistTemplateShareWithProfile } from '@nexvoy/types'
 import { supabase } from '@/lib/supabase'
+import { BottomSheet } from '@/components/ui'
 import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
 
 const TITLE_MAX = 50
@@ -54,13 +60,33 @@ export default function EditTemplateScreen() {
   const [itemPrivate, setItemPrivate] = useState(false)
   const [items, setItems] = useState<TemplateDraftItem[]>([])
   const [categories, setCategories] = useState<ChecklistCategory[]>([])
+  const [categoryPickerOpen, setCategoryPickerOpen] = useState(false)
+  const [categoryQuery, setCategoryQuery] = useState('')
   const [initialLoading, setInitialLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [templateOwnerId, setTemplateOwnerId] = useState<string | null>(null)
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null)
+  const [shareSheetOpen, setShareSheetOpen] = useState(false)
+  const [shares, setShares] = useState<ChecklistTemplateShareWithProfile[]>([])
+  const [sharesLoading, setSharesLoading] = useState(false)
   const isMounted = useRef(true)
   useEffect(() => () => { isMounted.current = false }, [])
+
+  const loadShares = useCallback(async () => {
+    if (!id) return
+    setSharesLoading(true)
+    try {
+      const data = await getTemplateShares(supabase, id)
+      if (isMounted.current) setShares(data)
+    } catch {
+      if (isMounted.current) setShares([])
+    } finally {
+      if (isMounted.current) setSharesLoading(false)
+    }
+  }, [id])
 
   const loadTemplate = useCallback(async () => {
     if (!id) return
@@ -73,6 +99,7 @@ export default function EditTemplateScreen() {
         return
       }
       setTitle(result.template.title)
+      setTemplateOwnerId(result.template.user_id)
       setItems(result.items.map((it) => ({
         id: it.id,
         item_name: it.item_name,
@@ -80,6 +107,7 @@ export default function EditTemplateScreen() {
         is_private: it.is_private,
       })))
       const { data: { user } } = await supabase.auth.getUser()
+      setCurrentUserId(user?.id ?? null)
       if (user) setCategories(await getChecklistCategories(supabase, user.id))
     } catch {
       if (isMounted.current) setNotFound(true)
@@ -96,6 +124,37 @@ export default function EditTemplateScreen() {
   const canAddItem = trimmedDraft.length > 0
   const busy = saving || deleting
   const canSubmit = title.trim().length > 0 && !busy
+  const canManageShares = Boolean(currentUserId && templateOwnerId === currentUserId)
+  const categoryOptions = useMemo(() => {
+    const base = categories.length > 0 ? categories : [{ id: 'fallback', name: '기타' } as ChecklistCategory]
+    const seen = new Set<string>()
+    return base.filter((category) => {
+      const key = category.name.trim().toLowerCase()
+      if (!key || seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+  }, [categories])
+  const filteredCategoryOptions = useMemo(() => {
+    const query = categoryQuery.trim().toLowerCase()
+    if (!query) return categoryOptions
+    return categoryOptions.filter((category) => category.name.toLowerCase().includes(query))
+  }, [categoryOptions, categoryQuery])
+  const canAddCategoryFromQuery = categoryQuery.trim().length > 0
+    && !categoryOptions.some((category) => category.name.trim().toLowerCase() === categoryQuery.trim().toLowerCase())
+  const groupedItems = useMemo(() => {
+    const groups: { category: string; items: (TemplateDraftItem & { index: number })[] }[] = []
+    items.forEach((item, index) => {
+      const category = item.category.trim() || '기타'
+      const existing = groups.find((group) => group.category === category)
+      if (existing) {
+        existing.items.push({ ...item, index })
+      } else {
+        groups.push({ category, items: [{ ...item, index }] })
+      }
+    })
+    return groups
+  }, [items])
 
   const handleAddItem = () => {
     if (!canAddItem) return
@@ -110,6 +169,8 @@ export default function EditTemplateScreen() {
     ])
     setItemDraft('')
     setItemPrivate(false)
+    setCategoryPickerOpen(false)
+    setCategoryQuery('')
   }
 
   const handleRemoveItem = (index: number) => {
@@ -177,6 +238,35 @@ export default function EditTemplateScreen() {
     )
   }
 
+  const openShareSheet = () => {
+    setShareSheetOpen(true)
+    void loadShares()
+  }
+
+  const handleShareTemplate = async (email: string, role: ChecklistTemplateShareRole) => {
+    if (!id || !currentUserId) return
+    const profile = await getProfileByEmail(supabase, email)
+    if (!profile) throw new Error('해당 이메일의 사용자를 찾을 수 없어요.')
+    if (profile.id === currentUserId) throw new Error('내 계정에는 공유할 수 없어요.')
+    await shareTemplate(supabase, {
+      template_id: id,
+      shared_with_user_id: profile.id,
+      role,
+      created_by: currentUserId,
+    })
+    await loadShares()
+  }
+
+  const handleUpdateShareRole = async (shareId: string, role: ChecklistTemplateShareRole) => {
+    await updateTemplateShareRole(supabase, shareId, role)
+    await loadShares()
+  }
+
+  const handleRemoveShare = async (shareId: string) => {
+    await removeTemplateShare(supabase, shareId)
+    await loadShares()
+  }
+
   return (
     <SafeAreaView style={styles.screen} edges={['top', 'bottom']}>
       <View style={styles.header}>
@@ -192,23 +282,39 @@ export default function EditTemplateScreen() {
         <Text style={styles.headerTitle} accessibilityRole="header">
           템플릿 편집
         </Text>
-        {notFound ? (
-          <View style={styles.headerRight} />
+        {notFound || !canManageShares ? (
+          <View style={styles.headerActions} />
         ) : (
-          <Pressable
-            onPress={handleDelete}
-            disabled={busy || initialLoading}
-            accessibilityRole="button"
-            accessibilityLabel="템플릿 삭제"
-            accessibilityState={{ disabled: busy || initialLoading }}
-            hitSlop={12}
-            style={({ pressed }) => [
-              styles.headerRight,
-              pressed && styles.pressedFade,
-            ]}
-          >
-            <Ionicons name="trash-outline" size={22} color={colors.brand.error} />
-          </Pressable>
+          <View style={styles.headerActions}>
+            <Pressable
+              onPress={openShareSheet}
+              disabled={busy || initialLoading}
+              accessibilityRole="button"
+              accessibilityLabel="템플릿 공유 관리"
+              accessibilityState={{ disabled: busy || initialLoading }}
+              hitSlop={12}
+              style={({ pressed }) => [
+                styles.headerActionButton,
+                pressed && styles.pressedFade,
+              ]}
+            >
+              <Ionicons name="share-social-outline" size={21} color={colors.brand.primary} />
+            </Pressable>
+            <Pressable
+              onPress={handleDelete}
+              disabled={busy || initialLoading}
+              accessibilityRole="button"
+              accessibilityLabel="템플릿 삭제"
+              accessibilityState={{ disabled: busy || initialLoading }}
+              hitSlop={12}
+              style={({ pressed }) => [
+                styles.headerActionButton,
+                pressed && styles.pressedFade,
+              ]}
+            >
+              <Ionicons name="trash-outline" size={22} color={colors.brand.error} />
+            </Pressable>
+          </View>
         )}
       </View>
 
@@ -285,68 +391,165 @@ export default function EditTemplateScreen() {
                   </Text>
                 </Pressable>
               </View>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.categoryChips}
-              >
-                {(categories.length > 0 ? categories : [{ id: 'fallback', name: '기타' } as ChecklistCategory]).map((category) => {
-                  const selected = itemCategory === category.name
-                  return (
-                    <Pressable
-                      key={category.id}
-                      onPress={() => setItemCategory(category.name)}
-                      style={[styles.categoryChip, selected && styles.categoryChipActive]}
+              <View style={styles.itemFormSection}>
+                <Text style={styles.fieldLabel}>카테고리</Text>
+                <Pressable
+                  onPress={() => setCategoryPickerOpen((prev) => !prev)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`카테고리 ${itemCategory} 선택`}
+                  style={({ pressed }) => [
+                    styles.categoryTrigger,
+                    categoryPickerOpen && styles.categoryTriggerActive,
+                    pressed && styles.pressedFade,
+                  ]}
+                >
+                  <View style={styles.categoryTriggerIcon}>
+                    <Ionicons name="pricetag-outline" size={17} color={colors.brand.primary} />
+                  </View>
+                  <Text style={styles.categoryTriggerText} numberOfLines={1}>
+                    {itemCategory || '카테고리 선택'}
+                  </Text>
+                  <Ionicons name={categoryPickerOpen ? 'chevron-up' : 'chevron-down'} size={16} color={colors.brand.muted} />
+                </Pressable>
+
+                {categoryPickerOpen ? (
+                  <View style={styles.categoryPickerPanel}>
+                    <View style={styles.categorySearchBox}>
+                      <Ionicons name="search-outline" size={16} color={colors.brand.muted} />
+                      <TextInput
+                        value={categoryQuery}
+                        onChangeText={setCategoryQuery}
+                        placeholder="카테고리 검색 또는 직접 입력"
+                        placeholderTextColor={colors.brand.mutedSoft}
+                        style={styles.categorySearchInput}
+                      />
+                    </View>
+                    {canAddCategoryFromQuery ? (
+                      <Pressable
+                        onPress={() => {
+                          setItemCategory(categoryQuery.trim())
+                          setCategoryPickerOpen(false)
+                          setCategoryQuery('')
+                        }}
+                        style={({ pressed }) => [styles.categoryOptionRow, styles.categoryAddRow, pressed && styles.pressedFade]}
+                      >
+                        <Text style={[styles.categoryOptionText, styles.categoryAddText]}>+ “{categoryQuery.trim()}”로 추가</Text>
+                      </Pressable>
+                    ) : null}
+                    <ScrollView
+                      nestedScrollEnabled
+                      showsVerticalScrollIndicator={filteredCategoryOptions.length > 5}
+                      keyboardShouldPersistTaps="handled"
+                      style={styles.categoryOptionScroll}
+                      contentContainerStyle={styles.categoryOptionList}
                     >
-                      <Text style={[styles.categoryChipText, selected && styles.categoryChipTextActive]}>
-                        {category.name}
-                      </Text>
-                    </Pressable>
-                  )
-                })}
-              </ScrollView>
+                      {filteredCategoryOptions.map((category) => {
+                        const selected = itemCategory === category.name
+                        return (
+                          <Pressable
+                            key={category.id}
+                            onPress={() => {
+                              setItemCategory(category.name)
+                              setCategoryPickerOpen(false)
+                              setCategoryQuery('')
+                            }}
+                            accessibilityRole="radio"
+                            accessibilityState={{ checked: selected }}
+                            style={({ pressed }) => [
+                              styles.categoryOptionRow,
+                              selected && styles.categoryOptionRowActive,
+                              pressed && styles.pressedFade,
+                            ]}
+                          >
+                            <Text style={[styles.categoryOptionText, selected && styles.categoryOptionTextActive]}>
+                              {category.name}
+                            </Text>
+                            <Ionicons
+                              name={selected ? 'checkmark-circle' : 'ellipse-outline'}
+                              size={20}
+                              color={selected ? colors.brand.primary : colors.brand.mutedSoft}
+                            />
+                          </Pressable>
+                        )
+                      })}
+                    </ScrollView>
+                  </View>
+                ) : null}
+              </View>
               <Pressable
                 onPress={() => setItemPrivate((prev) => !prev)}
                 accessibilityRole="checkbox"
                 accessibilityState={{ checked: itemPrivate }}
-                style={styles.privateToggle}
+                style={({ pressed }) => [styles.privateToggle, pressed && styles.pressedFade]}
               >
+                <View style={styles.privateToggleIcon}>
+                  <Ionicons
+                    name={itemPrivate ? 'lock-closed' : 'lock-open-outline'}
+                    size={17}
+                    color={itemPrivate ? colors.brand.primary : colors.brand.muted}
+                  />
+                </View>
+                <View style={styles.privateToggleBody}>
+                  <Text style={[styles.privateToggleText, itemPrivate && styles.privateToggleTextActive]}>
+                    비공개 항목
+                  </Text>
+                  <Text style={styles.privateToggleMeta}>
+                    템플릿 적용 시 나만 볼 수 있는 개인 준비물로 추가돼요.
+                  </Text>
+                </View>
                 <Ionicons
-                  name={itemPrivate ? 'lock-closed' : 'lock-open-outline'}
-                  size={16}
-                  color={itemPrivate ? colors.brand.primary : colors.brand.muted}
+                  name={itemPrivate ? 'checkmark-circle' : 'ellipse-outline'}
+                  size={20}
+                  color={itemPrivate ? colors.brand.primary : colors.brand.mutedSoft}
                 />
-                <Text style={[styles.privateToggleText, itemPrivate && styles.privateToggleTextActive]}>
-                  비공개 항목
-                </Text>
               </Pressable>
             </View>
 
             {/* 항목 리스트 */}
             {items.length > 0 && (
               <View style={styles.itemList}>
-                {items.map((item, index) => (
-                  <View key={item.id} style={styles.itemRow}>
-                    <View style={styles.itemTextBlock}>
-                      <Text style={styles.itemText} numberOfLines={1}>
-                        {item.item_name}
+                {groupedItems.map((group) => (
+                  <View key={group.category} style={styles.itemCategorySection}>
+                    <View style={styles.itemCategoryHeader}>
+                      <View style={styles.itemCategoryAccent} />
+                      <Text style={styles.itemCategoryTitle} numberOfLines={1}>
+                        {group.category}
                       </Text>
-                      <Text style={styles.itemMeta} numberOfLines={1}>
-                        {item.category}{item.is_private ? ' · 비공개' : ''}
-                      </Text>
+                      <View style={styles.itemCategoryCount}>
+                        <Text style={styles.itemCategoryCountText}>{group.items.length}</Text>
+                      </View>
                     </View>
-                    <Pressable
-                      onPress={() => handleRemoveItem(index)}
-                      accessibilityRole="button"
-                      accessibilityLabel={`${item.item_name} 항목 삭제`}
-                      hitSlop={8}
-                      style={({ pressed }) => [
-                        styles.itemRemoveBtn,
-                        pressed && styles.pressedFade,
-                      ]}
-                    >
-                      <Ionicons name="close" size={18} color={colors.brand.muted} />
-                    </Pressable>
+                    <View style={styles.itemCategoryBody}>
+                      {group.items.map((item) => (
+                        <View key={item.id} style={styles.itemRow}>
+                          <View style={styles.itemTextBlock}>
+                            <View style={styles.itemTitleRow}>
+                              <Text style={styles.itemText} numberOfLines={1}>
+                                {item.item_name}
+                              </Text>
+                              {item.is_private ? (
+                                <View style={styles.itemPrivateBadge}>
+                                  <Ionicons name="lock-closed" size={11} color={colors.brand.primary} />
+                                  <Text style={styles.itemPrivateBadgeText}>비공개</Text>
+                                </View>
+                              ) : null}
+                            </View>
+                          </View>
+                          <Pressable
+                            onPress={() => handleRemoveItem(item.index)}
+                            accessibilityRole="button"
+                            accessibilityLabel={`${item.item_name} 항목 삭제`}
+                            hitSlop={8}
+                            style={({ pressed }) => [
+                              styles.itemRemoveBtn,
+                              pressed && styles.pressedFade,
+                            ]}
+                          >
+                            <Ionicons name="close" size={18} color={colors.brand.muted} />
+                          </Pressable>
+                        </View>
+                      ))}
+                    </View>
                   </View>
                 ))}
               </View>
@@ -381,7 +584,238 @@ export default function EditTemplateScreen() {
           </ScrollView>
         </KeyboardAvoidingView>
       )}
+      <TemplateShareSheet
+        visible={shareSheetOpen}
+        shares={shares}
+        loading={sharesLoading}
+        onClose={() => setShareSheetOpen(false)}
+        onShare={handleShareTemplate}
+        onUpdateRole={handleUpdateShareRole}
+        onRemove={handleRemoveShare}
+      />
     </SafeAreaView>
+  )
+}
+
+function getShareProfileLabel(share: ChecklistTemplateShareWithProfile): string {
+  return share.profiles?.nickname?.trim()
+    || share.profiles?.email?.trim()
+    || '공유 사용자'
+}
+
+function getShareProfileMeta(share: ChecklistTemplateShareWithProfile): string {
+  return share.profiles?.email?.trim() || '이메일 정보 없음'
+}
+
+function TemplateShareSheet({
+  visible,
+  shares,
+  loading,
+  onClose,
+  onShare,
+  onUpdateRole,
+  onRemove,
+}: {
+  visible: boolean
+  shares: ChecklistTemplateShareWithProfile[]
+  loading: boolean
+  onClose: () => void
+  onShare: (email: string, role: ChecklistTemplateShareRole) => Promise<void>
+  onUpdateRole: (shareId: string, role: ChecklistTemplateShareRole) => Promise<void>
+  onRemove: (shareId: string) => Promise<void>
+}) {
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState<ChecklistTemplateShareRole>('viewer')
+  const [submitting, setSubmitting] = useState(false)
+  const [updatingId, setUpdatingId] = useState<string | null>(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!visible) return
+    setEmail('')
+    setRole('viewer')
+    setError('')
+  }, [visible])
+
+  const submit = async () => {
+    const value = email.trim()
+    if (!value) {
+      setError('공유할 사용자의 이메일을 입력해 주세요.')
+      return
+    }
+    setSubmitting(true)
+    setError('')
+    try {
+      await onShare(value, role)
+      setEmail('')
+      setRole('viewer')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '템플릿 공유에 실패했어요.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const updateRole = async (shareId: string, nextRole: ChecklistTemplateShareRole) => {
+    setUpdatingId(shareId)
+    setError('')
+    try {
+      await onUpdateRole(shareId, nextRole)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '권한 변경에 실패했어요.')
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  const remove = async (shareId: string) => {
+    setUpdatingId(shareId)
+    setError('')
+    try {
+      await onRemove(shareId)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '공유 해제에 실패했어요.')
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  return (
+    <BottomSheet visible={visible} title="템플릿 공유" onClose={onClose}>
+      <View style={styles.shareIntroCard}>
+        <View style={styles.shareIntroIcon}>
+          <Ionicons name="people-outline" size={18} color={colors.brand.primary} />
+        </View>
+        <View style={styles.shareIntroBody}>
+          <Text style={styles.shareIntroTitle}>사용자와 템플릿을 공유해요</Text>
+          <Text style={styles.shareIntroText}>뷰어는 템플릿 사용만, 편집자는 템플릿 수정까지 할 수 있어요.</Text>
+        </View>
+      </View>
+
+      <View style={styles.shareForm}>
+        <Text style={styles.fieldLabel}>공유할 사용자</Text>
+        <View style={styles.shareInputBox}>
+          <Ionicons name="mail-outline" size={16} color={colors.brand.muted} />
+          <TextInput
+            value={email}
+            onChangeText={setEmail}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="email-address"
+            placeholder="friend@example.com"
+            placeholderTextColor={colors.brand.mutedSoft}
+            style={styles.shareInput}
+          />
+        </View>
+        <View style={styles.shareRoleRow}>
+          {[
+            { key: 'viewer' as const, label: '뷰어', icon: 'eye-outline' as const },
+            { key: 'editor' as const, label: '편집', icon: 'create-outline' as const },
+          ].map((option) => {
+            const selected = role === option.key
+            return (
+              <Pressable
+                key={option.key}
+                onPress={() => setRole(option.key)}
+                accessibilityRole="radio"
+                accessibilityState={{ checked: selected }}
+                style={({ pressed }) => [
+                  styles.shareRoleButton,
+                  selected && styles.shareRoleButtonActive,
+                  pressed && styles.pressedFade,
+                ]}
+              >
+                <Ionicons
+                  name={option.icon}
+                  size={15}
+                  color={selected ? colors.brand.primary : colors.brand.muted}
+                />
+                <Text style={[styles.shareRoleText, selected && styles.shareRoleTextActive]}>{option.label}</Text>
+              </Pressable>
+            )
+          })}
+        </View>
+        <Pressable
+          onPress={submit}
+          disabled={submitting || !email.trim()}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: submitting || !email.trim() }}
+          style={({ pressed }) => [
+            styles.shareSubmitButton,
+            (submitting || !email.trim()) && styles.submitBtnDisabled,
+            pressed && !submitting && email.trim().length > 0 && styles.pressedSoft,
+          ]}
+        >
+          {submitting ? <ActivityIndicator color={colors.bg.canvas} /> : <Text style={styles.shareSubmitText}>공유 추가</Text>}
+        </Pressable>
+      </View>
+
+      <View style={styles.shareListSection}>
+        <View style={styles.shareListHeader}>
+          <Text style={styles.shareListTitle}>공유 중인 사용자</Text>
+          <View style={styles.shareListCount}>
+            <Text style={styles.shareListCountText}>{shares.length}</Text>
+          </View>
+        </View>
+        {loading ? (
+          <View style={styles.shareLoading}>
+            <ActivityIndicator color={colors.brand.primary} />
+          </View>
+        ) : shares.length === 0 ? (
+          <Text style={styles.shareEmptyText}>아직 공유된 사용자가 없어요.</Text>
+        ) : (
+          <View style={styles.shareList}>
+            {shares.map((share) => (
+              <View key={share.id} style={styles.shareRow}>
+                <View style={styles.shareAvatar}>
+                  <Text style={styles.shareAvatarText}>{getShareProfileLabel(share).slice(0, 1)}</Text>
+                </View>
+                <View style={styles.shareRowBody}>
+                  <Text style={styles.shareName} numberOfLines={1}>{getShareProfileLabel(share)}</Text>
+                  <Text style={styles.shareMeta} numberOfLines={1}>{getShareProfileMeta(share)}</Text>
+                  <View style={styles.shareInlineRoles}>
+                    {(['viewer', 'editor'] as ChecklistTemplateShareRole[]).map((option) => {
+                      const selected = share.role === option
+                      return (
+                        <Pressable
+                          key={option}
+                          onPress={() => updateRole(share.id, option)}
+                          disabled={updatingId === share.id || selected}
+                          style={({ pressed }) => [
+                            styles.shareInlineRoleButton,
+                            selected && styles.shareInlineRoleButtonActive,
+                            pressed && !selected && styles.pressedFade,
+                          ]}
+                        >
+                          <Text style={[styles.shareInlineRoleText, selected && styles.shareInlineRoleTextActive]}>
+                            {option === 'viewer' ? '뷰어' : '편집'}
+                          </Text>
+                        </Pressable>
+                      )
+                    })}
+                  </View>
+                </View>
+                <Pressable
+                  onPress={() => remove(share.id)}
+                  disabled={updatingId === share.id}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${getShareProfileLabel(share)} 공유 해제`}
+                  style={({ pressed }) => [styles.shareRemoveButton, pressed && styles.pressedFade]}
+                >
+                  {updatingId === share.id ? (
+                    <ActivityIndicator color={colors.brand.primary} />
+                  ) : (
+                    <Ionicons name="close" size={18} color={colors.brand.muted} />
+                  )}
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        )}
+      </View>
+
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+    </BottomSheet>
   )
 }
 
@@ -421,6 +855,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  headerActions: {
+    width: 88,
+    height: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+  headerActionButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.full,
+  },
   // 본문
   scrollBody: {
     flexGrow: 1,
@@ -444,6 +892,107 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.base,
     fontWeight: fontWeights.normal,
     color: colors.brand.ink,
+  },
+  itemFormSection: {
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  categoryTrigger: {
+    minHeight: 56,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.canvas,
+  },
+  categoryTriggerActive: {
+    borderColor: colors.brand.primary,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  categoryTriggerIcon: {
+    width: 34,
+    height: 34,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  categoryTriggerText: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.brand.ink,
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.bold,
+  },
+  categoryPickerPanel: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  categorySearchBox: {
+    minHeight: 44,
+    borderRadius: radii.sm,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    paddingHorizontal: spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    backgroundColor: colors.bg.canvas,
+  },
+  categorySearchInput: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.semibold,
+  },
+  categoryOptionList: {
+    gap: spacing.xs,
+    paddingBottom: spacing.xxs,
+  },
+  categoryOptionScroll: {
+    maxHeight: 240,
+  },
+  categoryOptionRow: {
+    minHeight: 48,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.canvas,
+  },
+  categoryOptionRowActive: {
+    borderColor: colors.brand.primary,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  categoryOptionText: {
+    flex: 1,
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.semibold,
+  },
+  categoryOptionTextActive: {
+    color: colors.brand.primary,
+    fontWeight: fontWeights.bold,
+  },
+  categoryAddRow: {
+    borderStyle: 'dashed',
+    borderColor: colors.brand.primary,
+  },
+  categoryAddText: {
+    color: colors.brand.primary,
+    fontWeight: fontWeights.bold,
   },
   // 항목 추가 행
   addRow: {
@@ -493,10 +1042,28 @@ const styles = StyleSheet.create({
     color: colors.brand.primary,
   },
   privateToggle: {
+    minHeight: 64,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    padding: spacing.md,
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing.xs,
-    marginTop: spacing.xs,
+    gap: spacing.md,
+    marginTop: spacing.sm,
+    backgroundColor: colors.bg.canvas,
+  },
+  privateToggleIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  privateToggleBody: {
+    flex: 1,
+    minWidth: 0,
   },
   privateToggleText: {
     fontSize: fontSizes.sm,
@@ -506,23 +1073,99 @@ const styles = StyleSheet.create({
   privateToggleTextActive: {
     color: colors.brand.primary,
   },
+  privateToggleMeta: {
+    marginTop: spacing.xxs,
+    color: colors.brand.muted,
+    fontSize: fontSizes.xs,
+    lineHeight: 17,
+  },
   // 항목 리스트
   itemList: {
     gap: spacing.sm,
     marginBottom: spacing.base,
   },
+  itemListHeader: {
+    minHeight: 56,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  itemListTitle: {
+    flex: 1,
+    color: colors.brand.ink,
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.bold,
+  },
+  itemListCount: {
+    minWidth: 28,
+    height: 28,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.canvas,
+  },
+  itemListCountText: {
+    color: colors.brand.primary,
+    fontSize: fontSizes.xs,
+    fontWeight: fontWeights.bold,
+  },
+  itemCategorySection: {
+    overflow: 'hidden',
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    backgroundColor: colors.bg.canvas,
+  },
+  itemCategoryHeader: {
+    minHeight: 52,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  itemCategoryAccent: {
+    width: 4,
+    height: 20,
+    borderRadius: radii.full,
+    backgroundColor: colors.brand.primary,
+  },
+  itemCategoryTitle: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+  },
+  itemCategoryCount: {
+    minWidth: 24,
+    height: 24,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  itemCategoryCountText: {
+    color: colors.brand.primary,
+    fontSize: 11,
+    fontWeight: fontWeights.bold,
+  },
+  itemCategoryBody: {
+    paddingVertical: spacing.xs,
+  },
   itemRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    borderRadius: radii.sm,
-    borderWidth: 1,
-    borderColor: colors.brand.hairline,
-    backgroundColor: colors.bg.surfaceSoft,
+    gap: spacing.sm,
+    backgroundColor: colors.bg.canvas,
     paddingLeft: spacing.md,
     paddingRight: spacing.xs,
     paddingVertical: spacing.sm,
-    minHeight: 48,
+    minHeight: 58,
   },
   itemText: {
     flex: 1,
@@ -531,16 +1174,42 @@ const styles = StyleSheet.create({
     color: colors.brand.ink,
   },
   itemTextBlock: { flex: 1 },
+  itemTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  itemPrivateBadge: {
+    minHeight: 22,
+    paddingHorizontal: spacing.xs,
+    borderRadius: radii.full,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  itemPrivateBadgeText: {
+    color: colors.brand.primary,
+    fontSize: 10,
+    fontWeight: fontWeights.bold,
+  },
+  itemMetaRow: {
+    marginTop: spacing.xxs,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xxs,
+  },
   itemMeta: {
     fontSize: fontSizes.xs,
     color: colors.brand.muted,
-    marginTop: 2,
   },
   itemRemoveBtn: {
     width: 36,
     height: 36,
+    borderRadius: radii.full,
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
   },
   // 에러 박스
   errorBox: {
@@ -570,6 +1239,225 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.base,
     fontWeight: fontWeights.bold,
     color: colors.bg.canvas,
+  },
+  shareIntroCard: {
+    minHeight: 72,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    padding: spacing.md,
+    flexDirection: 'row',
+    gap: spacing.md,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  shareIntroIcon: {
+    width: 38,
+    height: 38,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.canvas,
+  },
+  shareIntroBody: {
+    flex: 1,
+    minWidth: 0,
+    gap: spacing.xxs,
+  },
+  shareIntroTitle: {
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+  },
+  shareIntroText: {
+    color: colors.brand.muted,
+    fontSize: fontSizes.xs,
+    lineHeight: 17,
+  },
+  shareForm: {
+    marginTop: spacing.base,
+    gap: spacing.sm,
+  },
+  shareInputBox: {
+    minHeight: 48,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.canvas,
+  },
+  shareInput: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.semibold,
+  },
+  shareRoleRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  shareRoleButton: {
+    flex: 1,
+    minHeight: 44,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    backgroundColor: colors.bg.canvas,
+  },
+  shareRoleButtonActive: {
+    borderColor: colors.brand.primary,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  shareRoleText: {
+    color: colors.brand.muted,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.semibold,
+  },
+  shareRoleTextActive: {
+    color: colors.brand.primary,
+    fontWeight: fontWeights.bold,
+  },
+  shareSubmitButton: {
+    minHeight: 48,
+    borderRadius: radii.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.brand.primary,
+  },
+  shareSubmitText: {
+    color: colors.bg.canvas,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+  },
+  shareListSection: {
+    marginTop: spacing.lg,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    overflow: 'hidden',
+    backgroundColor: colors.bg.canvas,
+  },
+  shareListHeader: {
+    minHeight: 50,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  shareListTitle: {
+    flex: 1,
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+  },
+  shareListCount: {
+    minWidth: 24,
+    height: 24,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.canvas,
+  },
+  shareListCountText: {
+    color: colors.brand.primary,
+    fontSize: 11,
+    fontWeight: fontWeights.bold,
+  },
+  shareLoading: {
+    minHeight: 88,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  shareEmptyText: {
+    padding: spacing.md,
+    color: colors.brand.muted,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.semibold,
+    textAlign: 'center',
+  },
+  shareList: {
+    paddingVertical: spacing.xs,
+  },
+  shareRow: {
+    minHeight: 82,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    backgroundColor: colors.bg.canvas,
+  },
+  shareAvatar: {
+    width: 40,
+    height: 40,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  shareAvatarText: {
+    color: colors.brand.primary,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+  },
+  shareRowBody: {
+    flex: 1,
+    minWidth: 0,
+  },
+  shareName: {
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+  },
+  shareMeta: {
+    marginTop: 2,
+    color: colors.brand.muted,
+    fontSize: fontSizes.xs,
+  },
+  shareInlineRoles: {
+    marginTop: spacing.xs,
+    flexDirection: 'row',
+    gap: spacing.xs,
+  },
+  shareInlineRoleButton: {
+    minHeight: 26,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.full,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.canvas,
+  },
+  shareInlineRoleButtonActive: {
+    borderColor: colors.brand.primary,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  shareInlineRoleText: {
+    color: colors.brand.muted,
+    fontSize: fontSizes.xs,
+    fontWeight: fontWeights.semibold,
+  },
+  shareInlineRoleTextActive: {
+    color: colors.brand.primary,
+    fontWeight: fontWeights.bold,
+  },
+  shareRemoveButton: {
+    width: 36,
+    height: 36,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
   },
   // 인터랙션
   pressedSoft: { opacity: 0.92, transform: [{ scale: 0.98 }] },

--- a/apps/mobile/app/templates/new.tsx
+++ b/apps/mobile/app/templates/new.tsx
@@ -7,7 +7,7 @@
  *
  * category 는 빈 문자열로 저장(웹도 단순 항목만 사용). 화면은 폼 UI/검증/상태만 담당.
  */
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -47,6 +47,8 @@ export default function NewTemplateScreen() {
   const [itemPrivate, setItemPrivate] = useState(false)
   const [items, setItems] = useState<TemplateDraftItem[]>([])
   const [categories, setCategories] = useState<ChecklistCategory[]>([])
+  const [categoryPickerOpen, setCategoryPickerOpen] = useState(false)
+  const [categoryQuery, setCategoryQuery] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const isMounted = useRef(true)
@@ -65,6 +67,36 @@ export default function NewTemplateScreen() {
   const trimmedDraft = itemDraft.trim()
   const canAddItem = trimmedDraft.length > 0
   const canSubmit = title.trim().length > 0 && !loading
+  const categoryOptions = useMemo(() => {
+    const base = categories.length > 0 ? categories : [{ id: 'fallback', name: '기타' } as ChecklistCategory]
+    const seen = new Set<string>()
+    return base.filter((category) => {
+      const key = category.name.trim().toLowerCase()
+      if (!key || seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+  }, [categories])
+  const filteredCategoryOptions = useMemo(() => {
+    const query = categoryQuery.trim().toLowerCase()
+    if (!query) return categoryOptions
+    return categoryOptions.filter((category) => category.name.toLowerCase().includes(query))
+  }, [categoryOptions, categoryQuery])
+  const canAddCategoryFromQuery = categoryQuery.trim().length > 0
+    && !categoryOptions.some((category) => category.name.trim().toLowerCase() === categoryQuery.trim().toLowerCase())
+  const groupedItems = useMemo(() => {
+    const groups: { category: string; items: (TemplateDraftItem & { index: number })[] }[] = []
+    items.forEach((item, index) => {
+      const category = item.category.trim() || '기타'
+      const existing = groups.find((group) => group.category === category)
+      if (existing) {
+        existing.items.push({ ...item, index })
+      } else {
+        groups.push({ category, items: [{ ...item, index }] })
+      }
+    })
+    return groups
+  }, [items])
 
   const handleAddItem = () => {
     if (!canAddItem) return
@@ -79,6 +111,8 @@ export default function NewTemplateScreen() {
     ])
     setItemDraft('')
     setItemPrivate(false)
+    setCategoryPickerOpen(false)
+    setCategoryQuery('')
   }
 
   const handleRemoveItem = (index: number) => {
@@ -197,68 +231,165 @@ export default function NewTemplateScreen() {
                 </Text>
               </Pressable>
             </View>
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.categoryChips}
-            >
-              {(categories.length > 0 ? categories : [{ id: 'fallback', name: '기타' } as ChecklistCategory]).map((category) => {
-                const selected = itemCategory === category.name
-                return (
-                  <Pressable
-                    key={category.id}
-                    onPress={() => setItemCategory(category.name)}
-                    style={[styles.categoryChip, selected && styles.categoryChipActive]}
+            <View style={styles.itemFormSection}>
+              <Text style={styles.fieldLabel}>카테고리</Text>
+              <Pressable
+                onPress={() => setCategoryPickerOpen((prev) => !prev)}
+                accessibilityRole="button"
+                accessibilityLabel={`카테고리 ${itemCategory} 선택`}
+                style={({ pressed }) => [
+                  styles.categoryTrigger,
+                  categoryPickerOpen && styles.categoryTriggerActive,
+                  pressed && styles.pressedFade,
+                ]}
+              >
+                <View style={styles.categoryTriggerIcon}>
+                  <Ionicons name="pricetag-outline" size={17} color={colors.brand.primary} />
+                </View>
+                <Text style={styles.categoryTriggerText} numberOfLines={1}>
+                  {itemCategory || '카테고리 선택'}
+                </Text>
+                <Ionicons name={categoryPickerOpen ? 'chevron-up' : 'chevron-down'} size={16} color={colors.brand.muted} />
+              </Pressable>
+
+              {categoryPickerOpen ? (
+                <View style={styles.categoryPickerPanel}>
+                  <View style={styles.categorySearchBox}>
+                    <Ionicons name="search-outline" size={16} color={colors.brand.muted} />
+                    <TextInput
+                      value={categoryQuery}
+                      onChangeText={setCategoryQuery}
+                      placeholder="카테고리 검색 또는 직접 입력"
+                      placeholderTextColor={colors.brand.mutedSoft}
+                      style={styles.categorySearchInput}
+                    />
+                  </View>
+                  {canAddCategoryFromQuery ? (
+                    <Pressable
+                      onPress={() => {
+                        setItemCategory(categoryQuery.trim())
+                        setCategoryPickerOpen(false)
+                        setCategoryQuery('')
+                      }}
+                      style={({ pressed }) => [styles.categoryOptionRow, styles.categoryAddRow, pressed && styles.pressedFade]}
+                    >
+                      <Text style={[styles.categoryOptionText, styles.categoryAddText]}>+ “{categoryQuery.trim()}”로 추가</Text>
+                    </Pressable>
+                  ) : null}
+                  <ScrollView
+                    nestedScrollEnabled
+                    showsVerticalScrollIndicator={filteredCategoryOptions.length > 5}
+                    keyboardShouldPersistTaps="handled"
+                    style={styles.categoryOptionScroll}
+                    contentContainerStyle={styles.categoryOptionList}
                   >
-                    <Text style={[styles.categoryChipText, selected && styles.categoryChipTextActive]}>
-                      {category.name}
-                    </Text>
-                  </Pressable>
-                )
-              })}
-            </ScrollView>
+                    {filteredCategoryOptions.map((category) => {
+                      const selected = itemCategory === category.name
+                      return (
+                        <Pressable
+                          key={category.id}
+                          onPress={() => {
+                            setItemCategory(category.name)
+                            setCategoryPickerOpen(false)
+                            setCategoryQuery('')
+                          }}
+                          accessibilityRole="radio"
+                          accessibilityState={{ checked: selected }}
+                          style={({ pressed }) => [
+                            styles.categoryOptionRow,
+                            selected && styles.categoryOptionRowActive,
+                            pressed && styles.pressedFade,
+                          ]}
+                        >
+                          <Text style={[styles.categoryOptionText, selected && styles.categoryOptionTextActive]}>
+                            {category.name}
+                          </Text>
+                          <Ionicons
+                            name={selected ? 'checkmark-circle' : 'ellipse-outline'}
+                            size={20}
+                            color={selected ? colors.brand.primary : colors.brand.mutedSoft}
+                          />
+                        </Pressable>
+                      )
+                    })}
+                  </ScrollView>
+                </View>
+              ) : null}
+            </View>
             <Pressable
               onPress={() => setItemPrivate((prev) => !prev)}
               accessibilityRole="checkbox"
               accessibilityState={{ checked: itemPrivate }}
-              style={styles.privateToggle}
+              style={({ pressed }) => [styles.privateToggle, pressed && styles.pressedFade]}
             >
+              <View style={styles.privateToggleIcon}>
+                <Ionicons
+                  name={itemPrivate ? 'lock-closed' : 'lock-open-outline'}
+                  size={17}
+                  color={itemPrivate ? colors.brand.primary : colors.brand.muted}
+                />
+              </View>
+              <View style={styles.privateToggleBody}>
+                <Text style={[styles.privateToggleText, itemPrivate && styles.privateToggleTextActive]}>
+                  비공개 항목
+                </Text>
+                <Text style={styles.privateToggleMeta}>
+                  템플릿 적용 시 나만 볼 수 있는 개인 준비물로 추가돼요.
+                </Text>
+              </View>
               <Ionicons
-                name={itemPrivate ? 'lock-closed' : 'lock-open-outline'}
-                size={16}
-                color={itemPrivate ? colors.brand.primary : colors.brand.muted}
+                name={itemPrivate ? 'checkmark-circle' : 'ellipse-outline'}
+                size={20}
+                color={itemPrivate ? colors.brand.primary : colors.brand.mutedSoft}
               />
-              <Text style={[styles.privateToggleText, itemPrivate && styles.privateToggleTextActive]}>
-                비공개 항목
-              </Text>
             </Pressable>
           </View>
 
           {/* 항목 리스트 */}
           {items.length > 0 && (
             <View style={styles.itemList}>
-              {items.map((item, index) => (
-                <View key={item.id} style={styles.itemRow}>
-                  <View style={styles.itemTextBlock}>
-                    <Text style={styles.itemText} numberOfLines={1}>
-                      {item.item_name}
+              {groupedItems.map((group) => (
+                <View key={group.category} style={styles.itemCategorySection}>
+                  <View style={styles.itemCategoryHeader}>
+                    <View style={styles.itemCategoryAccent} />
+                    <Text style={styles.itemCategoryTitle} numberOfLines={1}>
+                      {group.category}
                     </Text>
-                    <Text style={styles.itemMeta} numberOfLines={1}>
-                      {item.category}{item.is_private ? ' · 비공개' : ''}
-                    </Text>
+                    <View style={styles.itemCategoryCount}>
+                      <Text style={styles.itemCategoryCountText}>{group.items.length}</Text>
+                    </View>
                   </View>
-                  <Pressable
-                    onPress={() => handleRemoveItem(index)}
-                    accessibilityRole="button"
-                    accessibilityLabel={`${item.item_name} 항목 삭제`}
-                    hitSlop={8}
-                    style={({ pressed }) => [
-                      styles.itemRemoveBtn,
-                      pressed && styles.pressedFade,
-                    ]}
-                  >
-                    <Ionicons name="close" size={18} color={colors.brand.muted} />
-                  </Pressable>
+                  <View style={styles.itemCategoryBody}>
+                    {group.items.map((item) => (
+                      <View key={item.id} style={styles.itemRow}>
+                        <View style={styles.itemTextBlock}>
+                          <View style={styles.itemTitleRow}>
+                            <Text style={styles.itemText} numberOfLines={1}>
+                              {item.item_name}
+                            </Text>
+                            {item.is_private ? (
+                              <View style={styles.itemPrivateBadge}>
+                                <Ionicons name="lock-closed" size={11} color={colors.brand.primary} />
+                                <Text style={styles.itemPrivateBadgeText}>비공개</Text>
+                              </View>
+                            ) : null}
+                          </View>
+                        </View>
+                        <Pressable
+                          onPress={() => handleRemoveItem(item.index)}
+                          accessibilityRole="button"
+                          accessibilityLabel={`${item.item_name} 항목 삭제`}
+                          hitSlop={8}
+                          style={({ pressed }) => [
+                            styles.itemRemoveBtn,
+                            pressed && styles.pressedFade,
+                          ]}
+                        >
+                          <Ionicons name="close" size={18} color={colors.brand.muted} />
+                        </Pressable>
+                      </View>
+                    ))}
+                  </View>
                 </View>
               ))}
             </View>
@@ -346,6 +477,107 @@ const styles = StyleSheet.create({
     fontWeight: fontWeights.normal,
     color: colors.brand.ink,
   },
+  itemFormSection: {
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  categoryTrigger: {
+    minHeight: 56,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.canvas,
+  },
+  categoryTriggerActive: {
+    borderColor: colors.brand.primary,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  categoryTriggerIcon: {
+    width: 34,
+    height: 34,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  categoryTriggerText: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.brand.ink,
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.bold,
+  },
+  categoryPickerPanel: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  categorySearchBox: {
+    minHeight: 44,
+    borderRadius: radii.sm,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    paddingHorizontal: spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    backgroundColor: colors.bg.canvas,
+  },
+  categorySearchInput: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.semibold,
+  },
+  categoryOptionList: {
+    gap: spacing.xs,
+    paddingBottom: spacing.xxs,
+  },
+  categoryOptionScroll: {
+    maxHeight: 240,
+  },
+  categoryOptionRow: {
+    minHeight: 48,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.canvas,
+  },
+  categoryOptionRowActive: {
+    borderColor: colors.brand.primary,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  categoryOptionText: {
+    flex: 1,
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.semibold,
+  },
+  categoryOptionTextActive: {
+    color: colors.brand.primary,
+    fontWeight: fontWeights.bold,
+  },
+  categoryAddRow: {
+    borderStyle: 'dashed',
+    borderColor: colors.brand.primary,
+  },
+  categoryAddText: {
+    color: colors.brand.primary,
+    fontWeight: fontWeights.bold,
+  },
   // 항목 추가 행
   addRow: {
     flexDirection: 'row',
@@ -394,10 +626,28 @@ const styles = StyleSheet.create({
     color: colors.brand.primary,
   },
   privateToggle: {
+    minHeight: 64,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    padding: spacing.md,
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing.xs,
-    marginTop: spacing.xs,
+    gap: spacing.md,
+    marginTop: spacing.sm,
+    backgroundColor: colors.bg.canvas,
+  },
+  privateToggleIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  privateToggleBody: {
+    flex: 1,
+    minWidth: 0,
   },
   privateToggleText: {
     fontSize: fontSizes.sm,
@@ -407,23 +657,99 @@ const styles = StyleSheet.create({
   privateToggleTextActive: {
     color: colors.brand.primary,
   },
+  privateToggleMeta: {
+    marginTop: spacing.xxs,
+    color: colors.brand.muted,
+    fontSize: fontSizes.xs,
+    lineHeight: 17,
+  },
   // 항목 리스트
   itemList: {
     gap: spacing.sm,
     marginBottom: spacing.base,
   },
+  itemListHeader: {
+    minHeight: 56,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  itemListTitle: {
+    flex: 1,
+    color: colors.brand.ink,
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.bold,
+  },
+  itemListCount: {
+    minWidth: 28,
+    height: 28,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.canvas,
+  },
+  itemListCountText: {
+    color: colors.brand.primary,
+    fontSize: fontSizes.xs,
+    fontWeight: fontWeights.bold,
+  },
+  itemCategorySection: {
+    overflow: 'hidden',
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: colors.brand.hairline,
+    backgroundColor: colors.bg.canvas,
+  },
+  itemCategoryHeader: {
+    minHeight: 52,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  itemCategoryAccent: {
+    width: 4,
+    height: 20,
+    borderRadius: radii.full,
+    backgroundColor: colors.brand.primary,
+  },
+  itemCategoryTitle: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.brand.ink,
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+  },
+  itemCategoryCount: {
+    minWidth: 24,
+    height: 24,
+    borderRadius: radii.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  itemCategoryCountText: {
+    color: colors.brand.primary,
+    fontSize: 11,
+    fontWeight: fontWeights.bold,
+  },
+  itemCategoryBody: {
+    paddingVertical: spacing.xs,
+  },
   itemRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    borderRadius: radii.sm,
-    borderWidth: 1,
-    borderColor: colors.brand.hairline,
-    backgroundColor: colors.bg.surfaceSoft,
+    gap: spacing.sm,
+    backgroundColor: colors.bg.canvas,
     paddingLeft: spacing.md,
     paddingRight: spacing.xs,
     paddingVertical: spacing.sm,
-    minHeight: 48,
+    minHeight: 58,
   },
   itemText: {
     flex: 1,
@@ -432,16 +758,42 @@ const styles = StyleSheet.create({
     color: colors.brand.ink,
   },
   itemTextBlock: { flex: 1 },
+  itemTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  itemPrivateBadge: {
+    minHeight: 22,
+    paddingHorizontal: spacing.xs,
+    borderRadius: radii.full,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    backgroundColor: colors.bg.surfaceSoft,
+  },
+  itemPrivateBadgeText: {
+    color: colors.brand.primary,
+    fontSize: 10,
+    fontWeight: fontWeights.bold,
+  },
+  itemMetaRow: {
+    marginTop: spacing.xxs,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xxs,
+  },
   itemMeta: {
     fontSize: fontSizes.xs,
     color: colors.brand.muted,
-    marginTop: 2,
   },
   itemRemoveBtn: {
     width: 36,
     height: 36,
+    borderRadius: radii.full,
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: colors.bg.surfaceSoft,
   },
   // 에러 박스
   errorBox: {

--- a/apps/mobile/app/trip/[id].tsx
+++ b/apps/mobile/app/trip/[id].tsx
@@ -825,13 +825,39 @@ export default function TripDetailScreen() {
       return
     }
     const next = !status.is_my_checked
+    const previousItems = items
+    const previousUserChecks = userChecks
+
     if (item.assignment_type === 'everyone' || status.required_count > 1) {
-      setUserChecks((prev) => {
+      const assignedIds = itemAssignees
+        .filter((assignee) => assignee.item_id === item.id)
+        .map((assignee) => assignee.user_id)
+      const specificIds = assignedIds.length > 0
+        ? assignedIds
+        : item.assigned_user_id
+          ? [item.assigned_user_id]
+          : []
+      const requiredIds = item.assignment_type === 'everyone' ? participantIds : specificIds
+
+      const nextUserChecks = (() => {
         if (next) {
-          return [...prev, { id: `tmp-${Date.now()}`, item_id: item.id, user_id: session.user.id, created_at: new Date().toISOString() }]
+          const alreadyChecked = userChecks.some((check) => check.item_id === item.id && check.user_id === session.user.id)
+          if (alreadyChecked) return userChecks
+          return [...userChecks, { id: `tmp-${Date.now()}`, item_id: item.id, user_id: session.user.id, created_at: new Date().toISOString() }]
         }
-        return prev.filter((check) => !(check.item_id === item.id && check.user_id === session.user.id))
-      })
+        return userChecks.filter((check) => !(check.item_id === item.id && check.user_id === session.user.id))
+      })()
+      const checkedIds = new Set(
+        nextUserChecks
+          .filter((check) => check.item_id === item.id)
+          .map((check) => check.user_id)
+      )
+      const itemChecked = requiredIds.length > 0 && requiredIds.every((userId) => checkedIds.has(userId))
+
+      setUserChecks(nextUserChecks)
+      setItems((prev) =>
+        prev.map((i) => (i.id === item.id ? { ...i, is_checked: itemChecked } : i))
+      )
     } else {
       setItems((prev) =>
         prev.map((i) => (i.id === item.id ? { ...i, is_checked: next } : i))
@@ -839,14 +865,14 @@ export default function TripDetailScreen() {
     }
     try {
       await toggleChecklistItemForUser(supabase, item, session.user.id, next)
-      await loadChecklist()
     } catch {
       if (isMounted.current) {
-        await loadChecklist()
+        setItems(previousItems)
+        setUserChecks(previousUserChecks)
       }
       Alert.alert('오류', '저장에 실패했어요. 다시 시도해 주세요.')
     }
-  }, [itemAssignees, loadChecklist, participantIds, session?.user.id, userChecks])
+  }, [itemAssignees, items, participantIds, session?.user.id, userChecks])
 
   const handleSaveTrip = useCallback(
     async (input: {

--- a/packages/core/src/supabase/queries.ts
+++ b/packages/core/src/supabase/queries.ts
@@ -1084,13 +1084,11 @@ export async function getProfileByEmail(
   sb: SupabaseClient,
   email: string
 ): Promise<Profile | null> {
-  const { data, error } = await sb
-    .from('profiles')
-    .select('*')
-    .ilike('email', email.trim())
-    .maybeSingle()
+  const { data, error } = await sb.rpc('find_profile_by_email', {
+    _email: email.trim(),
+  })
   if (error) throw error
-  return data ?? null
+  return (Array.isArray(data) ? data[0] : data) ?? null
 }
 
 /**

--- a/supabase/migrations/20260624000004_find_profile_by_email_rpc.sql
+++ b/supabase/migrations/20260624000004_find_profile_by_email_rpc.sql
@@ -1,0 +1,30 @@
+-- Allow exact-email user lookup for collaboration features without opening
+-- broad profile SELECT access through RLS.
+
+CREATE OR REPLACE FUNCTION public.find_profile_by_email(_email text)
+RETURNS TABLE (
+  id uuid,
+  email text,
+  nickname text,
+  auth_provider text,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    p.id,
+    p.email,
+    p.nickname,
+    p.auth_provider,
+    p.created_at,
+    p.updated_at
+  FROM public.profiles p
+  WHERE lower(p.email) = lower(trim(_email))
+  LIMIT 1;
+$$;
+
+REVOKE ALL ON FUNCTION public.find_profile_by_email(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.find_profile_by_email(text) TO authenticated;


### PR DESCRIPTION
## Summary
- Align template create/edit item entry with the checklist category picker and grouped item section UI.
- Add owner-only template sharing management with viewer/editor roles.
- Add exact-email profile lookup RPC for sharing and avoid full checklist reloads on item toggles.

## Test plan
- pnpm --filter @nexvoy/core typecheck
- pnpm --filter nexvoy-app typecheck
- pnpm --filter nexvoy-app lint
- pnpm --filter nexvoy-app build


Made with [Cursor](https://cursor.com)