### PR TITLE
docs: add local-first architecture refactor plan

### DIFF
--- a/docs/plans/PLAN-008-local-first-architecture-review.md
+++ b/docs/plans/PLAN-008-local-first-architecture-review.md
@@ -1,0 +1,147 @@
+# PLAN-008: Local-First Architecture Review
+
+## 결론
+
+현재 상태에서 전환은 가능합니다. 다만 단순한 API 교체가 아니라 데이터 계층과 협업 모델의 대규모 재설계입니다. UI 전체를 버리는 완전 재구축은 피할 수 있지만, `@nexvoy/core`의 Supabase query helper, Supabase RLS 기반 권한 모델, 체크리스트/일정 mutation 흐름은 사실상 새 아키텍처로 다시 짜야 합니다.
+
+권장 판단은 “전체 재구축”이 아니라 “신규 local-first data engine을 병행 구축한 뒤 도메인별 이관”입니다. 가장 먼저 Trip 단위 문서 모델과 동기화 계약을 설계하고, 체크리스트처럼 충돌 병합 가치가 큰 영역부터 실험하는 것이 안전합니다.
+
+## 현재 구조에서 강하게 묶인 지점
+
+- `packages/core/src/supabase/queries.ts`: Trip, Plan, Checklist, Template, 멤버/초대/공유 링크의 주요 조회와 mutation이 Supabase table API와 RPC에 직접 연결되어 있습니다.
+- `supabase/migrations/20260309000001_initial_schema.sql`: 현재 데이터 모델은 정규화된 PostgreSQL 테이블과 RLS가 원본 상태입니다.
+- `supabase/migrations/20260320000001_collaboration_and_sharing.sql`: 협업 권한은 `trip_members`, `trip_shares`, RLS helper 함수에 의존합니다.
+- `apps/web/app/trips/checklist/ChecklistClient.tsx`: 체크리스트는 일부 `@nexvoy/core`를 거치지 않고 화면에서 직접 Supabase read/write를 수행합니다.
+- `apps/web/services/DownloadService.ts`: 현재 오프라인은 local-first 원본이 아니라 Supabase 데이터를 localStorage에 read-only 번들로 복사하는 방식입니다.
+- `apps/mobile/lib/supabase.ts`: 모바일 인증 세션은 Supabase Auth와 SecureStore에 맞춰져 있습니다. 이 부분은 유지 가능합니다.
+
+## 목표 아키텍처 초안
+
+```mermaid
+flowchart TD
+  UI[WebAndMobileUI] --> Repo[DomainRepository]
+  Repo --> LocalStore[LocalDocumentStore]
+  LocalStore --> CRDT[YjsDocuments]
+  CRDT --> P2P[WebRTCProvider]
+  CRDT --> SyncQueue[BackupSyncQueue]
+  SyncQueue --> SupabaseBackup[SupabaseBackupTables]
+  SupabaseAuth[SupabaseAuth] --> Identity[UserIdentity]
+  Identity --> Repo
+  SupabaseBackup --> Restore[DeviceRestore]
+  Restore --> LocalStore
+```
+
+## 핵심 설계 결정
+
+- 저장 단위는 PostgreSQL row가 아니라 “Trip 문서” 단위가 유력합니다. `Trip` 안에 `plans`, `checklist`, `members`, metadata를 CRDT subdocument 또는 map/array로 묶어야 합니다.
+- Supabase는 source of truth가 아니라 auth, device bootstrap, encrypted backup, 초대/권한 registry 역할로 축소해야 합니다.
+- P2P는 실시간 동기화 채널일 뿐 신뢰 가능한 영구 저장소가 아닙니다. 모든 기기가 꺼져 있거나 NAT/방화벽 문제가 있으면 Supabase 백업/relay/restore 경로가 필요합니다.
+- 현재 RLS가 보장하던 권한은 local-first에서는 클라이언트 검증만으로 부족합니다. 백업 업로드, 초대 수락, 멤버 권한 변경은 서버에서 검증되어야 합니다.
+
+## 기존 데이터 호환성
+
+기존 데이터는 버리지 않고 이관 가능합니다. 다만 현재 Supabase row 모델과 local-first CRDT 문서 모델은 저장 단위가 다르므로, “기존 테이블을 그대로 CRDT화”하기보다는 변환 계층이 필요합니다.
+
+현재 보존해야 할 주요 데이터는 다음과 같습니다.
+
+- 사용자/인증: `auth.users`, `profiles`
+- 여행: `trips`
+- 일정: `plans`, `plan_urls`, 장소/사진 관련 컬럼(`location_lat`, `location_lng`, `google_place_id`, `photo_reference`, `image_url`)
+- 준비물: `checklists`, `checklist_categories`, `checklist_items`, `checklist_item_assignees`, `checklist_item_user_checks`
+- 협업/공유: `trip_members`, `trip_shares`, `trip_invitation_links`
+- 부가 기능: `user_devices`, 알림 관련 `plans.alarm_sent_at`, Supabase Storage의 `place-photos`, `trips`, `profiles` 버킷
+
+호환성 관점에서 가장 중요한 결정은 기존 row id를 CRDT 문서 내부 id로 유지하는 것입니다. `trips.id`, `plans.id`, `checklist_items.id`를 새 로컬 id로 바꾸면 기존 공유 링크, 초대, 사진 경로, 알림, E2E seed, 사용자의 북마크/URL이 깨질 수 있습니다.
+
+권장 문서 모델은 Trip 단위입니다.
+
+```mermaid
+flowchart TD
+  SupabaseRows[ExistingSupabaseRows] --> Exporter[RowToDocumentExporter]
+  Exporter --> TripDoc["TripDocument: schemaVersion"]
+  TripDoc --> LocalYjs[YjsLocalStore]
+  LocalYjs --> Snapshot[SupabaseDocumentSnapshot]
+  Snapshot --> Restore[RestoreToNewDevice]
+  TripDoc --> LegacyAdapter[OptionalLegacyRowAdapter]
+  LegacyAdapter --> SupabaseRows
+```
+
+### 호환 가능한 영역
+
+- 기존 사용자 계정은 Supabase Auth를 유지하므로 대부분 그대로 호환됩니다.
+- `profiles`는 계정 메타데이터로 유지할 수 있습니다.
+- 기존 여행/일정/준비물 데이터는 Trip document로 변환 가능합니다.
+- 기존 공개 공유 링크와 초대 토큰은 Supabase registry로 남기면 호환 가능합니다.
+- 기존 사진/첨부 파일은 Storage object path를 document 안에 reference로 보관하면 호환 가능합니다.
+
+### 호환이 어려운 영역
+
+- RLS 기반 권한 검증은 CRDT 문서 내부 변경에는 직접 적용되지 않습니다. 백업 업로드/복구/초대 수락/멤버 변경을 별도 서버 검증 경로로 분리해야 합니다.
+- PostgreSQL 정규화 join 기반 통계와 필터링은 CRDT 문서 저장 후 그대로 쓰기 어렵습니다. 검색/통계용 materialized index를 별도로 만들어야 합니다.
+- `updated_at` 기반 최신성 판단은 CRDT에서는 충분하지 않습니다. Yjs update clock, document version, device vector, tombstone을 함께 써야 합니다.
+- 삭제 데이터는 기존 DB에서는 cascade delete로 사라지지만 CRDT에서는 tombstone이 필요합니다. 즉시 hard delete로 변환하면 다른 기기의 오래된 update가 데이터를 되살릴 수 있습니다.
+- 템플릿 공유와 여행 협업은 권한 스냅샷과 서버 registry가 모두 필요합니다. 단순 P2P만으로는 안전하지 않습니다.
+
+### 마이그레이션 모드
+
+1. Read-through 호환: 기존 Supabase row를 읽어 Trip document로 변환하되, write는 기존 Supabase에 유지합니다. 이 단계는 스파이크와 검증용입니다.
+2. Dual-write 호환: UI write를 repository로 모으고, Supabase row와 CRDT document에 동시에 반영합니다. 충돌과 누락 감지가 핵심입니다.
+3. Document-primary 호환: 로컬 CRDT가 원본이 되고 Supabase에는 snapshot/update log를 백업합니다. 기존 row 테이블은 읽기 전용 legacy view 또는 migration fallback으로 남깁니다.
+4. Legacy 종료: 충분한 검증 후 신규 기능은 document store만 사용합니다. 단, Auth, profile, invitation registry, storage metadata는 Supabase에 유지합니다.
+
+### 백업 테이블 제안
+
+기존 정규화 테이블을 즉시 제거하지 않고, 아래와 같은 새 백업 계층을 추가하는 방식이 안전합니다.
+
+- `documents`: `id`, `owner_id`, `type`, `schema_version`, `snapshot`, `snapshot_hash`, `encrypted`, `created_at`, `updated_at`
+- `document_updates`: `document_id`, `client_id`, `seq`, `update_blob`, `hash`, `created_at`
+- `document_members`: `document_id`, `user_id`, `role`, `status`, `invited_email`
+- `document_devices`: `document_id`, `user_id`, `device_id`, `last_synced_seq`, `last_seen_at`
+- `legacy_row_map`: `document_id`, `table_name`, `row_id`, `path_in_document`
+
+이 구조를 두면 기존 row id와 새 document path를 연결할 수 있어, 데이터 복구와 부분 롤백이 쉬워집니다.
+
+### 롤백 전략
+
+초기 단계에서는 반드시 Supabase row를 authoritative fallback으로 유지해야 합니다. CRDT 변환 실패나 모바일 WebRTC 문제 발생 시 기존 화면을 Supabase repository 구현체로 되돌릴 수 있어야 합니다. 따라서 첫 구현 목표는 “Supabase 제거”가 아니라 “Supabase repository와 Local-first repository를 교체 가능한 구조로 만드는 것”입니다.
+
+## 단계적 전환 전략
+
+1. ADR 작성: “Supabase as Backup/Auth, Local-first as Primary Store”를 새 ADR로 제안합니다. 기존 ADR-010의 Supabase query helper 전략을 대체하거나 하위 호환 기간을 명시합니다.
+2. 저장소 인터페이스 도입: `TripRepository`, `ChecklistRepository`, `TemplateRepository` 같은 인터페이스를 `packages/core`에 만들고 Supabase 구현체를 기존 쿼리 위에 감쌉니다. UI는 repository 인터페이스만 보게 만듭니다.
+3. Local document schema 설계: Trip 문서의 CRDT 구조, stable id, 삭제 tombstone, attachment reference, 멤버 권한 snapshot, schema version을 정의합니다.
+4. 데이터 호환성 설계: 기존 Supabase row id 유지, Trip document path, `legacy_row_map`, schema version, tombstone 정책을 정의합니다.
+5. 파일럿 영역 선정: 체크리스트를 첫 대상으로 권장합니다. 항목 추가/수정/체크는 CRDT 이점이 크고, 일정/초대/사진보다 외부 의존이 적습니다.
+6. 로컬 저장소 구현: 웹은 IndexedDB/OPFS 계열, 모바일은 SQLite/MMKV/Expo SQLite 계열을 검토합니다. Yjs update log와 materialized view를 함께 둡니다.
+7. 동기화 구현: Yjs provider를 플랫폼별로 분리합니다. 웹은 WebRTC가 상대적으로 쉽지만, Expo RN은 `react-native-webrtc` 등 native module 제약이 있어 Expo Go만으로는 어렵습니다.
+8. Supabase 백업 설계: 기존 정규화 테이블을 즉시 버리기보다 `documents`, `document_updates`, `document_snapshots`, `device_sync_state` 같은 백업 테이블을 추가합니다.
+9. 마이그레이션 브리지: 기존 Supabase row 데이터를 Trip document로 변환하고, 일정 기간 dual-write 또는 read-through sync를 운용합니다.
+10. 도메인별 이관: Checklist → Plans → Templates → Collaboration/Invites 순서가 안전합니다. 초대/권한은 마지막에 옮겨야 합니다.
+11. 기존 Supabase write 제거: 안정화 후 화면 직접 Supabase mutation과 `@nexvoy/core/supabase/queries` 의존을 줄이고 백업/인증/복구 경로만 남깁니다.
+
+## 위험도 평가
+
+- 높음: 멀티 사용자 권한, 초대, 데이터 삭제/탈퇴, 충돌 해결 UX, 모바일 WebRTC 지원, 백업 암호화, 데이터 복구.
+- 중간: UI 이식, 도메인 타입 재사용, 단일 사용자 오프라인 편집.
+- 낮음: Supabase Auth 유지, 프로필/계정 관리 유지, 읽기 전용 백업 조회.
+
+## 재구축 여부
+
+완전 재구축은 권장하지 않습니다. 현재 웹/앱 UI, 도메인 타입, 인증 흐름, 일부 서비스는 재사용 가치가 큽니다. 하지만 데이터 계층은 새로 만드는 수준입니다. 체감 난이도는 “앱 재구축의 50~70%” 정도로 보는 것이 현실적입니다.
+
+## 추천 다음 액션
+
+- 1주 스파이크로 체크리스트 1개 여행에 대해 local Yjs document, IndexedDB 저장, 단일 탭/다중 탭 동기화, Supabase snapshot backup을 검증합니다.
+- 이 스파이크에는 기존 Supabase row를 Trip document로 변환하고 다시 legacy row 형태로 복원하는 round-trip 검증을 포함합니다.
+- 동시에 Expo RN에서 WebRTC/Yjs provider가 실제 빌드 가능한지 확인합니다. 이 결과가 전체 전환 가능성을 좌우합니다.
+- 스파이크 성공 후에만 본격 ADR과 마이그레이션 로드맵을 확정합니다.
+
+## 검토 TODO
+
+- [ ] Local-first 전환 ADR 초안 작성 및 기존 ADR-010과의 관계 정의
+- [ ] 현재 Supabase query helper 앞에 도메인 Repository 인터페이스 설계
+- [ ] 체크리스트 도메인으로 Yjs local document + local persistence 스파이크 수행
+- [ ] Expo RN 환경에서 WebRTC/Yjs provider 빌드 가능성 검증
+- [ ] Supabase 백업용 document/update/snapshot 테이블 설계
+- [ ] 기존 Supabase row 데이터를 Trip document로 변환하는 마이그레이션 브리지 설계
+- [ ] 기존 Supabase 데이터와 Local-first 문서 모델 간 호환성/복구 전략 정의

