### PR TITLE
Add Web IndexedDB Yjs checklist spike

### DIFF
--- a/apps/web/app/trips/checklist/ChecklistClient.tsx
+++ b/apps/web/app/trips/checklist/ChecklistClient.tsx
@@ -15,6 +15,7 @@ import { useNetworkStore } from '@/stores/useNetworkStore'
 import { CATEGORIES } from '@/constants/checklist'
 import ChecklistSkeleton from './ChecklistSkeleton'
 import { createWebRepositories } from '@/lib/local-first/repositoryFactory'
+import { subscribeToTripDocumentUpdates } from '@/lib/local-first/indexedDbStore'
 
 const getMemberDisplayName = (p: any, isMe: boolean = false) => {
     if (!p) return isMe ? '나' : '동행자'
@@ -374,6 +375,8 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
     const supabase = useMemo(() => createClient(), [])
     const repositories = useMemo(() => createWebRepositories(supabase), [supabase])
     const { isOnline } = useNetworkStore()
+    const isLocalFirstChecklistSpike = repositories.mode === 'local-first-checklist-spike'
+    const canUseChecklistActions = (isOnline || isLocalFirstChecklistSpike) && !isOffline
 
     const [isLoading, setIsLoading] = useState(true)
     const [checklistId, setChecklistId] = useState<string | null>(null)
@@ -426,7 +429,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
 
             // 2. 네트워크 확인
             const { isOfflineMode } = useNetworkStore.getState()
-            if (!isOnline || isOfflineMode) {
+            if (!isLocalFirstChecklistSpike && (!isOnline || isOfflineMode)) {
                 setIsLoading(false)
                 return
             }
@@ -465,9 +468,19 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
     useEffect(() => {
         if (isActive) {
             fetchChecklist()
-            supabase.auth.getUser().then(({ data }: { data: { user: any } }) => setCurrentUser(data.user))
+            supabase.auth
+                .getUser()
+                .then(({ data }: { data: { user: any } }) => setCurrentUser(data.user))
+                .catch(() => setCurrentUser(null))
         }
     }, [isActive, fetchChecklist])
+
+    useEffect(() => {
+        if (!tripId || !isLocalFirstChecklistSpike) return
+        return subscribeToTripDocumentUpdates(tripId, () => {
+            void fetchChecklist()
+        })
+    }, [fetchChecklist, isLocalFirstChecklistSpike, tripId])
 
     const toggleItem = async (itemId: string, currentStatus: boolean) => {
         const item = items.find(i => i.id === itemId)
@@ -709,7 +722,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
         const isAssignedToMe = item.assignment_type === 'specific'
             ? (assignedIds.length > 0 ? assignedIds.includes(currentUser?.id) : item.assigned_user_id === currentUser?.id)
             : true
-        const canCheck = (item.assignment_type === 'specific' ? isAssignedToMe : true) && isOnline && !isOffline
+        const canCheck = (item.assignment_type === 'specific' ? isAssignedToMe : true) && canUseChecklistActions
 
         const controls = useAnimation();
         const [isSwiping, setIsSwiping] = useState(false);
@@ -744,7 +757,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
         return (
             <li className={css({ position: 'relative', overflow: 'hidden', borderBottom: '1px solid', borderColor: 'brand.hairlineSoft', bg: 'white' })}>
                 {/* 배경 액션 버튼 (스와이프 시 보임) - 오프라인 모드에서는 숨김 */}
-                {isOnline && !isOffline && (
+                {canUseChecklistActions && (
                     <div className={css({
                         position: 'absolute', top: 0, right: 0, bottom: 0,
                         display: { base: 'flex', sm: 'none' }, // 모바일 전용
@@ -896,7 +909,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                     </div>
 
                     {/* PC에서만 보이는 우측 버튼 */}
-                    {isOnline && !isOffline && (
+                    {canUseChecklistActions && (
                         <div className={css({ display: { base: 'none', sm: 'flex' }, gap: '8px' })}>
                             <button
                                 onClick={(e) => { e.stopPropagation(); setEditingItem(item); }}
@@ -1229,7 +1242,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                     {totalItems === 0 && <div className={css({ display: { base: 'none', sm: 'block' } })}></div>}
 
                     {/* 액션 및 필터 컨트롤 그룹 (주로 모바일/PC 액션) */}
-                    {isOnline && !isOffline && (
+                    {canUseChecklistActions && (
                         <div className={css({ 
                             display: 'flex', 
                             flexDirection: { base: 'column', sm: 'row' },
@@ -1263,21 +1276,23 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                                     </button>
                                 )}
                                 
-                                <button
-                                    onClick={() => setIsTemplateModalOpen(true)}
-                                    className={css({
-                                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '5px',
-                                        px: '12px', h: '42px',
-                                        bg: 'white', color: 'brand.ink', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '12px',
-                                        fontSize: '13px', fontWeight: '700', cursor: 'pointer',
-                                        flex: '1',
-                                        whiteSpace: 'nowrap', transition: 'all 0.2s',
-                                        _hover: { bg: 'bg.surfaceSoft', borderColor: 'brand.primary' },
-                                        _active: { transform: 'scale(0.98)' }
-                                    })}
-                                >
-                                    <ListTodo size={14} color="var(--colors-brand-primary)" /> 템플릿
-                                </button>
+                                {!isLocalFirstChecklistSpike && (
+                                    <button
+                                        onClick={() => setIsTemplateModalOpen(true)}
+                                        className={css({
+                                            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '5px',
+                                            px: '12px', h: '42px',
+                                            bg: 'white', color: 'brand.ink', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '12px',
+                                            fontSize: '13px', fontWeight: '700', cursor: 'pointer',
+                                            flex: '1',
+                                            whiteSpace: 'nowrap', transition: 'all 0.2s',
+                                            _hover: { bg: 'bg.surfaceSoft', borderColor: 'brand.primary' },
+                                            _active: { transform: 'scale(0.98)' }
+                                        })}
+                                    >
+                                        <ListTodo size={14} color="var(--colors-brand-primary)" /> 템플릿
+                                    </button>
+                                )}
                             </div>
 
                             <div className={css({ display: { base: 'none', sm: 'flex' }, gap: '8px', w: { base: '100%', sm: 'auto' } })}>
@@ -1294,22 +1309,24 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                                     <Plus size={16} /> 항목 추가
                                 </button>
 
-                                <button
-                                    onClick={() => setIsTemplateModalOpen(true)}
-                                    className={css({
-                                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '5px',
-                                        px: '16px', h: '42px',
-                                        bg: 'white', color: 'brand.ink', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '12px',
-                                        fontSize: '13px', fontWeight: '700', cursor: 'pointer',
-                                        w: { base: '100%', sm: 'auto' }, flex: { base: '1', sm: 'none' },
-                                        flexShrink: '0',
-                                        whiteSpace: 'nowrap', transition: 'all 0.2s',
-                                        _hover: { bg: 'bg.surfaceSoft', borderColor: 'brand.primary' },
-                                        _active: { transform: 'scale(0.98)' }
-                                    })}
-                                >
-                                    <ListTodo size={14} color="var(--colors-brand-primary)" /> 템플릿 불러오기
-                                </button>
+                                {!isLocalFirstChecklistSpike && (
+                                    <button
+                                        onClick={() => setIsTemplateModalOpen(true)}
+                                        className={css({
+                                            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '5px',
+                                            px: '16px', h: '42px',
+                                            bg: 'white', color: 'brand.ink', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '12px',
+                                            fontSize: '13px', fontWeight: '700', cursor: 'pointer',
+                                            w: { base: '100%', sm: 'auto' }, flex: { base: '1', sm: 'none' },
+                                            flexShrink: '0',
+                                            whiteSpace: 'nowrap', transition: 'all 0.2s',
+                                            _hover: { bg: 'bg.surfaceSoft', borderColor: 'brand.primary' },
+                                            _active: { transform: 'scale(0.98)' }
+                                        })}
+                                    >
+                                        <ListTodo size={14} color="var(--colors-brand-primary)" /> 템플릿 불러오기
+                                    </button>
+                                )}
                             </div>
                         </div>
                     )}
@@ -1484,7 +1501,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                         <p className={css({ fontSize: '19px', fontWeight: '700', mb: '12px', color: 'brand.ink', letterSpacing: '-0.5px' })}>
                             여행을 완벽하게 해줄 준비물을 등록해 보세요! ✨
                         </p>
-                        {isOnline && !isOffline && (
+                        {canUseChecklistActions && (
                             <p className={css({ fontSize: '15px', color: 'brand.muted', lineHeight: '1.6', wordBreak: 'keep-all', maxW: '320px', mx: 'auto' })}>
                                 체크리스트로 꼼꼼하게 챙기면 여행의 설렘이 두 배가 됩니다. 🧳
                             </p>
@@ -1591,7 +1608,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                 </div>
             )}
             {/* 모바일 하단 플로팅 버튼 - + 항목 추가 - 오프라인 모드에서는 숨김 */}
-            {isActive && !isAdding && !isTemplateModalOpen && isOnline && !isOffline && (
+            {isActive && !isAdding && !isTemplateModalOpen && canUseChecklistActions && (
                 <div
                     onClick={() => setIsAdding(true)}
                     className={css({
@@ -1613,7 +1630,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                 </div>
             )}
 
-            {checklistId && (
+            {checklistId && !isLocalFirstChecklistSpike && (
                 <TemplateModal
                     isOpen={isTemplateModalOpen}
                     onClose={() => setIsTemplateModalOpen(false)}

--- a/apps/web/lib/local-first/indexedDbStore.ts
+++ b/apps/web/lib/local-first/indexedDbStore.ts
@@ -1,0 +1,121 @@
+const DATABASE_NAME = 'onvoy-local-first-spike'
+const DATABASE_VERSION = 1
+const TRIP_DOCUMENT_STORE = 'tripDocuments'
+const BROADCAST_CHANNEL_NAME = 'onvoy-local-first-checklist-spike'
+
+export interface StoredTripDocumentUpdate {
+  id: string
+  update: ArrayBuffer
+  updatedAt: string
+}
+
+export async function loadTripDocumentUpdate(documentId: string): Promise<Uint8Array | null> {
+  if (!canUseIndexedDb()) return null
+  const db = await openDatabase()
+  const row = await runTransaction<StoredTripDocumentUpdate | undefined>(
+    db,
+    TRIP_DOCUMENT_STORE,
+    'readonly',
+    (store) => store.get(documentId),
+  )
+  db.close()
+
+  return row ? new Uint8Array(row.update) : null
+}
+
+export async function saveTripDocumentUpdate(
+  documentId: string,
+  update: Uint8Array,
+): Promise<void> {
+  if (!canUseIndexedDb()) return
+  const db = await openDatabase()
+  await runTransaction(
+    db,
+    TRIP_DOCUMENT_STORE,
+    'readwrite',
+    (store) => store.put({
+      id: documentId,
+      update: toStandaloneArrayBuffer(update),
+      updatedAt: new Date().toISOString(),
+    } satisfies StoredTripDocumentUpdate),
+  )
+  db.close()
+  notifyTripDocumentUpdated(documentId)
+}
+
+export function subscribeToTripDocumentUpdates(
+  documentId: string,
+  onUpdate: () => void,
+): () => void {
+  if (typeof window === 'undefined') return () => undefined
+
+  const handleWindowEvent = (event: Event) => {
+    const customEvent = event as CustomEvent<{ documentId: string }>
+    if (customEvent.detail?.documentId === documentId) onUpdate()
+  }
+  window.addEventListener(BROADCAST_CHANNEL_NAME, handleWindowEvent)
+
+  const channel = typeof BroadcastChannel === 'undefined'
+    ? null
+    : new BroadcastChannel(BROADCAST_CHANNEL_NAME)
+  channel?.addEventListener('message', (event: MessageEvent<{ documentId: string }>) => {
+    if (event.data?.documentId === documentId) onUpdate()
+  })
+
+  return () => {
+    window.removeEventListener(BROADCAST_CHANNEL_NAME, handleWindowEvent)
+    channel?.close()
+  }
+}
+
+function notifyTripDocumentUpdated(documentId: string): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(BROADCAST_CHANNEL_NAME, { detail: { documentId } }))
+  }
+  if (typeof BroadcastChannel !== 'undefined') {
+    const channel = new BroadcastChannel(BROADCAST_CHANNEL_NAME)
+    channel.postMessage({ documentId })
+    channel.close()
+  }
+}
+
+function canUseIndexedDb(): boolean {
+  return typeof indexedDB !== 'undefined'
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION)
+
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(TRIP_DOCUMENT_STORE)) {
+        db.createObjectStore(TRIP_DOCUMENT_STORE, { keyPath: 'id' })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+function runTransaction<T>(
+  db: IDBDatabase,
+  storeName: string,
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(storeName, mode)
+    const request = operation(transaction.objectStore(storeName))
+
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+    transaction.onerror = () => reject(transaction.error)
+  })
+}
+
+function toStandaloneArrayBuffer(update: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(update.byteLength)
+  new Uint8Array(buffer).set(update)
+  return buffer
+}

--- a/apps/web/lib/local-first/localFirstChecklistRepository.ts
+++ b/apps/web/lib/local-first/localFirstChecklistRepository.ts
@@ -1,0 +1,446 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type {
+  Checklist,
+  ChecklistItem,
+  ChecklistItemAssignee,
+  ChecklistItemUserCheck,
+  Trip,
+  TripMember,
+} from '@nexvoy/types'
+import {
+  createEmptyTripDocumentV1,
+  materializeChecklists,
+  type ChecklistRepository,
+  type ChecklistRepositorySnapshot,
+  type ChecklistItemMutationResult,
+  type ToggleChecklistItemForUserInput,
+  type TripDocumentV1,
+} from '@nexvoy/core'
+import {
+  applyTripDocumentUpdate,
+  createYjsTripDocument,
+  encodeTripDocumentUpdate,
+  mutateTripDocumentInYjs,
+  readTripDocumentFromYjs,
+  writeTripDocumentToYjs,
+} from '@nexvoy/core/local-first/yjsTripDocument'
+import type { ChecklistItemInput } from '@nexvoy/core/supabase/queries'
+import {
+  loadTripDocumentUpdate,
+  saveTripDocumentUpdate,
+} from './indexedDbStore'
+
+const SPIKE_USER_ID = 'local-first-spike-user'
+
+export function createWebLocalFirstChecklistRepository(
+  supabase: SupabaseClient,
+): ChecklistRepository {
+  return {
+    getChecklist: (tripId) => getLocalChecklistSnapshot(supabase, tripId),
+    createItem: async (checklistId, input) => {
+      const tripId = parseTripIdFromChecklistId(checklistId)
+      if (!tripId) throw new Error('Local-first checklist id is invalid.')
+      let createdItemId = ''
+      const document = await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
+        const now = new Date().toISOString()
+        const itemId = createLocalEntityId('item', tripId)
+        createdItemId = itemId
+        const assigneeIds = normalizeAssigneeIds(input)
+
+        tripDocument.checklistItems[itemId] = {
+          id: itemId,
+          checklistId,
+          name: input.item_name.trim(),
+          categoryName: input.category ?? '기타',
+          legacyIsChecked: false,
+          isPrivate: input.is_private ?? false,
+          assignmentType: input.assignment_type ?? 'anyone',
+          assignedUserId: assigneeIds[0] ?? input.assigned_user_id ?? null,
+          sourceTemplateName: input.source_template_name ?? null,
+          createdAt: now,
+          updatedAt: now,
+        }
+        replaceAssignees(tripDocument, itemId, assigneeIds, now)
+      })
+      return toMutationResult(document, createdItemId)
+    },
+    updateItem: async (itemId, input) => {
+      const tripId = parseTripIdFromItemId(itemId)
+      if (!tripId) throw new Error('Local-first item id is invalid.')
+      const document = await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
+        const item = tripDocument.checklistItems[itemId]
+        if (!item) throw new Error('Local-first checklist item was not found.')
+        const now = new Date().toISOString()
+        const assigneeIds = normalizeAssigneeIds(input)
+
+        item.name = input.item_name.trim()
+        item.categoryName = input.category ?? '기타'
+        item.isPrivate = input.is_private ?? false
+        item.assignmentType = input.assignment_type ?? 'anyone'
+        item.assignedUserId = assigneeIds[0] ?? input.assigned_user_id ?? null
+        item.sourceTemplateName = input.source_template_name ?? item.sourceTemplateName
+        item.updatedAt = now
+        replaceAssignees(tripDocument, itemId, assigneeIds, now)
+      })
+      return toMutationResult(document, itemId)
+    },
+    deleteItem: async (itemId) => {
+      const tripId = parseTripIdFromItemId(itemId)
+      if (!tripId) throw new Error('Local-first item id is invalid.')
+      await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
+        const now = new Date().toISOString()
+        tripDocument.tombstones[`tombstone:${itemId}`] = {
+          id: `tombstone:${itemId}`,
+          entityType: 'checklistItem',
+          entityId: itemId,
+          deletedBy: tripDocument.trip.ownerId,
+          deletedAt: now,
+        }
+      })
+    },
+    toggleItem: async (itemId, isChecked) => {
+      const tripId = parseTripIdFromItemId(itemId)
+      if (!tripId) throw new Error('Local-first item id is invalid.')
+      await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
+        const item = tripDocument.checklistItems[itemId]
+        if (!item) throw new Error('Local-first checklist item was not found.')
+        item.legacyIsChecked = isChecked
+        item.updatedAt = new Date().toISOString()
+      })
+    },
+    toggleItemForUser: async (input) => {
+      const tripId = parseTripIdFromChecklistId(input.item.checklist_id)
+        ?? parseTripIdFromItemId(input.item.id)
+      if (!tripId) throw new Error('Local-first item id is invalid.')
+      const document = await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
+        const item = tripDocument.checklistItems[input.item.id]
+        if (!item) throw new Error('Local-first checklist item was not found.')
+        const checkId = createUserCheckId(input.item.id, input.currentUserId)
+
+        if (input.nextChecked) {
+          tripDocument.checklistItemUserChecks[checkId] = {
+            id: checkId,
+            itemId: input.item.id,
+            userId: input.currentUserId,
+            createdAt: new Date().toISOString(),
+          }
+        } else {
+          delete tripDocument.checklistItemUserChecks[checkId]
+        }
+
+        const requiredIds = item.assignmentType === 'everyone'
+          ? input.participantIds ?? []
+          : getAssigneeIds(tripDocument, input.item.id)
+        if (requiredIds.length > 0) {
+          const checkedIds = new Set(
+            Object.values(tripDocument.checklistItemUserChecks)
+              .filter((check) => check.itemId === input.item.id)
+              .map((check) => check.userId),
+          )
+          item.legacyIsChecked = requiredIds.every((userId) => checkedIds.has(userId))
+          item.updatedAt = new Date().toISOString()
+        }
+      })
+
+      return toChecklistItemUserCheckRows(document, input.item.id)
+    },
+  }
+}
+
+async function getLocalChecklistSnapshot(
+  supabase: SupabaseClient,
+  tripId: string,
+): Promise<ChecklistRepositorySnapshot> {
+  const document = await loadOrCreateTripDocument(supabase, tripId)
+  return toChecklistRepositorySnapshot(document, await getCurrentUserId(supabase))
+}
+
+async function mutateLocalTripDocument(
+  supabase: SupabaseClient,
+  tripId: string,
+  mutate: (tripDocument: TripDocumentV1) => void,
+): Promise<TripDocumentV1> {
+  const ydoc = await loadYjsTripDocument(supabase, tripId)
+  const document = mutateTripDocumentInYjs(ydoc, (tripDocument) => {
+    mutate(tripDocument)
+  })
+  await saveTripDocumentUpdate(tripId, encodeTripDocumentUpdate(ydoc))
+  return document
+}
+
+async function loadOrCreateTripDocument(
+  supabase: SupabaseClient,
+  tripId: string,
+): Promise<TripDocumentV1> {
+  const ydoc = createYjsTripDocument()
+  const update = await loadTripDocumentUpdate(tripId)
+  if (update) {
+    applyTripDocumentUpdate(ydoc, update)
+  }
+  const document = readTripDocumentFromYjs(ydoc)
+  if (document) return document
+
+  const initialDocument = await createInitialTripDocument(supabase, tripId)
+  writeTripDocumentToYjs(ydoc, initialDocument)
+  await saveTripDocumentUpdate(tripId, encodeTripDocumentUpdate(ydoc))
+  return initialDocument
+}
+
+async function loadYjsTripDocument(
+  supabase: SupabaseClient,
+  tripId: string,
+) {
+  const ydoc = createYjsTripDocument()
+  const update = await loadTripDocumentUpdate(tripId)
+  if (update) {
+    applyTripDocumentUpdate(ydoc, update)
+  } else {
+    writeTripDocumentToYjs(ydoc, await createInitialTripDocument(supabase, tripId))
+  }
+  return ydoc
+}
+
+async function createInitialTripDocument(
+  supabase: SupabaseClient,
+  tripId: string,
+): Promise<TripDocumentV1> {
+  const now = new Date().toISOString()
+  const ownerId = await getCurrentUserId(supabase) ?? SPIKE_USER_ID
+  const checklistId = createLocalChecklistId(tripId)
+  const today = now.slice(0, 10)
+  const tripDocument = createEmptyTripDocumentV1({
+    id: tripId,
+    ownerId,
+    destination: 'Local-first checklist spike',
+    startDate: today,
+    endDate: today,
+    adultsCount: 1,
+    childrenCount: 0,
+    createdAt: now,
+    createdFromLegacyAt: now,
+  })
+
+  tripDocument.checklists[checklistId] = {
+    id: checklistId,
+    title: '로컬 준비물',
+    createdAt: now,
+  }
+  tripDocument.members[`member:${ownerId}`] = {
+    id: `member:${ownerId}`,
+    userId: ownerId,
+    invitedEmail: null,
+    role: 'owner',
+    status: 'accepted',
+    nickname: '나',
+    email: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  return tripDocument
+}
+
+function toChecklistRepositorySnapshot(
+  tripDocument: TripDocumentV1,
+  currentUserId: string | null,
+): ChecklistRepositorySnapshot {
+  const materializedChecklists = materializeChecklists(tripDocument, { currentUserId })
+  const checklists = materializedChecklists.map((checklist): Checklist => ({
+    id: checklist.id,
+    trip_id: tripDocument.trip.id,
+    title: checklist.title,
+    created_at: checklist.createdAt,
+  }))
+  const items = materializedChecklists.flatMap((checklist) =>
+    checklist.items.map((item): ChecklistItem => ({
+      id: item.id,
+      checklist_id: item.checklistId,
+      item_name: item.name,
+      category: item.categoryName,
+      is_checked: item.status.isChecked,
+      is_private: item.isPrivate,
+      assignment_type: item.assignmentType,
+      assigned_user_id: item.assignedUserId,
+      source_template_name: item.sourceTemplateName,
+      created_at: item.createdAt,
+      updated_at: item.updatedAt,
+    })),
+  )
+  const trip = toTripRow(tripDocument)
+
+  return {
+    checklistId: checklists[0]?.id ?? null,
+    checklists,
+    trip,
+    items,
+    members: toTripMemberRows(tripDocument),
+    userChecks: Object.values(tripDocument.checklistItemUserChecks).map(toUserCheckRow),
+    itemAssignees: Object.values(tripDocument.checklistItemAssignees).map(toAssigneeRow),
+  }
+}
+
+function toMutationResult(
+  tripDocument: TripDocumentV1,
+  itemId: string,
+): ChecklistItemMutationResult {
+  const snapshot = toChecklistRepositorySnapshot(tripDocument, null)
+  const item = snapshot.items.find((row) => row.id === itemId)
+  if (!item) throw new Error('Local-first checklist item mutation result was not found.')
+
+  return {
+    item,
+    assignees: snapshot.itemAssignees.filter((assignee) => assignee.item_id === itemId),
+  }
+}
+
+function toTripRow(tripDocument: TripDocumentV1): Trip {
+  return {
+    id: tripDocument.trip.id,
+    user_id: tripDocument.trip.ownerId,
+    destination: tripDocument.trip.destination,
+    start_date: tripDocument.trip.startDate,
+    end_date: tripDocument.trip.endDate,
+    adults_count: tripDocument.trip.adultsCount,
+    children_count: tripDocument.trip.childrenCount,
+    created_at: tripDocument.trip.createdAt,
+    updated_at: tripDocument.trip.updatedAt,
+  }
+}
+
+function toTripMemberRows(tripDocument: TripDocumentV1): TripMember[] {
+  return Object.values(tripDocument.members)
+    .filter((member) => member.status === 'accepted')
+    .map((member) => ({
+      id: member.id,
+      trip_id: tripDocument.trip.id,
+      user_id: member.userId,
+      invited_email: member.invitedEmail ?? '',
+      role: member.role,
+      status: member.status === 'revoked' ? 'pending' : member.status,
+      created_at: member.createdAt,
+      profiles: {
+        nickname: member.nickname,
+        email: member.email,
+      },
+    }))
+}
+
+function toAssigneeRow(assignee: {
+  id: string
+  itemId: string
+  userId: string
+  createdAt: string
+}): ChecklistItemAssignee {
+  return {
+    id: assignee.id,
+    item_id: assignee.itemId,
+    user_id: assignee.userId,
+    created_at: assignee.createdAt,
+  }
+}
+
+function toUserCheckRow(check: {
+  id: string
+  itemId: string
+  userId: string
+  createdAt: string
+}): ChecklistItemUserCheck {
+  return {
+    id: check.id,
+    item_id: check.itemId,
+    user_id: check.userId,
+    created_at: check.createdAt,
+  }
+}
+
+function toChecklistItemUserCheckRows(
+  tripDocument: TripDocumentV1,
+  itemId: string,
+): ChecklistItemUserCheck[] {
+  return Object.values(tripDocument.checklistItemUserChecks)
+    .filter((check) => check.itemId === itemId)
+    .map(toUserCheckRow)
+}
+
+function replaceAssignees(
+  tripDocument: TripDocumentV1,
+  itemId: string,
+  assigneeIds: string[],
+  createdAt: string,
+): void {
+  for (const assignee of Object.values(tripDocument.checklistItemAssignees)) {
+    if (assignee.itemId === itemId) {
+      delete tripDocument.checklistItemAssignees[assignee.id]
+    }
+  }
+
+  for (const userId of assigneeIds) {
+    const assigneeId = createAssigneeId(itemId, userId)
+    tripDocument.checklistItemAssignees[assigneeId] = {
+      id: assigneeId,
+      itemId,
+      userId,
+      createdAt,
+    }
+  }
+}
+
+function normalizeAssigneeIds(input: ChecklistItemInput): string[] {
+  return Array.from(new Set((input.assignee_ids ?? [input.assigned_user_id]).filter(isPresent)))
+}
+
+function getAssigneeIds(tripDocument: TripDocumentV1, itemId: string): string[] {
+  const assigneeIds = Object.values(tripDocument.checklistItemAssignees)
+    .filter((assignee) => assignee.itemId === itemId)
+    .map((assignee) => assignee.userId)
+  const legacyAssignedUserId = tripDocument.checklistItems[itemId]?.assignedUserId
+  return assigneeIds.length > 0
+    ? assigneeIds
+    : legacyAssignedUserId
+      ? [legacyAssignedUserId]
+      : []
+}
+
+async function getCurrentUserId(supabase: SupabaseClient): Promise<string | null> {
+  try {
+    const { data } = await supabase.auth.getUser()
+    return data.user?.id ?? null
+  } catch {
+    return null
+  }
+}
+
+function createLocalChecklistId(tripId: string): string {
+  return `local-checklist:${tripId}`
+}
+
+function createLocalEntityId(entity: 'item', tripId: string): string {
+  const id = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  return `local-${entity}:${tripId}:${id}`
+}
+
+function createAssigneeId(itemId: string, userId: string): string {
+  return `assignee:${itemId}:${userId}`
+}
+
+function createUserCheckId(itemId: string, userId: string): string {
+  return `check:${itemId}:${userId}`
+}
+
+function parseTripIdFromChecklistId(checklistId: string): string | null {
+  return checklistId.startsWith('local-checklist:')
+    ? checklistId.slice('local-checklist:'.length)
+    : null
+}
+
+function parseTripIdFromItemId(itemId: string): string | null {
+  if (!itemId.startsWith('local-item:')) return null
+  const [, tripId] = itemId.split(':')
+  return tripId || null
+}
+
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined
+}

--- a/apps/web/lib/local-first/repositoryFactory.ts
+++ b/apps/web/lib/local-first/repositoryFactory.ts
@@ -3,17 +3,60 @@ import {
   createSupabaseLegacyRepositories,
   type LegacyRepositories,
 } from '@nexvoy/core/supabase/legacyRepository'
+import type { ChecklistRepository, TripRepository } from '@nexvoy/core/repositories/types'
+import { createWebLocalFirstChecklistRepository } from './localFirstChecklistRepository'
 
-export type WebRepositoryMode = 'legacy-supabase'
+export type WebRepositoryMode = 'legacy-supabase' | 'local-first-checklist-spike'
+
+export interface WebRepositories {
+  mode: WebRepositoryMode
+  trips: TripRepository
+  checklists: ChecklistRepository
+}
 
 export function createWebRepositories(
   supabase: SupabaseClient,
-  mode: WebRepositoryMode = 'legacy-supabase',
-): LegacyRepositories {
+  mode: WebRepositoryMode = resolveWebRepositoryMode(),
+): WebRepositories {
+  const legacyRepositories: LegacyRepositories = createSupabaseLegacyRepositories(supabase)
+
   switch (mode) {
+    case 'local-first-checklist-spike':
+      return {
+        ...legacyRepositories,
+        mode,
+        checklists: createWebLocalFirstChecklistRepository(supabase),
+      }
     case 'legacy-supabase':
-      return createSupabaseLegacyRepositories(supabase)
+      return {
+        ...legacyRepositories,
+        mode,
+      }
     default:
-      return createSupabaseLegacyRepositories(supabase)
+      return {
+        ...legacyRepositories,
+        mode: 'legacy-supabase',
+      }
   }
+}
+
+export function resolveWebRepositoryMode(): WebRepositoryMode {
+  if (process.env.NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_SPIKE === '1') {
+    return 'local-first-checklist-spike'
+  }
+  if (typeof window === 'undefined') return 'legacy-supabase'
+
+  const params = new URLSearchParams(window.location.search)
+  if (params.get('localFirstChecklist') === '1') {
+    window.localStorage.setItem('onvoy.localFirstChecklistSpike', '1')
+    return 'local-first-checklist-spike'
+  }
+  if (params.get('localFirstChecklist') === '0') {
+    window.localStorage.removeItem('onvoy.localFirstChecklistSpike')
+    return 'legacy-supabase'
+  }
+
+  return window.localStorage.getItem('onvoy.localFirstChecklistSpike') === '1'
+    ? 'local-first-checklist-spike'
+    : 'legacy-supabase'
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,18 +18,20 @@
     "./local-first/migrations": "./src/local-first/migrations.ts",
     "./local-first/tombstone": "./src/local-first/tombstone.ts",
     "./local-first/tripDocument": "./src/local-first/tripDocument.ts",
+    "./local-first/yjsTripDocument": "./src/local-first/yjsTripDocument.ts",
     "./repositories/types": "./src/repositories/types.ts",
     "./supabase/legacyRepository": "./src/supabase/legacyRepository.ts",
     "./utils/date": "./src/utils/date.ts"
   },
   "scripts": {
     "build": "tsc --noEmit",
-    "test": "tsx src/local-first/__tests__/migrations.test.ts && tsx src/local-first/__tests__/materialize.test.ts && tsx src/repositories/__tests__/types.test.ts",
+    "test": "tsx src/local-first/__tests__/migrations.test.ts && tsx src/local-first/__tests__/materialize.test.ts && tsx src/local-first/__tests__/yjsTripDocument.test.ts && tsx src/repositories/__tests__/types.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@nexvoy/types": "workspace:*",
-    "date-fns": "^4.0.0"
+    "date-fns": "^4.0.0",
+    "yjs": "^13.6.31"
   },
   "devDependencies": {
     "@supabase/supabase-js": "^2.0.0",

--- a/packages/core/src/local-first/__tests__/yjsTripDocument.test.ts
+++ b/packages/core/src/local-first/__tests__/yjsTripDocument.test.ts
@@ -1,0 +1,27 @@
+import { SAMPLE_TRIP_DOCUMENT_V1 } from '../tripDocument'
+import {
+  applyTripDocumentUpdate,
+  createYjsTripDocument,
+  encodeTripDocumentUpdate,
+  mutateTripDocumentInYjs,
+  readTripDocumentFromYjs,
+} from '../yjsTripDocument'
+
+const doc = createYjsTripDocument(SAMPLE_TRIP_DOCUMENT_V1)
+
+mutateTripDocumentInYjs(doc, (tripDocument) => {
+  tripDocument.checklists['checklist-1'] = {
+    id: 'checklist-1',
+    title: 'Packing',
+    createdAt: '2026-06-29T00:00:00.000Z',
+  }
+})
+
+const update = encodeTripDocumentUpdate(doc)
+const restoredDoc = createYjsTripDocument()
+applyTripDocumentUpdate(restoredDoc, update)
+
+const restored = readTripDocumentFromYjs(restoredDoc)
+if (restored?.checklists['checklist-1']?.title !== 'Packing') {
+  throw new Error('Yjs Trip document update should restore checklist data.')
+}

--- a/packages/core/src/local-first/yjsTripDocument.ts
+++ b/packages/core/src/local-first/yjsTripDocument.ts
@@ -1,0 +1,49 @@
+import * as Y from 'yjs'
+import type { TripDocumentV1 } from './documentModel'
+
+const TRIP_DOCUMENT_MAP_NAME = 'tripDocumentV1'
+const TRIP_DOCUMENT_VALUE_KEY = 'document'
+
+export function createYjsTripDocument(initialDocument?: TripDocumentV1): Y.Doc {
+  const doc = new Y.Doc()
+  if (initialDocument) writeTripDocumentToYjs(doc, initialDocument)
+  return doc
+}
+
+export function readTripDocumentFromYjs(doc: Y.Doc): TripDocumentV1 | null {
+  const value = getTripDocumentMap(doc).get(TRIP_DOCUMENT_VALUE_KEY)
+  if (!value) return null
+  return cloneTripDocument(value as TripDocumentV1)
+}
+
+export function writeTripDocumentToYjs(doc: Y.Doc, tripDocument: TripDocumentV1): void {
+  getTripDocumentMap(doc).set(TRIP_DOCUMENT_VALUE_KEY, cloneTripDocument(tripDocument))
+}
+
+export function mutateTripDocumentInYjs(
+  doc: Y.Doc,
+  mutate: (tripDocument: TripDocumentV1) => void,
+): TripDocumentV1 {
+  const tripDocument = readTripDocumentFromYjs(doc)
+  if (!tripDocument) throw new Error('Trip document is not initialized.')
+
+  mutate(tripDocument)
+  writeTripDocumentToYjs(doc, tripDocument)
+  return tripDocument
+}
+
+export function encodeTripDocumentUpdate(doc: Y.Doc): Uint8Array {
+  return Y.encodeStateAsUpdate(doc)
+}
+
+export function applyTripDocumentUpdate(doc: Y.Doc, update: Uint8Array): void {
+  Y.applyUpdate(doc, update)
+}
+
+function getTripDocumentMap(doc: Y.Doc): Y.Map<unknown> {
+  return doc.getMap(TRIP_DOCUMENT_MAP_NAME)
+}
+
+function cloneTripDocument(tripDocument: TripDocumentV1): TripDocumentV1 {
+  return JSON.parse(JSON.stringify(tripDocument)) as TripDocumentV1
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       date-fns:
         specifier: ^4.0.0
         version: 4.1.0
+      yjs:
+        specifier: ^13.6.31
+        version: 13.6.31
     devDependencies:
       '@supabase/supabase-js':
         specifier: ^2.0.0
@@ -4370,6 +4373,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -4506,6 +4512,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -6236,6 +6247,10 @@ packages:
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -11033,6 +11048,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic.js@0.2.5: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.2.1:
@@ -11200,6 +11217,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -13123,6 +13144,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,26 +1,24 @@
-# Walkthrough: TASK-004 Repository Abstraction
+# Walkthrough: TASK-005 Web IndexedDB + Yjs Checklist Spike
 
 ## Summary
 
-UI가 Supabase row query를 직접 호출하지 않도록 `@nexvoy/core`에 Repository interface와 legacy Supabase 구현체를 추가했다. 이번 변경은 Web checklist 화면을 repository factory 경유로 연결하되, 실제 data source는 기존 Supabase row helper를 유지해 동작 동일성을 우선한다.
+Web checklist 화면에서 feature flag로 켤 수 있는 local-first spike를 추가했다. 기본값은 기존 Supabase row repository이며, spike mode에서는 Yjs Trip document를 IndexedDB에 저장하고 checklist create/update/delete/toggle을 Supabase write 없이 로컬 document에 반영한다.
 
 ## Artifacts
 
-- GitHub Issue: `#260`
-- `docs/refactor/tasks/TASK-004-repository-abstraction.md`
+- GitHub Issue: `#262`
+- `docs/refactor/tasks/TASK-005-web-indexeddb-yjs-checklist-spike.md`
 - `docs/refactor/TECHNICAL-SPEC.md`
-- `docs/develop-context/architecture.md`
-- `docs/develop-context/conventions.md`
+- `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
 
 ## Key Changes
 
-- `packages/core/src/repositories/types.ts`에 `TripRepository`, `ChecklistRepository` 계약을 추가했다.
-- `packages/core/src/supabase/legacyRepository.ts`에 기존 Supabase query helper를 감싸는 legacy repository 구현체를 추가했다.
-- `apps/web/lib/local-first/repositoryFactory.ts`에서 Web repository factory 경계를 만들었다.
-- `apps/web/app/trips/checklist/ChecklistClient.tsx`의 온라인 checklist 조회/생성/수정/삭제/체크 토글을 repository 호출로 전환했다.
-- 기존 `@nexvoy/core/supabase/queries` helper는 제거하지 않고 fallback/legacy adapter 내부에서 계속 사용한다.
-- `apps/mobile/app/trip/[id].tsx`는 이미 core query helper 주입 경계가 있어, Web checklist spike 이후 별도 repository factory 적용 대상으로 TODO를 남겼다.
-- repository mock smoke test를 추가해 interface 소비가 data source와 독립적으로 가능한지 확인한다.
+- `packages/core/src/local-first/yjsTripDocument.ts`에 Trip document용 Yjs encode/apply/read/write helper를 추가했다.
+- Yjs helper는 모바일 번들 유입을 막기 위해 루트 export가 아니라 `@nexvoy/core/local-first/yjsTripDocument` subpath로만 노출한다.
+- `apps/web/lib/local-first/indexedDbStore.ts`에 Web-only IndexedDB persistence와 BroadcastChannel update notification을 추가했다.
+- `apps/web/lib/local-first/localFirstChecklistRepository.ts`에 Yjs/IndexedDB 기반 checklist repository spike를 추가했다.
+- `apps/web/lib/local-first/repositoryFactory.ts`가 `NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_SPIKE=1`, `?localFirstChecklist=1`, 또는 `localStorage` flag에서 local-first repository를 선택한다.
+- `ChecklistClient`는 local-first mode에서 네트워크가 없어도 add/update/delete/toggle UI를 사용할 수 있고, 템플릿 적용은 Supabase write 방지를 위해 숨긴다.
 
 ## Verification
 
@@ -35,5 +33,5 @@ UI가 Supabase row query를 직접 호출하지 않도록 `@nexvoy/core`에 Repo
 
 ## Notes
 
-- 이번 단계에서는 Supabase row가 계속 primary data source다.
-- `LocalFirstRepository`와 dual-write 전환은 후속 task에서 factory 뒤에 추가한다.
+- feature flag 기본값은 off라 기존 production checklist 화면은 Supabase repository를 계속 사용한다.
+- 수동 브라우저 검증 경로: `/trips/checklist?id=<tripId>&localFirstChecklist=1`에서 항목 추가/수정/삭제/체크 후 새로고침 복원을 확인한다. `?localFirstChecklist=0`으로 localStorage flag를 끌 수 있다.


### PR DESCRIPTION
## Summary
- Add a Web-only local-first checklist spike backed by Yjs Trip documents persisted to IndexedDB.
- Add a feature-flagged repository factory path while keeping the legacy Supabase repository as the default.
- Keep Yjs helper off the `@nexvoy/core` root export so mobile bundles do not pull in Web/Yjs dependencies.

## Test plan
- `pnpm --filter @nexvoy/core test`
- `pnpm --filter @nexvoy/core typecheck`
- `pnpm build`
- `pnpm --filter nexvoy-app lint` (existing warnings only)
- `pnpm --filter nexvoy-app typecheck`
- `pnpm build:mobile`
- reviewer 재검토 PASS
- QA 재검토 PASS

## Manual spike path
- Enable with `NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_SPIKE=1` or open `/trips/checklist?id=<tripId>&localFirstChecklist=1`.
- Disable the localStorage flag with `?localFirstChecklist=0`.

Resolves #262

Made with [Cursor](https://cursor.com)