### PR TITLE
feat: add local-first backup schema

### DIFF
--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -17,6 +17,7 @@ TASK-001-trip-document-model.md
 TASK-002-row-to-document-converter.md
 TASK-003-document-materialized-read-model.md
 TASK-004-repository-abstraction.md
+TASK-005-web-indexeddb-yjs-checklist-spike.md
 ```
 
 ## 권장 템플릿
@@ -52,22 +53,35 @@ TASK-004-repository-abstraction.md
 - WebRTC/P2P는 optional fast path이며, 기본 sync/restore는 Supabase backup pull/push다.
 - Cloudflare STUN/TURN은 managed provider 기준선으로 사용한다.
 
+## 진행 현황
+
+| Task | 상태 | 결과 |
+|------|------|------|
+| `TASK-001-trip-document-model.md` | 완료 | PR [#255](https://github.com/ysjee141/nexvoy-frontend/pull/255) |
+| `TASK-002-row-to-document-converter.md` | 완료 | PR [#257](https://github.com/ysjee141/nexvoy-frontend/pull/257) |
+| `TASK-003-document-materialized-read-model.md` | 완료 | PR [#259](https://github.com/ysjee141/nexvoy-frontend/pull/259) |
+| `TASK-004-repository-abstraction.md` | 완료 | PR [#261](https://github.com/ysjee141/nexvoy-frontend/pull/261) |
+| `TASK-005-web-indexeddb-yjs-checklist-spike.md` | 완료 | PR [#263](https://github.com/ysjee141/nexvoy-frontend/pull/263) |
+| `TASK-006-backup-schema-and-rls.md` | 완료 | 로컬 구현 및 검증 완료 |
+
+현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `TASK-006: Supabase Backup Schema 및 RLS`는 완료되었다. 다음 작업은 `TASK-007: Document Key Model 및 암호화 PoC`다.
+
 ## Phase별 작업 목록
 
 ### Phase 0: 모델과 변환 기반
 
-- [ ] `TASK-001-trip-document-model.md`: Trip 단위 `TripDocumentV1` 타입과 entity boundary 정의
-- [ ] `TASK-002-row-to-document-converter.md`: 기존 Supabase row bundle을 document로 변환
-- [ ] `TASK-003-document-materialized-read-model.md`: document에서 화면용 read model 생성
+- [x] `TASK-001-trip-document-model.md`: Trip 단위 `TripDocumentV1` 타입과 entity boundary 정의
+- [x] `TASK-002-row-to-document-converter.md`: 기존 Supabase row bundle을 document로 변환
+- [x] `TASK-003-document-materialized-read-model.md`: document에서 화면용 read model 생성
 
 ### Phase 1: Repository 경계와 Web 스파이크
 
-- [ ] `TASK-004-repository-abstraction.md`: Supabase query 앞 Repository interface 도입
-- [ ] `TASK-005-web-indexeddb-yjs-checklist-spike.md`: Web IndexedDB + Yjs checklist local-first 스파이크
+- [x] `TASK-004-repository-abstraction.md`: Supabase query 앞 Repository interface 도입
+- [x] `TASK-005-web-indexeddb-yjs-checklist-spike.md`: Web IndexedDB + Yjs checklist local-first 스파이크
 
 ### Phase 2: Backup, 암호화, Restore
 
-- [ ] `TASK-006-backup-schema-and-rls.md`: Supabase backup schema 및 RLS 추가
+- [x] `TASK-006-backup-schema-and-rls.md`: Supabase backup schema 및 RLS 추가
 - [ ] `TASK-007-document-key-model.md`: Server-wrapped key 기반 document 암호화 PoC
 - [ ] `TASK-008-backup-queue-and-restore.md`: backup queue와 snapshot/update restore flow 구현
 
@@ -88,10 +102,9 @@ TASK-004-repository-abstraction.md
 
 ## 권장 시작 순서
 
-1. `TASK-001-trip-document-model.md`
-2. `TASK-002-row-to-document-converter.md`
-3. `TASK-003-document-materialized-read-model.md`
-4. `TASK-004-repository-abstraction.md`
-5. `TASK-005-web-indexeddb-yjs-checklist-spike.md`
+1. `TASK-007-document-key-model.md`
+2. `TASK-008-backup-queue-and-restore.md`
+3. `TASK-009-mobile-webrtc-native-feasibility.md`
+4. `TASK-010-cloudflare-ice-config.md`
 
-이 순서까지 완료되면 Web checklist 도메인에서 local-first read/write 스파이크를 검증할 수 있다. 이후 backup schema와 restore flow를 붙이고, 모바일 WebRTC와 Cloudflare STUN/TURN은 기본 sync가 안정화된 뒤 optional fast path로 검증한다.
+TASK-001~006까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크와 Supabase backup schema/RLS 기반을 검증할 수 있는 상태가 되었다. 다음은 document key model과 backup queue/restore flow를 붙여 기본 sync/restore 경로를 안정화한다. 모바일 WebRTC와 Cloudflare STUN/TURN은 backup/restore 기반이 잡힌 뒤 optional fast path로 검증한다.

--- a/supabase/migrations/20260630000001_local_first_backup_schema.sql
+++ b/supabase/migrations/20260630000001_local_first_backup_schema.sql
@@ -1,0 +1,268 @@
+-- Local-first encrypted backup schema foundation.
+-- TASK-006: stores document snapshots/update blobs while legacy row tables remain authoritative fallback.
+
+CREATE TABLE IF NOT EXISTS public.documents (
+  id uuid PRIMARY KEY,
+  owner_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  type text NOT NULL CHECK (type IN ('trip', 'template')),
+  schema_version integer NOT NULL CHECK (schema_version > 0),
+  snapshot bytea,
+  snapshot_hash text,
+  encrypted boolean DEFAULT true NOT NULL,
+  created_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.document_members (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  document_id uuid REFERENCES public.documents(id) ON DELETE CASCADE NOT NULL,
+  user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  invited_email text,
+  role text NOT NULL CHECK (role IN ('owner', 'editor', 'viewer')),
+  status text NOT NULL CHECK (status IN ('pending', 'accepted', 'revoked')),
+  created_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CHECK (user_id IS NOT NULL OR invited_email IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS document_members_document_id_user_id_key
+  ON public.document_members(document_id, user_id)
+  WHERE user_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS document_members_document_id_invited_email_key
+  ON public.document_members(document_id, invited_email)
+  WHERE invited_email IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.document_updates (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  document_id uuid REFERENCES public.documents(id) ON DELETE CASCADE NOT NULL,
+  client_id text NOT NULL,
+  seq bigint NOT NULL CHECK (seq >= 0),
+  update_blob bytea NOT NULL,
+  update_hash text NOT NULL,
+  created_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  UNIQUE(document_id, client_id, seq)
+);
+
+CREATE TABLE IF NOT EXISTS public.document_devices (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  document_id uuid REFERENCES public.documents(id) ON DELETE CASCADE NOT NULL,
+  user_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  device_id text NOT NULL,
+  last_synced_seq bigint CHECK (last_synced_seq IS NULL OR last_synced_seq >= 0),
+  last_seen_at timestamp with time zone,
+  created_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  UNIQUE(document_id, user_id, device_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.legacy_row_map (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  document_id uuid REFERENCES public.documents(id) ON DELETE CASCADE NOT NULL,
+  table_name text NOT NULL,
+  row_id uuid NOT NULL,
+  path_in_document text NOT NULL,
+  created_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  UNIQUE(table_name, row_id)
+);
+
+CREATE INDEX IF NOT EXISTS documents_owner_id_idx
+  ON public.documents(owner_id);
+
+CREATE INDEX IF NOT EXISTS document_members_document_id_idx
+  ON public.document_members(document_id);
+
+CREATE INDEX IF NOT EXISTS document_members_user_id_idx
+  ON public.document_members(user_id);
+
+CREATE INDEX IF NOT EXISTS document_updates_document_id_created_at_idx
+  ON public.document_updates(document_id, created_at);
+
+CREATE INDEX IF NOT EXISTS document_devices_user_id_idx
+  ON public.document_devices(user_id);
+
+CREATE INDEX IF NOT EXISTS legacy_row_map_document_id_idx
+  ON public.legacy_row_map(document_id);
+
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.document_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.document_updates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.document_devices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.legacy_row_map ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.check_is_document_owner(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.documents
+    WHERE id = _document_id
+      AND owner_id = _user_id
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+      AND role = 'owner'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_is_document_member(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT public.check_is_document_owner(_document_id, _user_id)
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_is_document_editor(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT public.check_is_document_owner(_document_id, _user_id)
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+      AND role IN ('owner', 'editor')
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.check_is_document_owner(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_is_document_member(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_is_document_editor(uuid, uuid) TO anon, authenticated;
+
+-- documents ------------------------------------------------------------------
+CREATE POLICY "Select documents if accepted member"
+  ON public.documents
+  FOR SELECT
+  USING (public.check_is_document_member(id, auth.uid()));
+
+CREATE POLICY "Insert documents as owner"
+  ON public.documents
+  FOR INSERT
+  WITH CHECK (owner_id = auth.uid());
+
+CREATE POLICY "Update documents as owner"
+  ON public.documents
+  FOR UPDATE
+  USING (public.check_is_document_owner(id, auth.uid()))
+  WITH CHECK (owner_id = auth.uid());
+
+CREATE POLICY "Delete documents as owner"
+  ON public.documents
+  FOR DELETE
+  USING (public.check_is_document_owner(id, auth.uid()));
+
+-- document_members -----------------------------------------------------------
+CREATE POLICY "Select document members if related"
+  ON public.document_members
+  FOR SELECT
+  USING (
+    user_id = auth.uid()
+    OR invited_email = (auth.jwt() ->> 'email')
+    OR public.check_is_document_member(document_id, auth.uid())
+  );
+
+CREATE POLICY "Insert document members as owner"
+  ON public.document_members
+  FOR INSERT
+  WITH CHECK (public.check_is_document_owner(document_id, auth.uid()));
+
+CREATE POLICY "Update document members as owner"
+  ON public.document_members
+  FOR UPDATE
+  USING (public.check_is_document_owner(document_id, auth.uid()))
+  WITH CHECK (public.check_is_document_owner(document_id, auth.uid()));
+
+CREATE POLICY "Delete document members as owner"
+  ON public.document_members
+  FOR DELETE
+  USING (public.check_is_document_owner(document_id, auth.uid()));
+
+-- document_updates -----------------------------------------------------------
+CREATE POLICY "Select document updates if accepted member"
+  ON public.document_updates
+  FOR SELECT
+  USING (public.check_is_document_member(document_id, auth.uid()));
+
+CREATE POLICY "Insert document updates as editor"
+  ON public.document_updates
+  FOR INSERT
+  WITH CHECK (public.check_is_document_editor(document_id, auth.uid()));
+
+-- document_devices -----------------------------------------------------------
+CREATE POLICY "Select own document devices"
+  ON public.document_devices
+  FOR SELECT
+  USING (
+    user_id = auth.uid()
+    AND public.check_is_document_member(document_id, auth.uid())
+  );
+
+CREATE POLICY "Insert own document devices"
+  ON public.document_devices
+  FOR INSERT
+  WITH CHECK (
+    user_id = auth.uid()
+    AND public.check_is_document_member(document_id, auth.uid())
+  );
+
+CREATE POLICY "Update own document devices"
+  ON public.document_devices
+  FOR UPDATE
+  USING (
+    user_id = auth.uid()
+    AND public.check_is_document_member(document_id, auth.uid())
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    AND public.check_is_document_member(document_id, auth.uid())
+  );
+
+CREATE POLICY "Delete own document devices"
+  ON public.document_devices
+  FOR DELETE
+  USING (
+    user_id = auth.uid()
+    AND public.check_is_document_member(document_id, auth.uid())
+  );
+
+-- legacy_row_map -------------------------------------------------------------
+CREATE POLICY "Select legacy row map if accepted member"
+  ON public.legacy_row_map
+  FOR SELECT
+  USING (public.check_is_document_member(document_id, auth.uid()));
+
+CREATE POLICY "Insert legacy row map as editor"
+  ON public.legacy_row_map
+  FOR INSERT
+  WITH CHECK (public.check_is_document_editor(document_id, auth.uid()));
+
+CREATE POLICY "Update legacy row map as editor"
+  ON public.legacy_row_map
+  FOR UPDATE
+  USING (public.check_is_document_editor(document_id, auth.uid()))
+  WITH CHECK (public.check_is_document_editor(document_id, auth.uid()));
+
+CREATE POLICY "Delete legacy row map as owner"
+  ON public.legacy_row_map
+  FOR DELETE
+  USING (public.check_is_document_owner(document_id, auth.uid()));

--- a/supabase/tests/task006_backup_rls.sql
+++ b/supabase/tests/task006_backup_rls.sql
@@ -1,0 +1,191 @@
+-- TASK-006 targeted RLS checks for local Supabase.
+-- Run with: docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d postgres < supabase/tests/task006_backup_rls.sql
+
+RESET ROLE;
+
+DELETE FROM public.documents
+WHERE id = '10000000-0000-0000-0000-000000000001';
+
+DELETE FROM auth.users
+WHERE id IN (
+  '00000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000003',
+  '00000000-0000-0000-0000-000000000004'
+);
+
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'owner.onvoy.local@example.com',
+    crypt('password', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  ),
+  (
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'editor.onvoy.local@example.com',
+    crypt('password', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  ),
+  (
+    '00000000-0000-0000-0000-000000000003',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'viewer.onvoy.local@example.com',
+    crypt('password', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  ),
+  (
+    '00000000-0000-0000-0000-000000000004',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'outsider.onvoy.local@example.com',
+    crypt('password', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  );
+
+SET ROLE authenticated;
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000001';
+
+INSERT INTO public.documents (id, owner_id, type, schema_version, snapshot, snapshot_hash)
+VALUES (
+  '10000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  'trip',
+  1,
+  decode('aabbcc', 'hex'),
+  'owner-snapshot'
+);
+
+INSERT INTO public.document_members (document_id, user_id, role, status)
+VALUES
+  (
+    '10000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000001',
+    'owner',
+    'accepted'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000002',
+    'editor',
+    'accepted'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000003',
+    'viewer',
+    'accepted'
+  );
+
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000002';
+
+INSERT INTO public.document_updates (document_id, client_id, seq, update_blob, update_hash)
+VALUES (
+  '10000000-0000-0000-0000-000000000001',
+  'editor-device',
+  1,
+  decode('ddee', 'hex'),
+  'editor-update'
+);
+
+DO $$
+DECLARE
+  visible_updates integer;
+BEGIN
+  SELECT count(*) INTO visible_updates
+  FROM public.document_updates
+  WHERE document_id = '10000000-0000-0000-0000-000000000001';
+
+  IF visible_updates <> 1 THEN
+    RAISE EXCEPTION 'Expected editor to read one update, got %', visible_updates;
+  END IF;
+END $$;
+
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000003';
+
+DO $$
+BEGIN
+  INSERT INTO public.document_updates (document_id, client_id, seq, update_blob, update_hash)
+  VALUES (
+    '10000000-0000-0000-0000-000000000001',
+    'viewer-device',
+    1,
+    decode('ffee', 'hex'),
+    'viewer-update'
+  );
+
+  RAISE EXCEPTION 'Expected viewer update insert to be blocked';
+EXCEPTION
+  WHEN insufficient_privilege THEN
+    RAISE NOTICE 'Viewer update insert blocked as expected';
+END $$;
+
+DO $$
+DECLARE
+  visible_updates integer;
+BEGIN
+  SELECT count(*) INTO visible_updates
+  FROM public.document_updates
+  WHERE document_id = '10000000-0000-0000-0000-000000000001';
+
+  IF visible_updates <> 1 THEN
+    RAISE EXCEPTION 'Expected viewer to read one update, got %', visible_updates;
+  END IF;
+END $$;
+
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000004';
+
+DO $$
+DECLARE
+  visible_documents integer;
+BEGIN
+  SELECT count(*) INTO visible_documents
+  FROM public.documents
+  WHERE id = '10000000-0000-0000-0000-000000000001';
+
+  IF visible_documents <> 0 THEN
+    RAISE EXCEPTION 'Expected outsider to read zero documents, got %', visible_documents;
+  END IF;
+END $$;
+
+RESET ROLE;
+
+SELECT 'task006_backup_rls_checks_passed' AS result;

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,37 +1,40 @@
-# Walkthrough: TASK-005 Web IndexedDB + Yjs Checklist Spike
+# Walkthrough: TASK-006 Supabase Backup Schema 및 RLS
 
 ## Summary
 
-Web checklist 화면에서 feature flag로 켤 수 있는 local-first spike를 추가했다. 기본값은 기존 Supabase row repository이며, spike mode에서는 Yjs Trip document를 IndexedDB에 저장하고 checklist create/update/delete/toggle을 Supabase write 없이 로컬 document에 반영한다.
+Local-first Phase 2의 첫 단계로 암호화된 CRDT snapshot/update backup을 저장할 Supabase schema와 최소 RLS 기반을 추가했다. 기존 Supabase row 테이블은 그대로 유지하며, document backup/restore 경로가 준비될 때까지 fallback 역할을 계속한다.
 
 ## Artifacts
 
-- GitHub Issue: `#262`
-- `docs/refactor/tasks/TASK-005-web-indexeddb-yjs-checklist-spike.md`
+- `docs/refactor/tasks/TASK-006-backup-schema-and-rls.md`
 - `docs/refactor/TECHNICAL-SPEC.md`
 - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+- `docs/refactor/adrs/ADR-003-backup-encryption-key-management.md`
 
 ## Key Changes
 