--- a/docs/refactor/TECHNICAL-SPEC.md
+++ b/docs/refactor/TECHNICAL-SPEC.md
@@ -1,0 +1,770 @@
+# Local-First Data Engine Technical Spec
+
+## 1. 목적
+
+OnVoy의 데이터 통신 구조를 Supabase 원본 DB 중심에서 Local-first 원본 저장소 중심으로 전환한다. 클라이언트는 로컬 저장소와 CRDT(Yjs)를 우선 사용하고, P2P(WebRTC)로 실시간 협업을 수행한다. Supabase는 사용자 인증, 권한 registry, 백업, 복구, 초대/공유 bootstrap, 첨부 파일 저장을 담당한다.
+
+본 문서는 실제 구현을 위한 기술 명세다. 최종 아키텍처 결정은 `docs/refactor/adrs/ADR-001-local-first-data-engine.md`를 따른다.
+
+## 2. 범위
+
+### 포함
+
+- Trip 단위 Local-first document model
+- Yjs 기반 CRDT document/update 저장 전략
+- Web/RN 로컬 영속화 계층
+- WebRTC P2P 동기화 계층
+- Supabase backup/auth/registry 계층
+- 지연 인증, 소셜 로그인, guest data 승격 전략
+- 초대, 공유, 권한 registry 전략
+- 푸시/로컬 알림 전략
+- 기존 Supabase row 데이터 호환성 및 마이그레이션 전략
+- Repository 추상화
+- 단계별 이관 전략
+- 스파이크 및 검증 기준
+
+### 제외
+
+- 즉시 전체 도메인 전환
+- Supabase Auth 제거
+- Supabase Storage 제거
+- 기존 row 테이블 즉시 삭제
+- 모든 통계/검색 기능의 최종 구현
+- 암호화 세부 구현 및 cryptographic primitive 최종 확정
+
+## 3. 현재 상태 요약
+
+현재 OnVoy는 Supabase가 다음 역할을 모두 담당한다.
+
+- 인증: Supabase Auth, OAuth, 세션 저장
+- 원본 DB: `trips`, `plans`, `checklists`, `checklist_items`, `templates`
+- 권한: RLS, `trip_members`, helper RPC
+- 협업: 초대, 공유 링크, 멤버 권한
+- 알림: `user_devices`, push Edge Function, 일정 알림 RPC/trigger
+- 백엔드 로직: RPC, Edge Function, trigger
+- Storage: place photos, trip/profile assets
+- 일부 실시간: Supabase Realtime hook
+
+주요 결합 파일:
+
+- `packages/core/src/supabase/queries.ts`
+- `apps/web/app/trips/detail/TripClient.tsx`
+- `apps/web/app/trips/checklist/ChecklistClient.tsx`
+- `apps/mobile/app/trip/[id].tsx`
+- `apps/web/services/DownloadService.ts`
+- `apps/mobile/lib/supabase.ts`
+- `supabase/migrations/*.sql`
+
+## 4. 목표 아키텍처
+
+```mermaid
+flowchart TD
+  UI[WebAndMobileUI] --> Repo[DomainRepository]
+  Repo --> LocalStore[LocalDocumentStore]
+  LocalStore --> YDoc[YjsTripDocument]
+  YDoc --> MaterializedView[MaterializedReadModels]
+  YDoc --> P2P["OptionalWebRTCProvider"]
+  YDoc --> BackupQueue["PrimaryBackupSyncQueue"]
+  BackupQueue --> SupabaseBackup[SupabaseBackupTables]
+  SupabaseAuth[SupabaseAuth] --> Identity[IdentityContext]
+  SupabaseRegistry[SupabaseRegistry] --> Identity
+  Identity --> Repo
+  SupabaseBackup --> Restore[DeviceRestore]
+  Restore --> LocalStore
+```
+
+핵심 원칙:
+
+- UI는 Supabase client나 Yjs를 직접 호출하지 않는다.
+- UI는 `Repository` 인터페이스만 사용한다.
+- Local-first repository가 원본이다.
+- Supabase repository는 전환 기간의 fallback 및 legacy adapter다.
+- Supabase backup은 암호화된 CRDT snapshot/update를 저장하며 기본 sync/restore 경로다.
+- WebRTC P2P는 동시 접속 중인 peer 간 빠른 전파를 위한 optional fast path다.
+- Supabase RLS는 document registry와 backup row 접근에만 적용한다.
+
+## 5. 패키지 구조
+
+제안 구조:
+
+```text
+packages/core/src/
+  repositories/
+    tripRepository.ts
+    checklistRepository.ts
+    templateRepository.ts
+    types.ts
+  local-first/
+    documentModel.ts
+    tripDocument.ts
+    migrations.ts
+    materialize.ts
+    tombstone.ts
+    permissions.ts
+  sync/
+    backupTypes.ts
+    syncState.ts
+    conflictPolicy.ts
+  supabase/
+    queries.ts
+    legacyRepository.ts
+    backupRepository.ts
+
+apps/web/lib/local-first/
+  indexedDbStore.ts
+  webRtcProvider.ts
+  repositoryFactory.ts
+
+apps/mobile/lib/local-first/
+  sqliteStore.ts
+  webRtcProvider.native.ts
+  repositoryFactory.ts
+```
+
+`packages/core`에는 플랫폼 API를 넣지 않는다. IndexedDB, SQLite, WebRTC provider 생성은 앱 레이어에서 담당한다.
+
+## 6. Repository 인터페이스
+
+첫 단계에서는 기존 `@nexvoy/core/supabase/queries`를 즉시 제거하지 않고 repository로 감싼다.
+
+예시:
+
+```ts
+export interface TripRepository {
+  listTrips(userId: string): Promise<TripSummary[]>
+  getTripDocument(tripId: string): Promise<TripDocument | null>
+  createTrip(input: CreateTripInput): Promise<TripDocument>
+  updateTrip(tripId: string, patch: TripPatch): Promise<void>
+  deleteTrip(tripId: string): Promise<void>
+}
+
+export interface ChecklistRepository {
+  getChecklist(tripId: string): Promise<ChecklistReadModel>
+  createItem(tripId: string, input: ChecklistItemInput): Promise<string>
+  updateItem(tripId: string, itemId: string, patch: ChecklistItemPatch): Promise<void>
+  deleteItem(tripId: string, itemId: string): Promise<void>
+  toggleItemForUser(tripId: string, itemId: string, userId: string): Promise<void>
+}
+```
+
+구현체:
+
+- `SupabaseTripRepository`: 현재 Supabase queries 사용
+- `LocalFirstTripRepository`: Yjs document 사용
+- `DualWriteTripRepository`: migration 기간에 Supabase와 Local-first에 동시 반영
+
+## 7. Trip Document Model
+
+저장 단위는 Trip 단위 단일 Yjs 문서다. `ADR-005` 결정에 따라 초기 구현은 Trip 하나를 하나의 CRDT document로 저장한다. 기존 row id를 내부 id로 유지한다.
+
+```ts
+export interface TripDocumentV1 {
+  schemaVersion: 1
+  trip: {
+    id: string
+    ownerId: string
+    destination: string
+    startDate: string
+    endDate: string
+    adultsCount: number
+    childrenCount: number
+    coverImageRef: string | null
+    bgColor: string | null
+    createdAt: string
+    updatedAt: string
+  }
+  plans: Record<string, PlanNode>
+  planOrder: string[]
+  planUrls: Record<string, PlanUrlNode>
+  checklists: Record<string, ChecklistNode>
+  checklistItems: Record<string, ChecklistItemNode>
+  checklistCategories: Record<string, ChecklistCategoryNode>
+  checklistItemAssignees: Record<string, ChecklistItemAssigneeNode>
+  checklistItemUserChecks: Record<string, ChecklistItemUserCheckNode>
+  members: Record<string, TripMemberNode>
+  shares: Record<string, TripShareNode>
+  assets: Record<string, AssetRefNode>
+  tombstones: Record<string, TombstoneNode>
+  meta: {
+    createdFromLegacyAt?: string
+    lastLegacyExportAt?: string
+    lastBackupAt?: string
+  }
+}
+```
+
+Yjs 내부 표현:
+
+- `trip`: `Y.Map`
+- `plans`: `Y.Map<Y.Map>`
+- `planOrder`: `Y.Array<string>`
+- `checklistItems`: `Y.Map<Y.Map>`
+- user checks: `Y.Map<Y.Map>` 또는 item별 `Y.Map`
+- tombstones: `Y.Map`
+
+정렬이 필요한 컬렉션은 `Y.Array` 또는 명시적 `sort_order`를 사용한다. `created_at`에 의존한 정렬은 동시 작성 시 불안정하다.
+
+## 8. 기존 데이터 매핑
+
+### Trip
+
+| Supabase | Document |
+| --- | --- |
+| `trips.id` | `trip.id` 및 document id |
+| `trips.user_id` | `trip.ownerId` |
+| `destination` | `trip.destination` |
+| `start_date` | `trip.startDate` |
+| `end_date` | `trip.endDate` |
+| `adults_count` | `trip.adultsCount` |
+| `children_count` | `trip.childrenCount` |
+| `cover_image_ref` | `trip.coverImageRef` |
+| `bg_color` | `trip.bgColor` |
+
+### Plan
+
+| Supabase | Document |
+| --- | --- |
+| `plans.id` | `plans[id].id` |
+| `trip_id` | document id로 암묵 참조 |
+| `title` | `plans[id].title` |
+| `location`, `address` | `plans[id].location`, `plans[id].address` |
+| `location_lat`, `location_lng` | `plans[id].coordinates` |
+| `google_place_id` | `plans[id].googlePlaceId` |
+| `image_url` | `plans[id].imageUrl` |
+| `photo_reference` | `plans[id].photoReference` |
+| `start_datetime_local` | `plans[id].startDateTimeLocal` |
+| `end_datetime_local` | `plans[id].endDateTimeLocal` |
+| `timezone_string` | `plans[id].timezone` |
+| `alarm_minutes_before` | `plans[id].alarmMinutesBefore` |
+| `alarm_sent_at` | `plans[id].alarmSentAt` |
+| `is_visited` | `plans[id].isVisited` |
+
+`plan_urls`는 `plans[id].urls`로 embed하거나 `planUrls` map으로 유지한다. 기존 row id 호환성을 우선하면 `planUrls` map 유지가 안전하다.
+
+### Checklist
+
+| Supabase | Document |
+| --- | --- |
+| `checklists.id` | `checklists[id].id` |
+| `checklist_items.id` | `checklistItems[id].id` |
+| `item_name` | `checklistItems[id].name` |
+| `category` | `checklistItems[id].categoryName` |
+| `is_private` | `checklistItems[id].isPrivate` |
+| `assignment_type` | `checklistItems[id].assignmentType` |
+| `assigned_user_id` | `checklistItems[id].assignedUserId` |
+| `source_template_name` | `checklistItems[id].sourceTemplateName` |
+| `checklist_item_assignees` | `checklistItemAssignees` |
+| `checklist_item_user_checks` | `checklistItemUserChecks` |
+
+`is_checked`는 legacy 호환 필드로만 취급한다. CRDT에서는 `assignmentType`에 따라 user check map에서 상태를 계산한다.
+
+### Collaboration
+
+`trip_members`, `trip_shares`, `trip_invitation_links`는 document 내부에도 snapshot을 보관하지만, 최종 권한 검증과 초대 수락은 Supabase registry를 source of authority로 둔다.
+
+## 9. Supabase 백업 스키마
+
+기존 row 테이블은 즉시 제거하지 않는다. 새 backup/registry 테이블을 추가한다.
+
+```sql
+create table public.documents (
+  id uuid primary key,
+  owner_id uuid references public.profiles(id) not null,
+  type text not null check (type in ('trip', 'template')),
+  schema_version integer not null,
+  snapshot bytea,
+  snapshot_hash text,
+  encrypted boolean default false not null,
+  created_at timestamptz default now() not null,
+  updated_at timestamptz default now() not null
+);
+
+create table public.document_updates (
+  id uuid default gen_random_uuid() primary key,
+  document_id uuid references public.documents(id) on delete cascade not null,
+  client_id text not null,
+  seq bigint not null,
+  update_blob bytea not null,
+  update_hash text not null,
+  created_at timestamptz default now() not null,
+  unique(document_id, client_id, seq)
+);
+
+create table public.document_members (
+  id uuid default gen_random_uuid() primary key,
+  document_id uuid references public.documents(id) on delete cascade not null,
+  user_id uuid references public.profiles(id),
+  invited_email text,
+  role text not null check (role in ('owner', 'editor', 'viewer')),
+  status text not null check (status in ('pending', 'accepted', 'revoked')),
+  created_at timestamptz default now() not null,
+  updated_at timestamptz default now() not null
+);
+
+create table public.document_devices (
+  id uuid default gen_random_uuid() primary key,
+  document_id uuid references public.documents(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) not null,
+  device_id text not null,
+  last_synced_seq bigint,
+  last_seen_at timestamptz,
+  unique(document_id, user_id, device_id)
+);
+
+create table public.legacy_row_map (
+  id uuid default gen_random_uuid() primary key,
+  document_id uuid references public.documents(id) on delete cascade not null,
+  table_name text not null,
+  row_id uuid not null,
+  path_in_document text not null,
+  unique(table_name, row_id)
+);
+
+create table public.document_keys (
+  id uuid default gen_random_uuid() primary key,
+  document_id uuid references public.documents(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) not null,
+  key_version integer not null,
+  wrapped_dek bytea not null,
+  wrapping_alg text not null,
+  created_at timestamptz default now() not null,
+  revoked_at timestamptz,
+  unique(document_id, user_id, key_version)
+);
+```
+
+RLS 원칙:
+
+- owner/editor만 `document_updates` insert 가능
+- viewer는 snapshot/update read만 가능
+- `document_members` 변경은 owner만 가능
+- 초대 수락은 서버 RPC로만 수행
+- 삭제는 tombstone 생성 후 일정 기간 뒤 hard delete
+- `documents.snapshot`과 `document_updates.update_blob`은 기본적으로 암호문이다.
+- accepted member만 자신의 `document_keys.wrapped_dek`를 읽을 수 있다.
+
+## 10. 인증 및 Identity
+
+Supabase Auth는 유지한다. Local-first 전환 후에도 인증은 다음 기능의 기준이다.
+
+- 클라우드 백업/복구
+- 웹/모바일 간 데이터 복구
+- 친구 초대/수락
+- document 권한 registry
+- push token/device 등록
+- 회원 탈퇴 및 데이터 삭제
+
+### 지원 로그인
+
+- Email/password
+- Kakao OAuth
+- Google OAuth
+- Apple OAuth
+
+### 지연 인증
+
+`ADR-007` 결정에 따라 guest local mode를 허용한다.
+
+흐름:
+
+1. 앱 최초 실행 시 로그인 없이 로컬 여행/준비물 작성 가능
+2. 공유, 백업, 웹/모바일 동기화, 초대 수락 시점에 로그인 유도
+3. 로그인 성공 시 guest document를 authenticated document로 승격
+4. Supabase backup snapshot 최초 업로드
+5. 이후 backup/P2P/sync 활성화
+
+```mermaid
+flowchart TD
+  GuestStart[GuestStartsApp] --> LocalDoc[LocalOnlyDocument]
+  LocalDoc --> NeedNetwork[ShareOrBackupRequested]
+  NeedNetwork --> Login[SupabaseAuthLogin]
+  Login --> Attach[AttachUserIdentity]
+  Attach --> Backup[UploadInitialBackup]
+  Backup --> SyncEnabled[EnableSyncAndSharing]
+```
+
+정책:
+
+- guest data는 앱 삭제 시 유실될 수 있음을 UX에서 안내한다.
+- guest document는 `localOwnerId`를 사용한다.
+- 로그인 후 `ownerId`를 Supabase `auth.user.id`로 승격한다.
+- 로그아웃/계정 전환 시 local store는 user namespace로 격리한다.
+- 회원 탈퇴 시 local documents, backup rows, push tokens를 모두 정리한다.
+
+자세한 결정은 `docs/refactor/adrs/ADR-007-auth-identity-and-delayed-auth.md`를 따른다.
+
+## 11. Local Persistence
+
+### Web
+
+후보:
+
+- IndexedDB + `y-indexeddb`
+- OPFS 기반 binary blob store
+- Dexie wrapper
+
+초기 권장:
+
+- Yjs update log: IndexedDB
+- materialized read model: IndexedDB object store
+- 큰 binary asset: Supabase Storage reference 유지
+
+### Mobile
+
+후보:
+
+- Expo SQLite
+- react-native-quick-sqlite
+- MMKV
+
+초기 권장:
+
+- Expo managed workflow를 유지해야 한다면 Expo SQLite 우선 검토
+- `ADR-002` 결정에 따라 WebRTC native module 검증을 위해 dev client/EAS Build 전환을 허용
+- Yjs update blob은 SQLite BLOB 또는 base64 TEXT로 저장
+
+## 12. P2P 동기화
+
+`ADR-004` 결정에 따라 P2P는 optional fast path다. 기본 sync와 복구는 Supabase backup pull/push가 담당한다.
+
+Web:
+
+- `y-webrtc`는 optional Web PoC에서 검토
+- signaling server는 P2P 활성화 phase에서만 검토
+- BroadcastChannel로 동일 브라우저 탭 동기화
+
+Mobile:
+
+- `ADR-002` 결정에 따라 `react-native-webrtc` 또는 동등한 native provider를 검증한다.
+- Expo Go가 아니라 dev client/EAS Build 기반 검증을 허용한다.
+- 백그라운드 동기화는 P2P보다 Supabase backup queue를 우선한다.
+
+기본 sync 및 P2P 실패 시 fallback:
+
+1. Local write
+2. Backup queue에 pending update 추가
+3. 온라인 시 Supabase update upload
+4. 상대 기기는 Supabase에서 restore/pull
+5. P2P 연결 가능 시 peer 간 update를 빠르게 전파
+
+## 13. 초대, 공유, 권한 모델
+
+Local-first에서 권한은 두 층으로 나눈다.
+
+### Client permission snapshot
+
+문서 내부에 `members` snapshot을 둔다. UI 권한 표시와 optimistic guard에 사용한다.
+
+### Server authority
+
+Supabase `document_members`가 최종 권한 registry다. 다음 작업은 서버 검증을 반드시 거친다.
+
+- document backup upload
+- member role 변경
+- invitation 생성
+- invitation 수락
+- share link 생성/폐기
+- document hard delete
+
+클라이언트 snapshot과 Supabase registry가 충돌하면 Supabase registry를 우선한다.
+
+### 초대 방식
+
+`ADR-008` 결정에 따라 초대 방식은 복수 채널을 지원하되, 초기 구현은 딥 링크 + 초대 코드 fallback을 우선한다.
+
+- 딥 링크: 카카오톡/문자/공유 시트에 적합
+- 초대 코드: 딥 링크 실패 또는 PC/모바일 교차 사용 fallback
+- QR 코드: 오프라인 대면 상황에 적합하나 후순위
+- 이메일/계정 검색: 보안이 좋고 권한 지정이 명확하나 가입 UX가 필요
+
+초대 링크/코드는 Supabase registry에서 생성/검증한다. 링크 자체에 document content를 포함하지 않는다.
+
+### Signaling 권한 검증
+
+P2P room join 시 다음을 확인한다.
+
+1. Supabase JWT 유효성
+2. `document_members.status = accepted`
+3. role 기반 접근 권한
+4. room secret 유효성
+
+viewer는 로컬에서 임의 변경을 만들 수 있더라도 backup upload와 peer write propagation에서 차단되어야 한다. UI에서도 편집 버튼을 비활성화한다.
+
+자세한 결정은 `docs/refactor/adrs/ADR-008-invitation-and-permission-registry.md`를 따른다.
+
+## 14. 삭제와 Tombstone
+
+CRDT에서는 삭제를 즉시 hard delete로 처리하지 않는다.
+
+```ts
+interface TombstoneNode {
+  entityType: 'plan' | 'checklistItem' | 'checklist' | 'member' | 'asset'
+  entityId: string
+  deletedBy: string
+  deletedAt: string
+  reason?: string
+}
+```
+
+정책:
+
+- UI에서는 tombstone entity를 숨긴다.
+- sync에서는 tombstone을 전파한다.
+- 일정 보존 기간 이후 compaction을 수행한다.
+- compaction 전에는 legacy restore가 가능해야 한다.
+
+## 15. Push and Local Notifications
+
+`ADR-009` 결정에 따라 Local-first 구조에서는 알림을 두 종류로 나눈다.
+
+### 시간 기반 로컬 알림
+
+여행 일정 리마인더, 출발 전 준비물 리마인더는 기기 로컬 알림으로 처리한다.
+
+- plan 생성/수정 시 로컬 알림 예약
+- plan 삭제/시간 변경 시 기존 알림 취소 후 재등록
+- 네트워크 없이도 알림 동작
+- 로그아웃, document 접근 해제, 회원 탈퇴 시 관련 로컬 알림 제거
+
+### 협업 변경 푸시
+
+협업 변경 알림은 Yjs blob을 서버가 해석하지 않도록 notification metadata를 별도로 생성한다.
+
+흐름:
+
+1. local document 변경
+2. Yjs update 생성
+3. 사람이 읽을 수 있는 notification summary 생성
+4. Supabase `notification_events` insert
+5. Edge Function 또는 webhook이 Expo Push 발송
+
+정책:
+
+- document content 전체를 push payload에 넣지 않는다.
+- 오프라인 중 발생한 여러 변경은 batching/dedupe한다.
+- 같은 document를 보고 있는 사용자에게는 push 대신 in-app toast를 우선한다.
+- push token은 user/device lifecycle에 맞춰 등록/삭제한다.
+
+자세한 결정은 `docs/refactor/adrs/ADR-009-notification-strategy.md`를 따른다.
+
+## 16. Migration Strategy
+
+### Phase 0: Architecture Spike
+
+목표:
+
+- 체크리스트 1개 trip을 Trip document로 변환
+- Yjs local persistence 검증
+- Web 다중 탭 동기화 검증
+- Supabase snapshot backup 검증
+- row → document → row round-trip 검증
+
+성공 기준:
+
+- 기존 checklist item id 유지
+- 체크/해제 동시 편집 병합
+- 브라우저 새로고침 후 복원
+- Supabase snapshot에서 신규 기기 복원
+- legacy Supabase row와 의미상 동일한 결과 복원
+
+### Phase 1: Repository Abstraction
+
+목표:
+
+- 화면이 Supabase 직접 호출 대신 repository 사용
+- 기존 Supabase 구현으로 동작 동일성 유지
+
+대상:
+
+- `packages/core/src/supabase/queries.ts`
+- `apps/web/app/trips/checklist/ChecklistClient.tsx`
+- `apps/mobile/app/trip/[id].tsx`
+
+### Phase 2: Read-through Document
+
+목표:
+
+- Supabase row를 읽어 document 생성
+- write는 기존 Supabase 유지
+- document materialized read model 검증
+
+### Phase 3: Dual-write
+
+목표:
+
+- repository mutation이 Supabase row와 Yjs document에 동시 반영
+- mismatch detector 구현
+- 운영 데이터 손실 없이 검증
+
+### Phase 4: Document-primary
+
+목표:
+
+- Local-first repository를 기본값으로 전환
+- Supabase row는 fallback/read-only
+- backup/update log를 안정화
+
+### Phase 5: Legacy Reduction
+
+목표:
+
+- 신규 기능은 document model만 사용
+- legacy row sync 제거 후보 식별
+- 통계/search index 별도 구축
+
+## 17. Data Compatibility Requirements
+
+필수:
+
+- 기존 Supabase Auth 계정 유지
+- 기존 `trips.id` 기반 URL 유지
+- 기존 share token과 invitation token 유효성 유지
+- 기존 plan photo storage reference 유지
+- 기존 checklist assignment/check state 의미 보존
+- 기존 owner/editor/viewer 역할 보존
+- 기존 탈퇴/삭제 플로우에서 로컬 데이터와 백업 데이터 모두 정리
+
+비필수:
+
+- 기존 `updated_at` 값과 CRDT clock의 1:1 대응
+- 기존 RLS 정책명을 그대로 유지
+- 기존 row table을 영구적으로 primary로 유지
+
+## 18. Backup and Restore
+
+Backup queue:
+
+- local update 발생 시 update blob 저장
+- 네트워크 가능 시 Supabase `document_updates` 업로드
+- 일정 update 수 또는 크기마다 snapshot 생성
+- snapshot hash로 corruption 감지
+
+Restore:
+
+1. Supabase Auth 로그인
+2. 접근 가능한 `documents` 조회
+3. 최신 snapshot 다운로드
+4. snapshot 이후 updates 적용
+5. materialized read model 재생성
+6. P2P provider 연결
+
+## 19. Operating Cost and Infrastructure
+
+Local-first 구조는 중앙 서버 비용을 줄이지만, 완전 무인프라 구조는 아니다. `ADR-010`은 ADR-001~ADR-009 결정사항을 기준으로 후속 비용 검토를 수행한다.
+
+필요 인프라:
+
+- Supabase Auth
+- Supabase document backup/update storage
+- Supabase Edge Functions 또는 Realtime
+- signaling server (P2P optional phase에서 검토)
+- STUN/TURN
+- web hosting
+- Expo Push Service
+- 앱스토어 계정 및 도메인
+
+비용 제어 원칙:
+
+- Yjs update는 debounce/batch 후 업로드한다.
+- 일정 크기 이상 update log는 snapshot compaction한다.
+- image/binary data는 Yjs document에 넣지 않고 Storage reference만 저장한다.
+- TURN relay는 P2P optional phase에서만 사용한다.
+- notification event는 dedupe/batching한다.
+
+초기에는 managed/free tier를 우선 사용하되, quota 70% 도달 시 업그레이드를 검토한다. 단, 암호화 backup, hybrid index, notification metadata, guest promotion 정책이 반영된 write volume을 재산정해야 한다.
+
+자세한 비용 산정은 `docs/refactor/adrs/ADR-010-operating-cost-and-infrastructure.md`에서 후속 검토한다.
+
+## 20. Observability
+
+필요 이벤트:
+
+- `local_first_document_created`
+- `local_first_guest_document_promoted`
+- `local_first_restore_started`
+- `local_first_restore_completed`
+- `local_first_backup_failed`
+- `local_first_conflict_detected`
+- `local_first_dual_write_mismatch`
+- `p2p_connected`
+- `p2p_unavailable`
+- `local_notification_scheduled`
+- `collaboration_push_enqueued`
+- `document_permission_denied`
+
+로그에는 문서 id와 에러 코드만 남기고 문서 내용은 남기지 않는다.
+
+## 21. Security and Privacy Considerations
+
+- Supabase backup row는 RLS로 보호한다.
+- `ADR-003` 결정에 따라 snapshot/update blob은 암호화한다.
+- Key model은 Server-wrapped key를 사용한다.
+- 초대받은 사용자의 decrypt 권한 부여 방식을 별도 ADR로 분리할 수 있다.
+- P2P 연결은 signaling metadata 노출 범위를 점검한다.
+- 로그인 provider별 수집 항목을 개인정보 처리방침에 명시한다.
+- WebRTC 연결과 signaling 과정에서 IP 주소/네트워크 정보가 처리될 수 있음을 고지한다.
+- 협업 초대 시 참여자 간 프로필 정보와 여행 데이터가 공유됨을 고지한다.
+- Supabase 및 하위 인프라에 대한 개인정보 처리 위탁을 고지한다.
+- push token, device id, sync state 수집 목적과 보유 기간을 명시한다.
+
+## 22. Test Strategy
+
+Unit:
+
+- row → document 변환
+- document → read model materialization
+- tombstone merge
+- checklist toggle merge
+- schema migration
+
+Integration:
+
+- Supabase legacy read-through
+- document backup upload/download
+- restore from snapshot/update
+- dual-write mismatch detection
+- guest document promotion
+- notification event batching
+- permission registry validation
+
+E2E:
+
+- 기존 Supabase 여행 데이터가 새 클라이언트에서 보이는지
+- 오프라인에서 체크리스트 편집 후 온라인 복구
+- 두 기기 동시 체크리스트 수정 병합
+- 초대받은 사용자의 복구 가능 여부
+- viewer 권한 사용자의 write upload 차단
+- 딥 링크 초대 수락 후 document restore
+- guest 작성 데이터 로그인 후 backup 승격
+- 일정 로컬 알림 예약/취소
+- 회원 탈퇴 후 local/backup 데이터 정리
+
+## 23. Decision ADRs
+
+아래 항목은 구현 중 즉석에서 결정하지 않는다. 각 ADR을 검토하고 승인한 뒤 Technical Spec을 확정한다.
+
+| 결정 항목 | ADR | 현재 상태 |
+| --- | --- | --- |
+| Local-first + Supabase backup/auth 방향을 채택할 것인가? | `docs/refactor/adrs/ADR-001-local-first-data-engine.md` | 채택됨: Option C |
+| 모바일 WebRTC를 위해 Expo dev client/EAS Build 전환을 허용할 것인가? | `docs/refactor/adrs/ADR-002-mobile-webrtc-runtime.md` | 채택됨: Option B, native build 추가 검증 필요 |
+| Yjs update blob을 Supabase에 평문 저장할 것인가, 암호화할 것인가? | `docs/refactor/adrs/ADR-003-backup-encryption-key-management.md` | 채택됨: Option B + Server-wrapped key |
+| P2P signaling server를 직접 운영할 것인가, 외부 provider를 사용할 것인가? | `docs/refactor/adrs/ADR-004-p2p-signaling-strategy.md` | 채택됨: Option D |
+| Trip document가 너무 커질 경우 subdocument를 어떤 기준으로 분리할 것인가? | `docs/refactor/adrs/ADR-005-document-granularity.md` | 채택됨: Option A |
+| 검색/통계를 document backup에서 재생성할 것인가, 별도 index table로 유지할 것인가? | `docs/refactor/adrs/ADR-006-search-analytics-indexing.md` | 채택됨: Option C |
+| guest 사용과 지연 인증을 허용할 것인가? | `docs/refactor/adrs/ADR-007-auth-identity-and-delayed-auth.md` | 채택됨: Option B |
+| 초대 방식과 권한 authority를 어떻게 둘 것인가? | `docs/refactor/adrs/ADR-008-invitation-and-permission-registry.md` | 채택됨: 권장안 |
+| 푸시 알림과 로컬 알림을 어떻게 분리할 것인가? | `docs/refactor/adrs/ADR-009-notification-strategy.md` | 채택됨: Option B |
+| 초기 운영 인프라와 비용 제어 기준은 무엇인가? | `docs/refactor/adrs/ADR-010-operating-cost-and-infrastructure.md` | 후속 검토 |
+
+## 24. Immediate Next Tasks
+
+1. `ADR-010` 비용/인프라 후속 검토
+2. 체크리스트 스파이크 범위 확정
+3. repository interface 초안 작성
+4. row/document 변환기 초안 작성
+5. encrypted backup schema 및 `document_keys` migration 초안 작성
+6. Web IndexedDB persistence PoC
+7. Mobile WebRTC/Yjs native build feasibility PoC
+8. guest document promotion PoC
+9. invitation/permission registry PoC
+10. notification metadata + local notification PoC

--- a/docs/refactor/adrs/ADR-001-local-first-data-engine.md
+++ b/docs/refactor/adrs/ADR-001-local-first-data-engine.md
@@ -1,0 +1,316 @@
+# ADR-001: Local-First Data Engine 전환
+
+- 상태: 채택됨
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/plans/PLAN-008-local-first-architecture-review.md`
+  - `docs/adrs/ADR-010-shared-packages.md`
+  - `docs/develop-context/caching.md`
+  - `docs/refactor/adrs/ADR-002-mobile-webrtc-runtime.md`
+  - `docs/refactor/adrs/ADR-003-backup-encryption-key-management.md`
+  - `docs/refactor/adrs/ADR-004-p2p-signaling-strategy.md`
+  - `docs/refactor/adrs/ADR-005-document-granularity.md`
+  - `docs/refactor/adrs/ADR-006-search-analytics-indexing.md`
+  - `docs/refactor/adrs/ADR-007-auth-identity-and-delayed-auth.md`
+  - `docs/refactor/adrs/ADR-008-invitation-and-permission-registry.md`
+  - `docs/refactor/adrs/ADR-009-notification-strategy.md`
+  - `docs/refactor/adrs/ADR-010-operating-cost-and-infrastructure.md`
+
+---
+
+## 문제 정의
+
+현재 OnVoy는 Supabase를 원본 데이터베이스, 권한 모델, 협업 registry, 백업 저장소, 인증 provider로 사용한다. 이 구조는 구현이 단순하고 RLS로 보안 경계를 강하게 유지할 수 있지만, 다음 한계가 있다.
+
+1. 네트워크가 불안정하면 여행 계획과 체크리스트 편집 경험이 약해진다.
+2. 현재 오프라인 모드는 명시적 다운로드 기반 read-only cache이며, 진짜 local-first 편집 모델이 아니다.
+3. 협업 편집은 Supabase row mutation 중심이라 충돌 병합이 제한적이다.
+4. 웹/앱 모두 화면 곳곳에서 Supabase query 또는 `@nexvoy/core/supabase/queries`에 의존한다.
+5. 장기적으로 “여행 중 네트워크가 불안정해도 함께 편집 가능한 준비물/일정”이라는 제품 방향과 맞지 않는다.
+
+따라서 데이터 원본을 클라이언트 로컬 저장소와 CRDT 문서로 이동하고, Supabase는 인증/백업/권한 registry 역할로 축소하는 전환을 검토한다.
+
+---
+
+## 의사결정
+
+OnVoy는 Local-first Data Engine 전환을 단계적으로 추진한다.
+
+채택할 목표 구조:
+
+- 원본 편집 상태: 로컬 저장소 + Yjs CRDT document
+- 실시간 협업: WebRTC 기반 P2P sync
+- 영구 백업/복구: Supabase document snapshot/update log
+- 인증: Supabase Auth 유지
+- 권한/초대 registry: Supabase 유지
+- 첨부 파일: Supabase Storage 유지
+- 전환 기간 fallback: 기존 Supabase row table 유지
+
+즉시 전체 전환하지 않고, 체크리스트 도메인으로 스파이크를 먼저 수행한다.
+
+세부 결정은 ADR-002부터 ADR-010까지의 하위 ADR에서 검토한다. 본 ADR은 전환 방향성을 정의하고, 하위 ADR은 모바일 런타임, 암호화, signaling, 문서 분리, index, 인증 UX, 초대/권한, 알림, 운영 비용을 각각 결정한다.
+
+---
+
+## 결정 배경
+
+### 기존 ADR-010과의 관계
+
+ADR-010은 `@nexvoy/core`에 Supabase query helper를 두고 웹/앱이 공유하는 전략을 채택했다. 이 결정은 현재 구조에서는 여전히 유효하다.
+
+다만 Local-first 전환이 승인되면 ADR-010의 “Supabase query helper 공유”는 최종 목표가 아니라 legacy repository 구현체가 된다. 새 공유 경계는 다음처럼 바뀐다.
+
+- 기존: `@nexvoy/core` = Supabase query helper + 플랫폼 독립 로직
+- 변경 후: `@nexvoy/core` = Repository interface + domain logic + local-first document logic + legacy Supabase adapter
+
+따라서 본 ADR은 ADR-010을 폐기하지 않고 상위 전환 전략으로 확장한다.
+
+### 기존 캐싱 정책과의 관계
+
+`docs/develop-context/caching.md`는 현재 오프라인 정책을 read-only downloaded trip bundle로 정의한다. Local-first 전환 이후에는 이 정책을 갱신해야 한다.
+
+기존 cache는 “서버 데이터를 복사한 보조 저장소”다. 새 local-first store는 “편집 가능한 원본 저장소”다. 두 개념을 혼용하면 안 된다.
+
+---
+
+## 검토한 선택지
+
+### Option A: Supabase 유지 + optimistic UI 강화
+
+장점:
+
+- 공수가 가장 작다.
+- RLS와 기존 schema를 그대로 사용한다.
+- 데이터 손실 위험이 낮다.
+
+단점:
+
+- 네트워크 단절 중 편집 문제를 해결하지 못한다.
+- 협업 충돌 해결이 row update 수준에 머문다.
+- local-first 제품 방향과 맞지 않는다.
+
+결론: 단기 개선책으로는 가능하지만 목표 아키텍처로는 부족하다.
+
+### Option B: Supabase Realtime 중심 협업 강화
+
+장점:
+
+- 기존 Supabase 구조를 유지하면서 실시간성을 높일 수 있다.
+- 서버 권한 모델이 유지된다.
+
+단점:
+
+- 오프라인 편집과 나중 병합은 여전히 약하다.
+- CRDT 수준의 충돌 병합이 없다.
+- 네트워크와 Supabase availability에 계속 의존한다.
+
+결론: 협업 표시 개선에는 유효하지만 local-first 전환은 아니다.
+
+### Option C: Local-first + Supabase backup/auth
+
+장점:
+
+- 오프라인 편집이 기본 동작이 된다.
+- P2P로 같은 여행 참여자 간 빠른 동기화가 가능하다.
+- Supabase를 완전히 버리지 않아 인증, 백업, 복구, 초대를 유지할 수 있다.
+- 기존 UI와 도메인 타입을 상당 부분 재사용할 수 있다.
+
+단점:
+
+- 데이터 계층 재설계 공수가 매우 크다.
+- RLS 기반 권한을 CRDT 문서 내부 변경에 직접 적용할 수 없다.
+- 모바일 WebRTC 빌드/런타임 제약이 크다.
+- 백업 암호화와 복구 키 관리가 어려울 수 있다.
+
+결론: 채택하되, 스파이크와 단계적 이관을 전제로 한다.
+
+### Option D: 완전 재구축
+
+장점:
+
+- 새 아키텍처에 맞춰 처음부터 단순하게 설계할 수 있다.
+
+단점:
+
+- 현재 웹/앱 UI, 인증, 타입, Supabase 마이그레이션, E2E 기반을 버리게 된다.
+- 기능 재현 비용이 과도하다.
+- 데이터 마이그레이션 위험은 여전히 남는다.
+
+결론: 채택하지 않는다.
+
+---
+
+## 결정
+
+Option C(Local-first + Supabase backup/auth)를 명시적으로 채택한다.
+
+단, 즉시 전면 전환하지 않는다. 다음 순서를 따른다.
+
+1. 체크리스트 도메인 스파이크
+2. Repository abstraction 도입
+3. 기존 row → Trip document 변환기 작성
+4. Supabase backup schema 추가
+5. read-through 모드 검증
+6. dual-write 모드 검증
+7. document-primary 모드로 전환
+8. legacy row 의존 축소
+
+---
+
+## 데이터 호환성 결정
+
+기존 Supabase 데이터와의 호환성을 유지한다.
+
+필수 결정:
+
+- 기존 `trips.id`를 document id로 유지한다.
+- 기존 `plans.id`, `checklist_items.id`, `trip_members.id`를 document 내부 entity id로 유지한다.
+- 기존 share token과 invitation token은 Supabase registry에서 계속 유효하게 한다.
+- Supabase Storage object path는 document 내부 asset reference로 보존한다.
+- 기존 row table은 초기 전환 기간 authoritative fallback으로 유지한다.
+- CRDT 삭제는 hard delete가 아니라 tombstone으로 전파한다.
+
+이 결정은 다음을 보장한다.
+
+- 기존 URL과 공유 링크가 깨지지 않는다.
+- 기존 사용자 데이터 이관이 가능하다.
+- 문제 발생 시 Supabase row 기반 화면으로 rollback할 수 있다.
+
+---
+
+## 보안 결정
+
+Supabase Auth는 유지한다.
+
+Supabase RLS는 다음 테이블에 계속 적용한다.
+
+- `documents`
+- `document_updates`
+- `document_members`
+- `document_devices`
+- `legacy_row_map`
+- 기존 `profiles`
+- 기존 초대/공유 registry
+- Storage buckets
+
+서버 검증이 필요한 작업:
+
+- backup update upload
+- snapshot upload
+- member role 변경
+- invitation 생성/수락
+- share link 생성/폐기
+- hard delete
+
+클라이언트 권한 snapshot은 UX guard이며 최종 보안 경계가 아니다.
+
+---
+
+## 기대 효과
+
+- 네트워크 단절 중에도 여행/준비물 편집 가능
+- 동행자 간 체크리스트 동시 편집 충돌 감소
+- 서버 지연과 네트워크 왕복에 덜 민감한 UX
+- Supabase 장애 시에도 로컬 데이터 접근 가능
+- 기존 Supabase Auth/Storage/초대 기반을 유지하면서 단계적 전환 가능
+
+---
+
+## 위험 요소
+
+### 모바일 WebRTC 위험
+
+Expo Go에서는 WebRTC 지원이 제한될 수 있다. `react-native-webrtc` 사용 시 dev client 또는 EAS Build 전환이 필요할 수 있다.
+
+완화:
+
+- 첫 스파이크에서 모바일 WebRTC 빌드 가능성을 별도로 검증한다.
+- P2P 실패 시 Supabase backup pull/push를 fallback으로 둔다.
+
+### 권한 모델 위험
+
+CRDT update는 클라이언트에서 만들어지므로 기존 RLS가 내부 변경 단위까지 검증하지 못한다.
+
+완화:
+
+- backup upload 시 document membership을 Supabase에서 검증한다.
+- owner/editor/viewer 권한 registry를 서버에 둔다.
+- 초대와 role 변경은 RPC 또는 API route를 통해 처리한다.
+
+### 데이터 손실 위험
+
+row → document 변환, dual-write, tombstone 처리 중 누락이 발생할 수 있다.
+
+완화:
+
+- legacy row table을 fallback으로 유지한다.
+- round-trip 변환 테스트를 필수화한다.
+- mismatch detector를 dual-write 단계에 포함한다.
+
+### 복잡도 위험
+
+Yjs, P2P, local persistence, Supabase backup이 함께 들어오면 시스템 복잡도가 크게 증가한다.
+
+완화:
+
+- 체크리스트 하나로 스파이크를 제한한다.
+- repository interface를 먼저 도입해 UI 변경 범위를 제한한다.
+- 도메인별 단계 이관을 강제한다.
+
+---
+
+## 마이그레이션 정책
+
+전환 단계:
+
+1. Supabase-primary
+2. Read-through document
+3. Dual-write
+4. Document-primary
+5. Legacy reduction
+
+각 단계는 rollback 가능해야 한다.
+
+Rollback 기준:
+
+- document restore 실패율 증가
+- dual-write mismatch 발생
+- 모바일 build/runtime 이슈
+- 백업 upload 실패
+- 권한 registry 불일치
+
+Rollback 방법:
+
+- repository factory에서 Supabase repository로 전환
+- local-first feature flag 비활성화
+- document backup은 보존하되 UI에서는 사용하지 않음
+
+---
+
+## 후속 과제
+
+- `docs/refactor/tasks`에 phase별 작업 문서 작성
+- 체크리스트 스파이크 범위 확정
+- Web IndexedDB + Yjs persistence PoC
+- Expo RN WebRTC 가능성 검증
+- guest document 승격 및 지연 인증 PoC
+- 초대 링크/코드 및 permission registry PoC
+- 로컬 알림/협업 푸시 metadata PoC
+- Supabase backup schema migration 초안 작성
+- row/document 변환기 테스트 작성
+- dual-write mismatch detector 설계
+
+---
+
+## 승인 조건
+
+본 ADR이 승인되더라도 즉시 전면 전환하지 않는다. 다음 조건을 만족해야 Phase 1 구현으로 넘어간다.
+
+- 체크리스트 스파이크 성공
+- 모바일 WebRTC 또는 fallback sync 전략 검증
+- 지연 인증/초대/권한/알림 관련 하위 ADR 임시 결정
+- 기존 Supabase row와의 round-trip 변환 테스트 통과
+- 백업/복구 데이터 손실 테스트 통과
+- rollback 경로 확인

--- a/docs/refactor/adrs/ADR-002-mobile-webrtc-runtime.md
+++ b/docs/refactor/adrs/ADR-002-mobile-webrtc-runtime.md
@@ -1,0 +1,101 @@
+# ADR-002: 모바일 WebRTC 런타임 전략
+
+- 상태: 채택됨 (native build 가능성 추가 검증 필요)
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+
+---
+
+## 문제 정의
+
+Local-first 전환의 실시간 협업은 Yjs + WebRTC 기반 P2P 동기화를 목표로 한다. 웹은 `y-webrtc`를 비교적 직접 검토할 수 있지만, Expo React Native 앱은 WebRTC 지원 방식에 제약이 있다.
+
+특히 Expo Go 환경에서는 native WebRTC 모듈 사용이 제한될 수 있으며, `react-native-webrtc`를 사용하려면 dev client 또는 EAS Build 기반의 native runtime 전환이 필요할 가능성이 높다.
+
+---
+
+## 결정해야 할 질문
+
+모바일에서 WebRTC를 위해 Expo dev client/EAS Build 전환을 허용할 것인가?
+
+---
+
+## 선택지
+
+### Option A: Expo Go 호환성 유지, 모바일 P2P 제외
+
+장점:
+
+- 개발 환경 변화가 작다.
+- native module 관리 부담이 없다.
+- 앱 빌드/디버깅 복잡도가 낮다.
+
+단점:
+
+- 모바일은 P2P 실시간 협업을 사용할 수 없다.
+- 모바일 동기화는 Supabase backup/pull fallback에 의존한다.
+- Local-first의 핵심 경험이 웹과 앱에서 다르게 동작한다.
+
+### Option B: Expo dev client/EAS Build 전환 후 `react-native-webrtc` 사용
+
+장점:
+
+- 모바일에서도 P2P 협업 가능성이 생긴다.
+- 웹/앱 모두 유사한 동기화 모델을 유지할 수 있다.
+- 여행 중 기기간 직접 동기화 경험을 검증할 수 있다.
+
+단점:
+
+- native dependency 관리 부담이 커진다.
+- Expo Go 기반 빠른 개발 루프가 약해진다.
+- iOS/Android 권한, background, network edge case 검증이 필요하다.
+
+### Option C: 모바일은 P2P 대신 Supabase relay/sync 우선
+
+장점:
+
+- 안정적인 fallback을 먼저 확보할 수 있다.
+- WebRTC 도입을 늦출 수 있다.
+- 백그라운드/재접속 시나리오가 단순해진다.
+
+단점:
+
+- 완전한 P2P 목표와 거리가 있다.
+- Supabase availability 의존이 남는다.
+- 실시간성은 WebRTC보다 낮을 수 있다.
+
+---
+
+## 결정
+
+Option B를 채택한다. 모바일 앱은 Expo dev client/EAS Build 전환을 허용하고, `react-native-webrtc` 또는 동등한 native WebRTC provider 사용을 전제로 검증한다.
+
+단, native build 가능 여부와 iOS/Android 런타임 안정성은 추가 검토가 필요하다. WebRTC는 제품의 optional fast path이며, 실패 시 Supabase backup/pull sync로 fallback한다.
+
+결정 사항:
+
+- Expo Go 호환성보다 native WebRTC 가능성을 우선한다.
+- dev client/EAS Build 전환 비용을 수용한다.
+- `react-native-webrtc` 도입 가능성을 1차 후보로 검증한다.
+- background sync는 WebRTC가 아니라 Supabase backup queue 중심으로 설계한다.
+
+---
+
+## 승인 기준
+
+- `react-native-webrtc` 또는 대체 provider가 iOS/Android 빌드에서 동작한다.
+- 앱 foreground/background 전환 시 연결 해제와 복구가 안전하다.
+- WebRTC 실패 시 local write와 Supabase backup이 정상 동작한다.
+- Expo dev client/EAS Build 전환 비용을 수용할 수 있다.
+
+---
+
+## 후속 작업
+
+- 모바일 WebRTC PoC task 작성
+- iOS/Android 빌드 검증
+- P2P 실패 fallback 시나리오 E2E 작성
+- provider factory 설계

--- a/docs/refactor/adrs/ADR-003-backup-encryption-key-management.md
+++ b/docs/refactor/adrs/ADR-003-backup-encryption-key-management.md
@@ -1,0 +1,148 @@
+# ADR-003: 백업 암호화 및 키 관리 전략
+
+- 상태: 채택됨
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+
+---
+
+## 문제 정의
+
+Local-first 전환 후 Supabase에는 기존 정규화 row가 아니라 Yjs snapshot/update blob이 백업될 수 있다. 이 blob은 여행 일정, 장소, 메모, 준비물, 동행자 정보 등 민감한 개인 데이터를 포함한다.
+
+Supabase RLS로 접근 제어를 할 수 있지만, 서버 저장소에 평문 snapshot/update를 보관할지, 클라이언트에서 암호화한 blob만 보관할지 결정해야 한다.
+
+암호화할 경우 키 관리가 가장 큰 문제가 된다. 사용자가 새 기기에서 로그인했을 때 기존 백업을 복호화할 수 있어야 하고, 동행자 초대 시 문서 decrypt 권한도 공유되어야 한다.
+
+---
+
+## 결정해야 할 질문
+
+Yjs update blob을 Supabase에 평문 저장할 것인가, 암호화할 것인가?
+
+---
+
+## 선택지
+
+### Option A: Supabase RLS만 사용하고 blob은 평문 저장
+
+장점:
+
+- 구현이 가장 단순하다.
+- 서버에서 백업 검증, 인덱싱, migration이 쉽다.
+- 새 기기 복구가 쉽다.
+
+단점:
+
+- Supabase 저장소에는 사용자의 여행 데이터가 평문으로 존재한다.
+- 보안/프라이버시 기대치가 높아질수록 부담이 된다.
+- 문서 단위 공유/권한 변경 시 서버가 모든 내용을 볼 수 있다.
+
+### Option B: 클라이언트 E2EE, 서버는 암호문만 저장
+
+장점:
+
+- 서버에 평문 데이터가 저장되지 않는다.
+- 프라이버시 측면에서 가장 강하다.
+
+단점:
+
+- 키 복구 UX가 어렵다.
+- 초대받은 사용자에게 키를 안전하게 전달해야 한다.
+- 검색/통계/indexing이 어렵다.
+- 키 분실 시 데이터 복구가 불가능할 수 있다.
+
+### Option C: 민감 본문은 암호화, 서버 index는 제한적으로 평문 저장
+
+장점:
+
+- 주요 내용은 보호하면서 목록/검색/복구 UX를 일부 유지할 수 있다.
+- 문서 title, date range 같은 최소 metadata만 서버 index로 둘 수 있다.
+- 단계적 도입이 가능하다.
+
+단점:
+
+- 어떤 필드를 평문 metadata로 둘지 정책이 필요하다.
+- 구현이 Option A보다 복잡하다.
+- 완전한 E2EE는 아니다.
+
+---
+
+## 결정
+
+Option B를 기반으로 채택한다. Supabase에 저장되는 Yjs snapshot/update blob은 클라이언트에서 암호화하고, 서버는 암호문만 저장한다.
+
+Key model은 Server-wrapped key를 채택한다. 문서별 content encryption key(DEK)는 클라이언트에서 생성하고, Supabase Auth 사용자/멤버 권한에 따라 wrapping된 key material만 서버에 저장한다.
+
+결정 원칙:
+
+- `documents.encrypted = true`를 기본값으로 한다.
+- `document_updates.update_blob`과 `documents.snapshot`은 암호문이다.
+- 서버는 문서 본문을 복호화하지 않는다.
+- 서버에는 복호화 가능한 원문 key를 저장하지 않는다.
+- 서버는 wrapped key와 권한 registry만 관리한다.
+- 로그에는 document payload를 남기지 않는다.
+- snapshot/update integrity hash를 저장한다.
+- 검색/목록/알림에 필요한 최소 metadata는 `ADR-006`과 `ADR-009`의 index/notification payload 정책을 따른다.
+
+---
+
+## Key Model
+
+채택 모델: Server-wrapped key.
+
+개념:
+
+- DEK(Document Encryption Key): 문서 snapshot/update 암호화에 사용하는 대칭키
+- KEK(Key Encryption Key): 사용자/디바이스/세션 기반으로 DEK를 wrapping하는 키
+- Wrapped DEK: Supabase에 저장되는 암호화된 DEK
+
+제안 테이블:
+
+```sql
+create table public.document_keys (
+  id uuid default gen_random_uuid() primary key,
+  document_id uuid references public.documents(id) on delete cascade not null,
+  user_id uuid references public.profiles(id) not null,
+  key_version integer not null,
+  wrapped_dek bytea not null,
+  wrapping_alg text not null,
+  created_at timestamptz default now() not null,
+  revoked_at timestamptz,
+  unique(document_id, user_id, key_version)
+);
+```
+
+권한 원칙:
+
+- owner는 document key를 생성하고 멤버별 wrapped key를 발급할 수 있다.
+- accepted member만 자신의 wrapped key를 읽을 수 있다.
+- role revoked 또는 member removed 시 해당 사용자의 key를 revoke한다.
+- key rotation은 document membership 변경 또는 보안 이벤트 발생 시 수행한다.
+
+추가 검토:
+
+- KEK를 Supabase 세션 기반으로 만들지, 디바이스 local key와 조합할지
+- Apple/Google/Kakao OAuth 계정 복구 시 key unwrap UX
+- multi-device 사용자가 새 기기에서 wrapped key를 복구하는 절차
+
+---
+
+## 승인 기준
+
+- 선택한 방식으로 새 기기 복구가 가능하다.
+- 초대받은 사용자가 접근 가능한 문서만 복호화할 수 있다.
+- 탈퇴/권한 회수 시 키 접근 정책이 정의되어 있다.
+- 백업 손상 감지와 복구 실패 처리가 가능하다.
+
+---
+
+## 후속 작업
+
+- 백업 암호화 PoC
+- key wrapping 모델 비교
+- document metadata 평문 범위 정의
+- 개인정보 처리방침 영향 검토

--- a/docs/refactor/adrs/ADR-004-p2p-signaling-strategy.md
+++ b/docs/refactor/adrs/ADR-004-p2p-signaling-strategy.md
@@ -1,0 +1,156 @@
+# ADR-004: P2P Signaling 및 Relay 전략
+
+- 상태: 채택됨
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+  - `docs/refactor/adrs/ADR-002-mobile-webrtc-runtime.md`
+
+---
+
+## 문제 정의
+
+WebRTC P2P 동기화는 peer discovery와 연결 협상에 signaling이 필요하다. 또한 NAT, 방화벽, 모바일 네트워크 환경에 따라 직접 P2P 연결이 실패할 수 있다.
+
+OnVoy는 여행 중 사용되는 서비스이므로 네트워크 품질이 다양하다. P2P signaling을 직접 운영할지, 외부 provider를 사용할지, 또는 Supabase를 relay/fallback으로 활용할지 결정해야 한다.
+
+---
+
+## 결정해야 할 질문
+
+P2P signaling server를 직접 운영할 것인가, 외부 provider를 사용할 것인가?
+
+---
+
+## 선택지
+
+### Option A: `y-webrtc` 기본 public signaling 사용
+
+장점:
+
+- PoC가 빠르다.
+- 별도 서버 구축이 필요 없다.
+- 웹 스파이크에 적합하다.
+
+단점:
+
+- 운영 안정성과 보안 통제권이 낮다.
+- 서비스 수준을 보장하기 어렵다.
+- 모바일 지원과 장기 운영에 부적합할 수 있다.
+
+### Option B: 자체 signaling server 운영
+
+장점:
+
+- 접근 제어, 로깅, rate limit, room 정책을 직접 통제할 수 있다.
+- OnVoy document id와 권한 registry를 연동할 수 있다.
+- 운영 품질을 관리할 수 있다.
+
+단점:
+
+- 별도 인프라 운영이 필요하다.
+- WebSocket server 운영 비용이 생긴다.
+- 1인 개발 규모에서 부담이 크다.
+
+### Option C: Supabase Realtime 또는 Edge Function을 signaling/fallback으로 활용
+
+장점:
+
+- 기존 Supabase 인프라와 Auth를 활용할 수 있다.
+- document membership 검증과 통합하기 쉽다.
+- P2P 실패 시 backup sync와 자연스럽게 연결된다.
+
+단점:
+
+- 순수 P2P와 거리가 있다.
+- Supabase Realtime 비용/제약을 확인해야 한다.
+- signaling latency와 payload 정책을 별도 검증해야 한다.
+
+### Option D: P2P는 optional, 기본 sync는 Supabase backup pull/push
+
+장점:
+
+- 가장 안정적인 fallback을 중심에 둔다.
+- 모바일/네트워크 edge case에 강하다.
+- P2P 도입 실패 시에도 local-first 편집은 유지된다.
+
+단점:
+
+- 실시간 협업 품질은 낮아질 수 있다.
+- “P2P-first” 목표와 다소 다르다.
+- Supabase 의존이 더 오래 남는다.
+
+---
+
+## 결정
+
+Option D를 채택한다. P2P는 optional fast path이며, 기본 sync 경로는 Supabase backup pull/push로 둔다.
+
+결정 사항:
+
+- Local-first write는 항상 로컬에서 성공해야 한다.
+- 온라인 backup sync는 Supabase document snapshot/update log를 기본 경로로 사용한다.
+- WebRTC P2P는 동시 접속 중인 peer 간 빠른 전파에만 사용한다.
+- signaling server는 초기 필수 인프라가 아니라 P2P provider 활성화 시 필요한 보조 인프라다.
+- 자체 signaling server 운영은 후속 검토로 미룬다.
+- Supabase backup pull/push가 항상 데이터 복구의 기준 경로다.
+
+---
+
+## STUN/TURN 운영 정책
+
+STUN/TURN은 P2P optional fast path를 보조하는 네트워크 인프라로만 사용한다. 데이터 정합성의 기준은 Supabase backup pull/push이며, TURN relay를 통과하지 못해도 local-first 편집과 백업 복구는 가능해야 한다.
+
+역할 구분:
+
+- 공개 STUN은 peer가 자신의 public endpoint 후보를 발견하기 위한 저비용 기본 경로다.
+- TURN managed provider는 NAT, 방화벽, 모바일망 등으로 direct P2P가 실패할 때 encrypted WebRTC traffic을 relay하는 fallback 경로다.
+- signaling은 peer discovery와 SDP/ICE candidate 교환만 담당하며, 여행 본문 데이터나 CRDT payload를 signaling metadata에 포함하지 않는다.
+
+운영 원칙:
+
+- 클라이언트에 TURN username/password를 하드코딩하지 않는다.
+- ICE server config는 Supabase Edge Function 또는 동등한 server-side endpoint에서 짧은 TTL로 발급한다.
+- STUN/TURN managed provider는 Cloudflare Realtime TURN을 기준으로 채택한다.
+- STUN은 Cloudflare STUN을 기본값으로 사용하고, 연결성 검증 단계에서 Google public STUN을 보조 후보로 둘 수 있다.
+- Metered/OpenRelay는 Cloudflare 적용 전후의 연결성 비교 또는 장애 대응 참고 후보로만 둔다.
+- Twilio/Xirsys는 비용보다 지원, 계약, 기업용 신뢰성이 중요해지는 단계의 대체 후보로만 둔다.
+- TURN 사용량, relay 연결 비율, P2P 실패율을 관측해 ADR-010의 비용 검토 입력으로 사용한다.
+
+---
+
+## Signaling Room 정책
+
+room id는 document id만 노출하지 않는다.
+
+권장:
+
+- `roomId = hash(documentId + rotatingRoomSecret)`
+- room secret은 Supabase registry에서 권한 있는 사용자에게만 제공
+- role 변경 또는 share 폐기 시 secret rotation 검토
+
+Option D 결정에 따라 signaling room 정책은 P2P provider를 활성화하는 phase에서만 구현한다. 그 전까지는 Supabase backup sync와 permission registry를 우선 완성한다.
+
+---
+
+## 승인 기준
+
+- 권한 없는 사용자가 signaling room에 참여할 수 없다.
+- P2P 연결 실패 시 데이터 손실 없이 backup sync로 전환된다.
+- signaling metadata에 여행 내용이 포함되지 않는다.
+- Web/RN 양쪽 provider factory가 같은 인터페이스를 따른다.
+
+---
+
+## 후속 작업
+
+- Supabase backup pull/push fallback 구현
+- Web y-webrtc PoC는 optional fast path 검증으로 수행
+- Supabase Realtime signaling 가능성은 후속 검토
+- Supabase Edge Function 기반 ICE server config 발급 방식 검토
+- Cloudflare Realtime TURN 기반 Web/RN 연결성 PoC
+- Metered/OpenRelay는 비교 검증이 필요할 때만 제한적으로 확인
+- room id/secret rotation 설계
+- P2P fallback E2E 시나리오 작성

--- a/docs/refactor/adrs/ADR-005-document-granularity.md
+++ b/docs/refactor/adrs/ADR-005-document-granularity.md
@@ -1,0 +1,135 @@
+# ADR-005: CRDT Document Granularity 및 Subdocument 분리 기준
+
+- 상태: 채택됨
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+
+---
+
+## 문제 정의
+
+Local-first 전환의 기본 저장 단위는 Trip document로 제안되어 있다. Trip 단위 문서는 여행 하나에 필요한 일정, 준비물, 멤버, 공유, asset reference를 한 번에 복구하고 동기화하기 쉽다.
+
+하지만 여행 기간이 길거나 계획/체크리스트가 많아지면 단일 Yjs document가 커질 수 있다. document가 커지면 초기 로딩, 백업 snapshot, update merge, 모바일 메모리 사용량에 문제가 생길 수 있다.
+
+따라서 Trip document를 언제 subdocument로 나눌지 기준이 필요하다.
+
+---
+
+## 결정해야 할 질문
+
+Trip document가 너무 커질 경우 subdocument를 어떤 기준으로 분리할 것인가?
+
+---
+
+## 선택지
+
+### Option A: Trip 하나 = Yjs document 하나
+
+장점:
+
+- 구현이 가장 단순하다.
+- 복구와 백업 단위가 명확하다.
+- 일정/체크리스트 간 참조가 쉽다.
+
+단점:
+
+- 큰 여행에서 document가 비대해질 수 있다.
+- 일부 탭만 열어도 전체 document를 로드해야 한다.
+- conflict/update log compaction 비용이 커질 수 있다.
+
+### Option B: Trip root + 도메인별 subdocument
+
+구조:
+
+- `trip-root`
+- `trip-plans`
+- `trip-checklist`
+- `trip-members`
+- `trip-assets`
+
+장점:
+
+- 탭별 lazy loading이 가능하다.
+- 체크리스트와 일정 sync를 독립적으로 최적화할 수 있다.
+- 백업 snapshot 크기를 나눌 수 있다.
+
+단점:
+
+- 문서 간 transaction 경계가 복잡해진다.
+- restore 순서와 schema migration이 어려워진다.
+- 권한/멤버 변경 전파를 여러 문서에 반영해야 한다.
+
+### Option C: Trip root + entity collection sharding
+
+구조:
+
+- `trip-root`
+- `plans-by-date`
+- `checklist-category-*`
+- `assets-*`
+
+장점:
+
+- 매우 큰 데이터셋에 유리하다.
+- 특정 날짜/카테고리만 sync할 수 있다.
+
+단점:
+
+- 현재 제품 규모에는 과도하다.
+- 구현 복잡도가 매우 높다.
+- migration과 compaction이 어렵다.
+
+---
+
+## 결정
+
+Option A를 채택한다. 초기 local-first 모델은 Trip 하나를 하나의 Yjs document로 저장한다.
+
+단, document model에는 향후 subdocument로 분리 가능한 경계를 명확히 둔다.
+
+분리 후보:
+
+- `plans`
+- `checklist`
+- `members`
+- `assets`
+
+다음 조건 중 하나를 만족하면 후속 ADR로 Option B 전환을 검토한다.
+
+- snapshot 크기가 1MB를 지속적으로 초과
+- update log compaction 시간이 모바일에서 UX에 영향을 줌
+- 체크리스트/일정 중 하나만 열 때 전체 document load가 병목이 됨
+- 여행 하나의 plan 수가 300개 이상
+- checklist item 수가 500개 이상
+
+---
+
+## Document Boundary 원칙
+
+- URL과 공유 링크의 기준은 항상 Trip root document다.
+- owner/editor/viewer 권한은 Trip root에서 파생한다.
+- subdocument는 root document의 membership snapshot을 따른다.
+- subdocument id는 `tripId:domain` 형식을 사용한다.
+- cross-document reference는 기존 row id를 유지한다.
+
+---
+
+## 승인 기준
+
+- 초기 단일 document 모델에서 checklist 스파이크가 동작한다.
+- document 크기 측정 지표가 수집된다.
+- subdocument 전환 시 기존 entity id가 유지된다.
+- root/subdocument restore 순서가 정의된다.
+
+---
+
+## 후속 작업
+
+- document size instrumentation 추가
+- snapshot/update compaction 비용 측정
+- subdocument migration protocol 초안 작성
+- Trip root와 subdocument 권한 전파 규칙 정의

--- a/docs/refactor/adrs/ADR-006-search-analytics-indexing.md
+++ b/docs/refactor/adrs/ADR-006-search-analytics-indexing.md
@@ -1,0 +1,198 @@
+# ADR-006: 검색, 통계, 분석용 Index 전략
+
+- 상태: 채택됨
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+
+---
+
+## 문제 정의
+
+현재 OnVoy는 Supabase PostgreSQL row를 기준으로 여행 목록, 통계, 방문 장소, 준비물 진행률 등을 조회한다. Local-first 전환 후 원본 데이터가 Yjs document snapshot/update blob으로 이동하면 PostgreSQL join/query 기반 조회를 그대로 사용할 수 없다.
+
+특히 다음 기능은 document blob만으로는 효율적으로 처리하기 어렵다.
+
+- 홈 여행 목록
+- 프로필 여행 기록
+- 방문한 곳
+- 체크리스트 진행률
+- 템플릿 목록/공유 상태
+- 알림 대상 일정 조회
+- 관리자/운영 분석
+
+따라서 검색/통계/index 데이터를 어떻게 유지할지 결정해야 한다.
+
+---
+
+## 결정해야 할 질문
+
+검색/통계를 document backup에서 재생성할 것인가, 별도 index table로 유지할 것인가?
+
+---
+
+## 선택지
+
+### Option A: 클라이언트 materialized view만 사용
+
+장점:
+
+- 서버 index schema가 단순하다.
+- local-first 철학에 가장 가깝다.
+- 오프라인에서도 목록/통계를 계산할 수 있다.
+
+단점:
+
+- 서버 기반 검색/통계가 어렵다.
+- 새 기기 첫 복구 전에는 목록 표시가 느릴 수 있다.
+- 푸시 알림/서버 cron 대상 조회가 어렵다.
+
+### Option B: Supabase에 서버 index table 유지
+
+장점:
+
+- 기존 목록/통계 조회 경험을 유지하기 쉽다.
+- 푸시 알림, 운영 분석, 검색을 서버에서 처리할 수 있다.
+- 점진적 전환에 유리하다.
+
+단점:
+
+- document와 index 간 불일치 가능성이 생긴다.
+- index update pipeline이 필요하다.
+- 암호화된 document와 충돌할 수 있다.
+
+### Option C: Hybrid index
+
+구조:
+
+- 클라이언트: 전체 local materialized read model
+- Supabase: 최소 metadata/index table
+
+장점:
+
+- 오프라인 UX와 서버 조회를 모두 지원한다.
+- 서버에는 민감 본문 대신 필요한 최소 metadata만 둘 수 있다.
+- 단계적 전환과 암호화 전략에 유리하다.
+
+단점:
+
+- 어떤 metadata를 서버에 둘지 정책이 필요하다.
+- index 불일치 감지/복구가 필요하다.
+- 구현 복잡도는 Option A보다 높다.
+
+---
+
+## 결정
+
+Option C(Hybrid index)를 채택한다.
+
+클라이언트는 document에서 read model을 생성해 UI를 렌더링한다. Supabase에는 목록, 권한, 복구, 알림에 필요한 최소 index만 저장한다.
+
+추천 서버 index:
+
+- `document_index`
+  - `document_id`
+  - `type`
+  - `owner_id`
+  - `destination`
+  - `start_date`
+  - `end_date`
+  - `member_count`
+  - `plan_count`
+  - `checklist_total_count`
+  - `checklist_done_count`
+  - `updated_at`
+  - `schema_version`
+- `document_place_index`
+  - `document_id`
+  - `plan_id`
+  - `place_name`
+  - `address`
+  - `google_place_id`
+  - `location_lat`
+  - `location_lng`
+  - `visited_at`
+- `document_alarm_index`
+  - `document_id`
+  - `plan_id`
+  - `alarm_at`
+  - `timezone`
+  - `sent_at`
+
+---
+
+## Index 생성 방식
+
+### Client-generated index
+
+클라이언트가 document materialization 결과로 index payload를 만들어 Supabase에 업로드한다.
+
+장점:
+
+- 서버가 Yjs blob을 해석할 필요가 없다.
+- 암호화된 document와 호환하기 쉽다.
+
+단점:
+
+- 악의적/버그 있는 client가 잘못된 index를 보낼 수 있다.
+- 서버 검증이 제한적이다.
+
+### Server-generated index
+
+서버가 snapshot/update를 읽어 index를 생성한다.
+
+장점:
+
+- 서버에서 index 신뢰성을 확보하기 쉽다.
+- analytics/cron과 연동하기 좋다.
+
+단점:
+
+- 서버에서 Yjs update를 해석해야 한다.
+- E2EE와 충돌한다.
+- Edge Function runtime 제약을 확인해야 한다.
+
+### 권장
+
+초기에는 client-generated index를 사용하고, integrity check를 추가한다. E2EE 정책이 확정되기 전까지 server-generated index를 전제로 설계하지 않는다.
+
+---
+
+## 불일치 복구
+
+index는 원본이 아니다. 원본은 local CRDT document와 Supabase backup snapshot/update다.
+
+불일치 감지:
+
+- `snapshot_hash`
+- `index_source_hash`
+- `updated_at`
+- `schema_version`
+
+복구:
+
+1. document restore
+2. materialized read model 재생성
+3. index payload 재업로드
+4. 서버 index 갱신
+
+---
+
+## 승인 기준
+
+- 홈 여행 목록을 index에서 빠르게 조회할 수 있다.
+- 오프라인 상태에서는 local read model만으로 목록을 표시할 수 있다.
+- index 불일치가 감지되면 재생성할 수 있다.
+- 암호화 전략과 충돌하지 않는 metadata 범위가 정의되어 있다.
+
+---
+
+## 후속 작업
+
+- `document_index` schema 초안 작성
+- 클라이언트 materializer 출력 포맷 정의
+- index payload validation 설계
+- 기존 프로필 통계/방문 장소 화면 영향 분석
+- 알림 cron이 사용할 index 범위 정의

--- a/docs/refactor/adrs/ADR-007-auth-identity-and-delayed-auth.md
+++ b/docs/refactor/adrs/ADR-007-auth-identity-and-delayed-auth.md
@@ -1,0 +1,164 @@
+# ADR-007: 인증, 계정 연결, 지연 인증 전략
+
+- 상태: 채택됨
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+
+---
+
+## 문제 정의
+
+Local-first 아키텍처에서는 로컬 저장소가 먼저 동작하므로 로그인 없이도 여행 일정과 준비물 데이터를 만들 수 있다. 그러나 클라우드 백업, 웹/모바일 간 복구, 친구 초대, 권한 관리, 푸시 알림을 제공하려면 사용자 식별자가 반드시 필요하다.
+
+따라서 다음을 결정해야 한다.
+
+- 앱 최초 사용 시 로그인을 강제할 것인가?
+- guest local data를 로그인 계정으로 어떻게 귀속할 것인가?
+- Kakao, Apple, Google, Email 로그인에서 어떤 개인정보 수집을 전제로 할 것인가?
+- 계정 탈퇴/로그아웃 시 local-first 데이터와 백업 데이터를 어떻게 처리할 것인가?
+
+---
+
+## 결정해야 할 질문
+
+Local-first UX를 위해 “선 사용, 후 로그인”을 허용할 것인가?
+
+---
+
+## 선택지
+
+### Option A: 기존처럼 로그인 후 사용
+
+장점:
+
+- Supabase Auth/RLS 경계가 단순하다.
+- 모든 데이터가 처음부터 `user_id`에 귀속된다.
+- 백업과 복구 UX가 단순하다.
+
+단점:
+
+- 초기 진입 장벽이 높다.
+- local-first의 장점인 즉시 사용 경험을 살리기 어렵다.
+- 여행 계획을 가볍게 시작하는 사용자에게 부담이 된다.
+
+### Option B: Guest local-first 사용 후 네트워크 기능에서 로그인 유도
+
+장점:
+
+- 앱 설치 직후 바로 여행/준비물 작성 가능하다.
+- 공유, 백업, 기기 변경 복구가 필요한 시점에 로그인 필요성을 자연스럽게 설명할 수 있다.
+- 초기 이탈을 줄일 수 있다.
+
+단점:
+
+- guest document를 계정 document로 귀속하는 migration이 필요하다.
+- 동일 기기에 여러 계정이 로그인할 때 데이터 격리가 중요하다.
+- guest 상태에서 앱 삭제 시 데이터가 사라진다는 안내가 필요하다.
+
+### Option C: Supabase anonymous auth 사용 후 계정 업그레이드
+
+장점:
+
+- guest도 서버 관점의 user id를 가질 수 있다.
+- 나중에 social/email 계정으로 link하는 흐름을 만들 수 있다.
+- backup opt-in을 조금 더 일찍 제공할 수 있다.
+
+단점:
+
+- anonymous user lifecycle 관리가 필요하다.
+- Supabase Auth 정책과 provider link 제약을 검토해야 한다.
+- 사용자에게 “익명 계정” 개념이 혼란스러울 수 있다.
+
+---
+
+## 결정
+
+Option B를 채택한다. Local-first UX를 위해 guest local-first 사용을 허용하고, 공유/백업/동기화/초대 수락 시점에 로그인을 유도한다.
+
+Option C(Supabase anonymous auth)는 당장 채택하지 않고, Supabase 지원 범위와 계정 연결 UX를 별도 검증한다.
+
+정책:
+
+- 로컬 여행/준비물 작성은 guest로 허용한다.
+- 공유, 클라우드 백업, 웹/모바일 동기화, 초대 수락 시 로그인 필요.
+- 로그인 완료 시 guest local document를 계정 소유 document로 승격한다.
+- guest document에는 `localOwnerId`를 두고, 계정 연결 시 `ownerId = auth.user.id`로 migration한다.
+
+---
+
+## 지원 로그인 방식
+
+- Email/password
+- Kakao OAuth
+- Google OAuth
+- Apple OAuth
+
+수집 가정:
+
+- Email: 이메일 주소, Supabase Auth password hash
+- Kakao: 이메일, 닉네임/프로필 정보, Kakao provider id
+- Google: 이메일, 이름/닉네임, 프로필 이미지, Google provider id
+- Apple: 이메일 또는 private relay email, 이름, Apple provider id
+
+최소 수집 원칙:
+
+- 협업자 식별에 필요한 이메일/닉네임 중심으로 수집한다.
+- 프로필 이미지는 선택 정보로 취급하는 방향을 우선 검토한다.
+- provider id는 계정 연결과 중복 가입 방지 목적으로만 사용한다.
+
+---
+
+## Guest 데이터 승격 흐름
+
+```mermaid
+flowchart TD
+  GuestCreate[GuestCreatesLocalDocument] --> LocalOnly[LocalOnlyDocument]
+  LocalOnly --> LoginRequired[ShareOrBackupRequiresLogin]
+  LoginRequired --> SupabaseAuth[SupabaseAuth]
+  SupabaseAuth --> AttachOwner[AttachAuthUserId]
+  AttachOwner --> UploadBackup[UploadInitialSnapshot]
+  UploadBackup --> EnableSync[EnableBackupAndSharing]
+```
+
+승격 조건:
+
+- 로그인 성공
+- document owner가 local guest owner인 상태
+- 기존 계정에 같은 document id가 없는 상태
+- backup upload 성공 또는 retry queue 등록 성공
+
+---
+
+## 개인정보 처리방침 반영 항목
+
+필수 고지:
+
+- 로그인 provider별 수집 항목
+- 사용자가 입력한 여행/일정/준비물 데이터의 로컬 저장 및 클라우드 백업
+- 협업 초대 시 참여자 간 프로필 정보와 작성 데이터 공유
+- WebRTC 연결 및 signaling 과정에서 IP 주소/네트워크 정보 처리 가능성
+- 기기 동기화를 위한 device id, push token, sync state 수집
+- Supabase 및 하위 인프라에 대한 개인정보 처리 위탁
+
+---
+
+## 승인 기준
+
+- guest document와 authenticated document 간 migration 테스트가 가능하다.
+- 앱 삭제 시 guest 데이터 유실 가능성을 UX에서 안내한다.
+- 로그인 후 기존 guest data가 중복 생성되지 않는다.
+- 로그아웃/계정 전환 시 local document 격리가 보장된다.
+- 개인정보 처리방침에 수집/공유/위탁 항목이 반영된다.
+
+---
+
+## 후속 작업
+
+- guest local owner id 설계
+- account attach migration PoC
+- provider별 개인정보 수집 항목 확정
+- 회원 탈퇴 시 local/backup 삭제 정책 정리
+- 약관/개인정보 처리방침 개정안 작성

--- a/docs/refactor/adrs/ADR-008-invitation-and-permission-registry.md
+++ b/docs/refactor/adrs/ADR-008-invitation-and-permission-registry.md
@@ -1,0 +1,185 @@
+# ADR-008: 초대 방식 및 권한 Registry 전략
+
+- 상태: 채택됨
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+  - `docs/refactor/adrs/ADR-004-p2p-signaling-strategy.md`
+  - `docs/refactor/adrs/ADR-007-auth-identity-and-delayed-auth.md`
+
+---
+
+## 문제 정의
+
+Local-first/P2P 구조에서도 “누가 어떤 여행 문서에 접근할 수 있는가”는 신뢰 가능한 중앙 registry가 필요하다. 클라이언트 로컬 문서의 `members` snapshot은 UX와 optimistic guard로는 충분하지만, 보안 경계가 될 수 없다.
+
+여행 공유에는 다음이 필요하다.
+
+- 초대 생성
+- 초대 링크/코드/QR/계정 초대
+- 초대 수락
+- owner/editor/viewer role 관리
+- signaling room 접근 제어
+- backup read/write 접근 제어
+- 권한 회수
+
+---
+
+## 결정해야 할 질문
+
+친구 초대와 권한 관리를 어떤 방식으로 제공하고, 최종 권한 authority를 어디에 둘 것인가?
+
+---
+
+## 선택지
+
+### Option A: 딥 링크 기반 초대
+
+장점:
+
+- 카카오톡/문자 공유 UX가 자연스럽다.
+- 앱 설치/미설치 시나리오와 연결하기 쉽다.
+- 현재 서비스의 공유 링크 UX와 잘 맞는다.
+
+단점:
+
+- 링크 유출 시 접근 위험이 있다.
+- 만료, 비밀번호, role 제한 정책이 필요하다.
+
+### Option B: 초대 코드 입력
+
+장점:
+
+- 구현이 단순하다.
+- 웹/앱/오프라인 대면 상황에서 모두 사용 가능하다.
+- 딥 링크가 실패해도 fallback으로 좋다.
+
+단점:
+
+- 사용자가 직접 입력해야 한다.
+- 코드 추측 방지를 위한 entropy와 rate limit이 필요하다.
+
+### Option C: QR 코드 초대
+
+장점:
+
+- 대면 여행 계획 상황에서 UX가 좋다.
+- 연락처 없이 즉시 참여 가능하다.
+
+단점:
+
+- 카메라 권한과 QR scanner가 필요하다.
+- 원격 초대에는 적합하지 않다.
+
+### Option D: 이메일/계정 검색 초대
+
+장점:
+
+- 지정 사용자만 초대할 수 있어 보안이 좋다.
+- pending/accepted 상태 관리가 명확하다.
+- 권한 부여와 audit trail이 쉽다.
+
+단점:
+
+- 초대받는 사용자가 계정을 가지고 있어야 하거나 가입 유도가 필요하다.
+- 검색/프로필 노출 정책이 필요하다.
+
+---
+
+## 결정
+
+초기 제품은 다음 조합을 채택한다.
+
+- 기본: 딥 링크 초대
+- fallback: 초대 코드 입력
+- 현장 사용성: QR 코드는 후속 기능
+- 보안 초대: 이메일/계정 초대는 owner/editor/viewer 권한 관리와 함께 유지
+
+권한 authority는 Supabase `document_members`와 초대 registry에 둔다.
+
+---
+
+## Supabase Registry
+
+제안 테이블:
+
+- `document_members`
+- `document_invitation_links`
+- `document_share_tokens`
+
+권장 컬럼:
+
+```sql
+create table public.document_invitation_links (
+  id uuid default gen_random_uuid() primary key,
+  document_id uuid references public.documents(id) on delete cascade not null,
+  token text unique not null,
+  invite_code text unique,
+  role text not null check (role in ('editor', 'viewer')),
+  created_by uuid references public.profiles(id) not null,
+  expires_at timestamptz,
+  max_uses integer,
+  used_count integer default 0 not null,
+  revoked_at timestamptz,
+  created_at timestamptz default now() not null
+);
+```
+
+RLS/RPC 원칙:
+
+- owner만 초대 링크 생성/폐기 가능
+- editor 초대 권한은 별도 결정 전까지 비활성
+- 초대 수락은 RPC로 처리
+- RPC는 token 만료/폐기/사용 횟수/role을 검증
+- `document_members` 변경은 owner만 가능
+
+---
+
+## P2P Signaling 권한
+
+시그널링 서버 또는 provider는 room join 시 다음을 검증해야 한다.
+
+1. Supabase JWT 유효성
+2. `document_members.status = accepted`
+3. 해당 document 접근 role
+4. room secret 유효성
+
+viewer 정책:
+
+- viewer는 document backup read 가능
+- viewer는 local UI에서 편집 버튼 비활성화
+- viewer가 로컬에서 임의 update를 만들어도 backup upload는 RLS/RPC에서 거부
+- P2P provider는 viewer의 write update를 다른 peer에게 전파하지 않거나, peer가 role 검증 후 무시
+
+---
+
+## 개인정보 공유 고지
+
+초대/공유 기능 사용 시 다음을 고지해야 한다.
+
+- 여행 참여자 간 닉네임, 이메일 일부, 프로필 이미지가 공유될 수 있음
+- 참여자 간 여행 일정, 장소, 준비물, 체크 상태, 메모가 공유됨
+- P2P 연결 과정에서 네트워크 정보가 처리될 수 있음
+- 초대 링크를 받은 사용자가 링크 조건에 따라 여행방에 접근할 수 있음
+
+---
+
+## 승인 기준
+
+- 초대 링크로 신규 사용자가 문서를 복구할 수 있다.
+- 초대 코드 fallback이 동작한다.
+- owner/editor/viewer 권한이 backup upload와 P2P join에 반영된다.
+- 권한 회수 후 새 sync/update가 차단된다.
+- 링크 만료/폐기/rate limit 정책이 정의된다.
+
+---
+
+## 후속 작업
+
+- document invitation schema 작성
+- invite RPC 설계
+- 딥 링크 route 설계
+- QR 초대 후순위 task 작성
+- signaling room 권한 검증 PoC

--- a/docs/refactor/adrs/ADR-009-notification-strategy.md
+++ b/docs/refactor/adrs/ADR-009-notification-strategy.md
@@ -1,0 +1,162 @@
+# ADR-009: Local-First 환경의 푸시 및 로컬 알림 전략
+
+- 상태: 채택됨
+- 결정일: 2026-06-29
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+  - `docs/refactor/adrs/ADR-006-search-analytics-indexing.md`
+
+---
+
+## 문제 정의
+
+전통적인 서버 중심 구조에서는 서버가 row 변경 내용을 해석해 푸시 알림을 발송한다. Local-first 전환 후 Supabase에는 Yjs update blob 또는 snapshot이 저장되며, 서버는 변경 내용의 의미를 직접 알기 어렵다.
+
+하지만 여행 서비스에는 두 종류의 알림이 필요하다.
+
+1. 일정 시간 기반 리마인더
+2. 협업 변경 알림
+
+두 알림은 성격이 다르므로 같은 방식으로 처리하면 안 된다.
+
+---
+
+## 결정해야 할 질문
+
+Local-first 구조에서 푸시 알림과 로컬 알림을 어떤 책임 분리로 처리할 것인가?
+
+---
+
+## 선택지
+
+### Option A: 모든 알림을 서버 푸시로 처리
+
+장점:
+
+- 알림 발송 경로가 일관적이다.
+- 기기가 꺼져 있어도 서버가 알림을 보낼 수 있다.
+
+단점:
+
+- 서버가 CRDT update 의미를 해석해야 한다.
+- 오프라인/로컬 수정과 맞지 않는다.
+- E2EE 도입 시 변경 내용을 알 수 없다.
+
+### Option B: 시간 기반 알림은 로컬, 협업 변경은 서버 metadata push
+
+장점:
+
+- 여행 일정 리마인더는 네트워크 없이도 동작한다.
+- 협업 알림은 사람이 읽을 수 있는 metadata만 서버에 전달하면 된다.
+- Yjs blob과 알림 요약을 분리할 수 있다.
+
+단점:
+
+- 클라이언트가 notification summary를 생성해야 한다.
+- 오프라인 변경을 나중에 묶어 보낼 batching 정책이 필요하다.
+
+### Option C: 모든 알림을 로컬 동기화 후 클라이언트가 판단
+
+장점:
+
+- 서버가 사용자 내용을 몰라도 된다.
+- local-first 철학에 가깝다.
+
+단점:
+
+- 앱이 실행되지 않으면 협업 알림을 받을 수 없다.
+- 사용자가 변경 사실을 늦게 알 수 있다.
+
+---
+
+## 결정
+
+Option B를 채택한다.
+
+- 일정 리마인더: 기기 로컬 알림으로 예약
+- 협업 변경 알림: Supabase Edge Function 또는 DB webhook으로 push
+- Yjs update blob과 알림 metadata는 분리
+- 오프라인 중 발생한 다수 변경은 summary batching
+
+---
+
+## 알림 데이터 모델
+
+제안 테이블:
+
+```sql
+create table public.notification_events (
+  id uuid default gen_random_uuid() primary key,
+  document_id uuid references public.documents(id) on delete cascade not null,
+  actor_id uuid references public.profiles(id),
+  event_type text not null,
+  target_user_ids uuid[] not null,
+  title text not null,
+  body text not null,
+  dedupe_key text,
+  created_at timestamptz default now() not null,
+  delivered_at timestamptz
+);
+```
+
+기존 `user_devices` 또는 새 `push_tokens` 테이블을 사용해 target device를 찾는다.
+
+---
+
+## 협업 알림 흐름
+
+```mermaid
+flowchart TD
+  LocalChange[LocalDocumentChange] --> YUpdate[YjsUpdate]
+  LocalChange --> Summary[NotificationSummary]
+  YUpdate --> BackupQueue[BackupQueue]
+  Summary --> NotificationEvent[SupabaseNotificationEvent]
+  NotificationEvent --> EdgeFunction[EdgeFunction]
+  EdgeFunction --> ExpoPush[ExpoPushService]
+  ExpoPush --> TargetDevice[TargetDevice]
+```
+
+규칙:
+
+- document content 전체를 notification payload에 넣지 않는다.
+- 여러 변경은 `dedupe_key`로 묶는다.
+- 사용자가 같은 document를 현재 보고 있으면 push 대신 in-app toast를 우선한다.
+- viewer에게는 읽기 가능한 변경 알림만 보낸다.
+
+---
+
+## 로컬 알림
+
+일정 리마인더는 local materialized read model을 기반으로 기기 OS에 예약한다.
+
+대상:
+
+- 일정 시작 전 알림
+- 준비물 마감/출발 전 리마인더
+
+정책:
+
+- plan 변경 시 기존 로컬 알림을 취소하고 재등록한다.
+- backup sync 성공 여부와 무관하게 로컬 알림은 유지한다.
+- 로그아웃 또는 document 접근 해제 시 해당 document의 로컬 알림을 제거한다.
+
+---
+
+## 승인 기준
+
+- 서버가 Yjs blob을 해석하지 않아도 협업 알림을 보낼 수 있다.
+- 오프라인 변경이 온라인 복구 시 과도한 푸시 폭탄으로 이어지지 않는다.
+- 일정 리마인더가 오프라인에서도 동작한다.
+- push token 저장과 삭제가 계정/기기 lifecycle과 연결된다.
+
+---
+
+## 후속 작업
+
+- notification metadata schema 설계
+- Expo push token lifecycle 정리
+- 로컬 알림 scheduler 추상화
+- 협업 알림 batching/debounce 정책 작성
+- Edge Function push PoC

--- a/docs/refactor/adrs/ADR-010-operating-cost-and-infrastructure.md
+++ b/docs/refactor/adrs/ADR-010-operating-cost-and-infrastructure.md
@@ -1,0 +1,210 @@
+# ADR-010: 운영 비용 및 인프라 구성 전략
+
+- 상태: 후속 검토
+- 결정일: 미정
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+  - `docs/refactor/adrs/ADR-004-p2p-signaling-strategy.md`
+  - `docs/refactor/adrs/ADR-009-notification-strategy.md`
+
+---
+
+## 문제 정의
+
+Local-first + P2P 구조는 중앙 서버 부하를 줄일 수 있지만, 완전 무인프라 구조는 아니다. 실제 서비스 운영에는 다음 인프라가 필요하다.
+
+- Supabase Auth
+- Supabase backup/update storage
+- Supabase Realtime 또는 Edge Functions
+- signaling server
+- STUN/TURN
+- 웹 호스팅
+- push notification 인프라
+- 앱스토어 계정/도메인
+
+따라서 목표 비용과 scaling trigger를 명확히 해야 한다.
+
+---
+
+## 결정해야 할 질문
+
+초기 운영에서 어떤 인프라를 무료/저비용 managed service로 시작하고, 어떤 시점에 유료/자체 운영으로 전환할 것인가?
+
+본 ADR은 ADR-001부터 ADR-009까지의 결정사항을 `docs/refactor/TECHNICAL-SPEC.md`에 승격한 뒤 후속 검토한다.
+
+---
+
+## 기본 비용 가정
+
+초기/소규모:
+
+- Supabase: Free tier 우선
+- Signaling: 무료 또는 hobby tier
+- STUN: 공개 STUN
+- TURN: managed provider의 무료 제공량 또는 종량제
+- Web hosting: 현재 Vercel 유지 우선
+- Push: Expo Push Service + Supabase Edge Function
+- App Store: Apple Developer Program, Google Play Console
+
+스케일업:
+
+- Supabase Pro 이상
+- signaling server paid instance
+- TURN paid quota
+- Web hosting pro tier
+- monitoring/logging 도구
+
+---
+
+## 비용상 유리한 이유
+
+전통적 서버 구조:
+
+- 모든 읽기/쓰기/실시간 협업이 서버 DB와 API를 통과한다.
+- 동시접속과 문서 편집량이 서버 비용에 직접 반영된다.
+
+Local-first 구조:
+
+- 읽기/쓰기는 로컬에서 처리한다.
+- 동시 접속자는 가능하면 P2P로 sync한다.
+- Supabase는 backup, restore, registry, push metadata에 집중한다.
+- 서버 비용은 사용자 조작 횟수보다 backup/update batching 정책에 더 크게 좌우된다.
+
+---
+
+## 비용 위험 요소
+
+- Yjs update log를 너무 자주 Supabase에 insert하면 DB write 비용이 증가한다.
+- snapshot compaction 없이 update log가 누적되면 저장소 비용이 증가한다.
+- TURN relay 사용량이 많아지면 네트워크 비용이 증가한다.
+- Supabase Realtime을 fallback sync로 과도하게 사용하면 비용과 quota가 증가한다.
+- push notification batching이 없으면 Edge Function 호출이 증가한다.
+- 웹 호스팅 이전을 TURN provider 선택과 묶으면 불필요한 마이그레이션 리스크가 생긴다.
+
+---
+
+## 비용 제어 정책
+
+- Yjs update는 debounce/batch 후 업로드한다.
+- 일정 크기 이상 update log는 snapshot compaction한다.
+- P2P 실패 시에만 TURN relay 사용한다.
+- Supabase Realtime은 critical document room에 제한적으로 사용한다.
+- notification event는 dedupe/batching한다.
+- image/binary data는 Yjs document에 넣지 않고 Storage reference만 저장한다.
+- TURN provider와 웹 호스팅 provider는 독립적으로 결정한다.
+
+---
+
+## STUN/TURN Provider 기준
+
+Local-first 전환의 P2P는 optional fast path이므로, STUN/TURN 선택은 "항상 연결되어야 하는 primary sync 인프라"가 아니라 "동시 접속 중 빠른 전파를 위한 connectivity 보조 인프라" 관점에서 비용을 산정한다.
+
+권장 기준선:
+
+- STUN: Cloudflare STUN을 기본값으로 사용한다. Google public STUN은 연결성 검증 단계의 보조 후보로만 둔다.
+- TURN: Cloudflare Realtime TURN을 managed provider 기준선으로 채택한다.
+- TURN 비교 후보: Metered/OpenRelay는 Cloudflare 적용 전후의 연결성 비교 또는 장애 대응 참고 후보로만 둔다.
+- TURN 대체 후보: Twilio 또는 Xirsys는 비용보다 안정성, 지원, 계약, 기업용 신뢰성이 중요해지는 시점에 별도 검토한다.
+
+운영 방식:
+
+- TURN credential은 클라이언트에 고정 저장하지 않는다.
+- Supabase Edge Function 또는 별도 server-side endpoint가 짧은 TTL의 ICE server config를 발급한다.
+- TURN relay bytes, relay 연결 비율, P2P 실패율, 연결 수립 p95 latency를 비용 관측 지표로 둔다.
+- TURN 무료 제공량의 70%를 넘으면 paid quota, provider fallback, P2P 정책 조정을 검토한다.
+
+---
+
+## Cloudflare 웹 호스팅 이전 검토
+
+Cloudflare Realtime TURN 채택 여부와 웹 호스팅 이전 여부는 분리해서 결정한다. Cloudflare TURN을 사용하더라도 Vercel 웹 호스팅을 즉시 이전할 필요는 없다.
+
+현재 판단:
+
+- 단기: Vercel 웹 호스팅을 유지하고 Cloudflare TURN만 독립 도입할 수 있다.
+- 중기: Local-first 전환으로 서버 의존도가 줄어든 뒤 Cloudflare Pages/Workers 이전을 별도 PoC로 검토한다.
+- 이전 판단은 비용 절감뿐 아니라 Next.js 호환성, API Route, auth middleware, Sentry/analytics, image handling 차이를 함께 검증해야 한다.
+
+Cloudflare 이전이 유리해지는 조건:
+
+- Vercel seat 비용 또는 사용량 과금이 지속적으로 증가한다.
+- 웹 앱이 정적 UI와 client-side local-first 동작 중심으로 단순해진다.
+- server-side Next.js 기능 의존도가 줄고, Edge Function 성격의 API만 남는다.
+- Cloudflare Pages/Workers PoC에서 `proxy.ts`, App Router API Route, Supabase Auth callback이 안정적으로 동작한다.
+
+Vercel 유지가 유리한 조건:
+
+- 현재 월 비용이 낮고 운영 문제가 없다.
+- Next.js 16 기능, middleware/proxy, image optimization, API Route 호환성 리스크가 크다.
+- Cloudflare 이전으로 절감되는 비용보다 마이그레이션 및 검증 비용이 크다.
+
+결론적으로 웹 호스팅 이전은 Local-first refactor의 필수 조건이 아니다. `Cloudflare TURN 도입`과 `Cloudflare 웹 호스팅 이전`은 별도 ADR 또는 후속 비용 검토 항목으로 관리한다.
+
+---
+
+## Scaling Trigger
+
+다음 기준 중 하나를 만족하면 인프라 업그레이드를 검토한다.
+
+- Supabase DB 저장소 70% 초과
+- monthly active users가 free tier 한계의 70% 초과
+- Edge Function invocation이 free quota의 70% 초과
+- TURN relay 사용량이 무료 제공량의 70% 초과
+- signaling server 동시 연결이 hobby tier 한계의 70% 초과
+- backup restore p95 latency가 제품 기준 초과
+- Vercel 사용량/seat 비용이 Cloudflare 이전 PoC 비용보다 커짐
+
+---
+
+## 현재 기준선
+
+ADR-001부터 ADR-009까지의 현재 결정 기준선은 다음과 같다.
+
+- Supabase는 Auth, encrypted backup, permission registry, invitation registry, index, notification metadata를 담당한다.
+- P2P는 optional fast path이며 기본 sync는 Supabase backup pull/push다.
+- 모바일 WebRTC는 dev client/EAS Build 기반 native provider로 검증한다.
+- 백업 blob은 암호화하고 Server-wrapped key model을 사용한다.
+- Trip document는 초기에는 단일 Yjs document다.
+- index는 hybrid index를 사용한다.
+- guest local-first 사용 후 로그인 승격을 허용한다.
+- 알림은 로컬 알림과 서버 metadata push를 분리한다.
+
+이 기준선에서 초기에는 managed/free tier 중심으로 시작한다.
+
+- Supabase Free/Pro 후보
+- Vercel 또는 현재 웹 배포 환경
+- Expo Push Service
+- Cloudflare STUN
+- Cloudflare Realtime TURN
+- Metered/OpenRelay는 제한적 비교 후보
+- Twilio/Xirsys는 fallback 또는 enterprise-grade 대체 후보
+- signaling은 P2P optional phase에서만 검토
+- 기본 sync 비용은 Supabase backup/update write volume으로 산정
+- 웹 호스팅은 단기적으로 Vercel 유지, Cloudflare Pages/Workers 이전은 별도 후속 검토
+
+자체 signaling server 운영은 사용자 규모와 P2P 품질 요구가 검증된 뒤 별도 결정한다.
+
+---
+
+## 승인 기준
+
+- 1인 개발자가 운영 가능한 비용/복잡도여야 한다.
+- P2P 실패 fallback 비용을 예측할 수 있어야 한다.
+- update batching/compaction 정책이 있어야 한다.
+- 비용 관측 지표가 정의되어야 한다.
+
+---
+
+## 후속 작업
+
+- Supabase backup write volume 추정
+- TURN relay 사용량 PoC
+- Cloudflare Realtime TURN 기반 ICE server config 발급 PoC
+- Cloudflare STUN/TURN Web/RN 연결성 검증
+- Metered/OpenRelay provider 비교는 필요 시 제한적으로 수행
+- signaling server 후보 비교
+- Cloudflare Pages/Workers 이전 가능성 및 비용 PoC
+- monthly cost dashboard 항목 정의
+- update batching 정책과 비용 영향 테스트

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -1,0 +1,57 @@
+# Local-First Refactor Tasks
+
+이 디렉토리는 Local-first Data Engine 전환 작업의 phase별 실행 문서를 보관한다.
+
+상위 문서:
+
+- `docs/refactor/TECHNICAL-SPEC.md`
+- `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+- `docs/plans/PLAN-008-local-first-architecture-review.md`
+
+## 문서 네이밍
+
+작업 문서는 아래 형식을 사용한다.
+
+```text
+TASK-001-checklist-yjs-spike.md
+TASK-002-repository-abstraction.md
+TASK-003-backup-schema.md
+TASK-004-row-document-migration.md
+```
+
+## 권장 템플릿
+
+```markdown
+# TASK-NNN: 제목
+
+## 목적
+
+## 범위
+
+## 선행 조건
+
+## 변경 대상
+
+## 구현 단계
+
+## 데이터 호환성 고려사항
+
+## 검증 방법
+
+## 롤백 방법
+
+## 완료 조건
+```
+
+## 초기 작업 후보
+
+- [ ] `TASK-001-checklist-yjs-spike.md`: 체크리스트 Yjs document 스파이크
+- [ ] `TASK-002-mobile-webrtc-feasibility.md`: Expo dev client/EAS Build 기반 RN WebRTC/Yjs provider 검증
+- [ ] `TASK-003-repository-abstraction.md`: Supabase query 앞 Repository interface 도입
+- [ ] `TASK-004-encrypted-backup-schema.md`: Supabase encrypted document backup schema 및 `document_keys` 설계
+- [ ] `TASK-005-row-document-round-trip.md`: 기존 row/document 변환 round-trip 검증
+- [ ] `TASK-006-dual-write-detector.md`: dual-write mismatch detector 설계
+- [ ] `TASK-007-guest-auth-promotion.md`: Option B 지연 인증 기반 guest local document를 Supabase Auth 계정으로 승격하는 PoC
+- [ ] `TASK-008-invitation-permission-registry.md`: 딥 링크/초대 코드와 Supabase document permission registry PoC
+- [ ] `TASK-009-notification-metadata.md`: 시간 기반 로컬 알림과 협업 push metadata 분리 PoC
+- [ ] `TASK-010-cost-observability.md`: ADR-001~009 결정사항 기반 backup/update/index/notification 비용 관측 지표 설계


### PR DESCRIPTION
## Summary
- Add the local-first architecture review plan and technical spec.
- Record ADR decisions for CRDT/Yjs, P2P, backup encryption, auth, sharing, notifications, and cost strategy.
- Define follow-up refactor tasks and Cloudflare STUN/TURN operating assumptions.

## Test plan
- [x] pnpm build
- [x] pnpm build:mobile


Made with [Cursor](https://cursor.com)