-- `packages/core/src/local-first/yjsTripDocument.ts`에 Trip document용 Yjs encode/apply/read/write helper를 추가했다.
-- Yjs helper는 모바일 번들 유입을 막기 위해 루트 export가 아니라 `@nexvoy/core/local-first/yjsTripDocument` subpath로만 노출한다.
-- `apps/web/lib/local-first/indexedDbStore.ts`에 Web-only IndexedDB persistence와 BroadcastChannel update notification을 추가했다.
-- `apps/web/lib/local-first/localFirstChecklistRepository.ts`에 Yjs/IndexedDB 기반 checklist repository spike를 추가했다.
-- `apps/web/lib/local-first/repositoryFactory.ts`가 `NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_SPIKE=1`, `?localFirstChecklist=1`, 또는 `localStorage` flag에서 local-first repository를 선택한다.
-- `ChecklistClient`는 local-first mode에서 네트워크가 없어도 add/update/delete/toggle UI를 사용할 수 있고, 템플릿 적용은 Supabase write 방지를 위해 숨긴다.
+- `supabase/migrations/20260630000001_local_first_backup_schema.sql`에 `documents`, `document_updates`, `document_devices`, `legacy_row_map`을 추가했다.
+- owner/editor/viewer RLS를 강제하기 위해 최소 authority table인 `document_members`도 함께 추가했다. 초대 링크/RPC와 세부 permission registry는 `TASK-013` 범위로 남겨두었다.
+- `documents.encrypted` 기본값은 `true`이며, `snapshot`과 `document_updates.update_blob`은 `TASK-007` 암호화 PoC 이후 암호문 저장 경로로 사용된다.
+- `check_is_document_owner`, `check_is_document_member`, `check_is_document_editor` security-definer helper를 추가해 RLS 재귀를 피했다.
+- `supabase/tests/task006_backup_rls.sql`에 local-only owner/editor/viewer/outsider RLS 검증 스크립트를 추가했다.
 
 ## Verification
 
-- `pnpm --filter @nexvoy/core test` 성공
-- `pnpm --filter @nexvoy/core typecheck` 성공
+- `supabase db reset --local` 성공
+- `docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d postgres < supabase/tests/task006_backup_rls.sql` 성공
+  - owner: document 생성 및 member 등록 가능
+  - editor: `document_updates` insert/read 가능
+  - viewer: `document_updates` read 가능, insert 차단
+  - outsider: document read 차단
 - `pnpm build` 성공
-- `pnpm --filter nexvoy-app lint` 성공 (기존 warning 6건)
-- `pnpm --filter nexvoy-app typecheck` 성공
 - `pnpm build:mobile` 성공
-- reviewer 재검토 PASS
-- QA 재검토 PASS
+
+## Rollback
+
+문제 발생 시 신규 backup schema만 제거하는 보상 migration을 작성한다. 제거 대상은 `legacy_row_map`, `document_devices`, `document_updates`, `document_members`, `documents` 및 `check_is_document_*` helper 함수이며, 기존 row 기반 서비스 테이블은 건드리지 않는다.
 
 ## Notes
 
-- feature flag 기본값은 off라 기존 production checklist 화면은 Supabase repository를 계속 사용한다.
-- 수동 브라우저 검증 경로: `/trips/checklist?id=<tripId>&localFirstChecklist=1`에서 항목 추가/수정/삭제/체크 후 새로고침 복원을 확인한다. `?localFirstChecklist=0`으로 localStorage flag를 끌 수 있다.
+- `document_keys` schema와 암호화 helper는 계획대로 `TASK-007-document-key-model.md`에서 처리한다.
+- `packages/types/src/database.generated.ts`는 이번 작업에서 최종 변경하지 않았다. 새 backup table 타입은 실제 repository/backup 구현에서 소비하기 시작할 때 local schema drift를 함께 정리해 재생성한다.


### PR DESCRIPTION
## Summary
- Add the TASK-006 Supabase backup schema for local-first document snapshots, updates, devices, legacy row mapping, and minimal document membership authority.
- Add RLS helper functions and policies for owner/editor/viewer backup access.
- Add a targeted local SQL RLS check and update task progress plus walkthrough notes.

## Test plan
- `supabase db reset --local`
- `docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d postgres < supabase/tests/task006_backup_rls.sql`
- `pnpm build`
- `pnpm build:mobile`


Made with [Cursor](https://cursor.com)