### PR TITLE
docs: add web checklist hydration task

### DIFF
--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -18,6 +18,7 @@ TASK-002-row-to-document-converter.md
 TASK-003-document-materialized-read-model.md
 TASK-004-repository-abstraction.md
 TASK-005-web-indexeddb-yjs-checklist-spike.md
+TASK-008a-web-checklist-read-through-hydration.md
 ```
 
 ## 권장 템플릿
@@ -65,8 +66,9 @@ TASK-005-web-indexeddb-yjs-checklist-spike.md
 | `TASK-006-backup-schema-and-rls.md` | 완료 | 로컬 구현 및 검증 완료 |
 | `TASK-007-document-key-model.md` | 완료 | 로컬 구현 및 검증 완료 |
 | `TASK-008-backup-queue-and-restore.md` | 완료 | 로컬 구현 및 검증 완료 |
+| `TASK-008a-web-checklist-read-through-hydration.md` | 예정 | `localFirstChecklist=1` 최초 진입 시 legacy row → IndexedDB/Yjs hydration |
 
-현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`의 핵심 기반은 완료되었다. 다음 작업은 `TASK-009: Mobile WebRTC Native Feasibility`다.
+현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`의 핵심 기반은 완료되었다. 다음 작업은 누락된 read-through 연결인 `TASK-008a: Web Checklist Read-through Hydration`이다.
 
 ## Phase별 작업 목록
 
@@ -87,6 +89,10 @@ TASK-005-web-indexeddb-yjs-checklist-spike.md
 - [x] `TASK-007-document-key-model.md`: Server-wrapped key 기반 document 암호화 PoC
 - [x] `TASK-008-backup-queue-and-restore.md`: backup queue와 snapshot/update restore flow 구현
 
+### Phase 2.5: Web Read-through 보완
+
+- [ ] `TASK-008a-web-checklist-read-through-hydration.md`: Web checklist local-first 최초 진입 시 기존 Supabase row를 document로 hydrate
+
 ### Phase 3: P2P Optional Fast Path
 
 - [ ] `TASK-009-mobile-webrtc-native-feasibility.md`: Expo dev client/EAS Build 기반 모바일 WebRTC 검증
@@ -104,7 +110,8 @@ TASK-005-web-indexeddb-yjs-checklist-spike.md
 
 ## 권장 시작 순서
 
-1. `TASK-009-mobile-webrtc-native-feasibility.md`
-2. `TASK-010-cloudflare-ice-config.md`
+1. `TASK-008a-web-checklist-read-through-hydration.md`
+2. `TASK-009-mobile-webrtc-native-feasibility.md`
+3. `TASK-010-cloudflare-ice-config.md`
 
-TASK-001~008까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크, Supabase backup schema/RLS, document key model, backup queue 및 snapshot/update restore flow를 검증할 수 있는 상태가 되었다. 다음은 모바일 WebRTC와 Cloudflare STUN/TURN을 optional fast path로 검증한다.
+TASK-001~008까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크, Supabase backup schema/RLS, document key model, backup queue 및 snapshot/update restore flow를 검증할 수 있는 상태가 되었다. 다만 `localFirstChecklist=1` 최초 진입 시 기존 Supabase row를 IndexedDB/Yjs 문서로 hydrate하는 runtime 연결이 누락되어 있으므로, WebRTC optional fast path 전에 이 보완 작업을 먼저 수행한다.

--- a/docs/refactor/tasks/TASK-008a-web-checklist-read-through-hydration.md
+++ b/docs/refactor/tasks/TASK-008a-web-checklist-read-through-hydration.md
@@ -1,0 +1,69 @@
+# TASK-008a: Web Checklist Read-through Hydration
+
+## 목적
+
+`localFirstChecklist=1` 최초 진입 시 IndexedDB에 local-first 문서가 없으면 기존 Supabase row 데이터를 읽어 `TripDocumentV1`로 변환하고, Yjs update로 IndexedDB에 저장해 기존 체크리스트가 local-first mode에서도 보이게 한다.
+
+## 범위
+
+- Web checklist local-first spike의 최초 hydration
+- Supabase legacy row bundle 조회
+- `convertLegacyTripRowsToDocument()` 연결
+- 변환된 `TripDocumentV1`을 Yjs document/update로 저장
+- 이후 local-first mutation은 IndexedDB/Yjs 문서를 우선 사용
+- hydration 실패 시 legacy Supabase repository fallback 또는 명확한 에러 처리
+
+## 선행 조건
+
+- `TASK-002-row-to-document-converter.md`
+- `TASK-003-document-materialized-read-model.md`
+- `TASK-005-web-indexeddb-yjs-checklist-spike.md`
+- `TASK-008-backup-queue-and-restore.md`
+
+## 변경 대상
+
+- `apps/web/lib/local-first/localFirstChecklistRepository.ts`
+- `apps/web/lib/local-first/indexedDbStore.ts` 필요 시
+- `packages/core/src/supabase/legacyRepository.ts` 또는 legacy row bundle query helper
+- `packages/core/src/local-first/migrations.ts` 필요 시 보강
+- Web local-first hydration 테스트 또는 수동 검증 문서
+
+## 구현 단계
+
+1. IndexedDB에 해당 `tripId` Yjs update가 있는지 확인한다.
+2. 없으면 Supabase legacy row bundle을 조회한다.
+3. legacy row bundle을 `convertLegacyTripRowsToDocument()`로 변환한다.
+4. 변환 validation warning을 로그에 남기되 document payload 전체는 기록하지 않는다.
+5. 변환된 document를 Yjs update로 encode해 IndexedDB에 저장한다.
+6. materialized read model로 기존 checklist item, check state, assignee가 화면에 보이는지 확인한다.
+7. hydration 실패 시 기존 Supabase repository로 되돌릴 수 있는 fallback 기준을 명시한다.
+
+## 데이터 호환성 고려사항
+
+- 기존 `trips.id`, `checklists.id`, `checklist_items.id`를 document 내부 id로 유지한다.
+- 기존 Supabase row table은 계속 fallback이며 이 단계에서는 document-primary로 전환하지 않는다.
+- `localFirstChecklist=1`에서만 동작하고 feature flag off 상태의 production flow는 변경하지 않는다.
+- 이미 IndexedDB 문서가 있으면 legacy row를 다시 덮어쓰지 않는다.
+- 기존에 빈 spike 문서가 저장된 사용자는 IndexedDB 삭제 또는 migration/rehydration 정책이 필요하다.
+
+## 검증 방법
+
+- 기존 Supabase checklist item이 있는 trip에서 `/trips/checklist?id=<tripId>&localFirstChecklist=1` 진입
+- IndexedDB `onvoy-local-first-spike.tripDocuments`에 해당 trip document update 생성 확인
+- 기존 checklist item, check state, assignee가 화면에 표시되는지 확인
+- 새 항목 추가/체크 후 새로고침 시 IndexedDB 문서에서 복원되는지 확인
+- `?localFirstChecklist=0` 또는 flag off 시 기존 Supabase repository 화면이 유지되는지 확인
+- `pnpm build`
+- `pnpm build:mobile`
+
+## 롤백 방법
+
+- `localFirstChecklist` flag를 off로 유지한다.
+- hydration 경로를 제거해도 기존 Supabase repository는 그대로 동작해야 한다.
+- 잘못 생성된 local spike document는 IndexedDB `onvoy-local-first-spike` DB 삭제로 초기화한다.
+
+## 완료 조건
+
+- local-first mode 최초 진입 시 기존 Supabase checklist 데이터가 빈 화면이 아니라 local-first read model로 표시된다.
+- hydration 이후 local write와 새로고침 복원이 동작한다.
+- hydration 실패/rollback 기준이 명확하다.


### PR DESCRIPTION
## Summary
- Add `TASK-008a-web-checklist-read-through-hydration.md` for the missing `localFirstChecklist=1` initial hydration path.
- Update the task index so Web checklist read-through hydration runs before WebRTC optional fast path work.
- Document that IndexedDB should be seeded from legacy Supabase rows via `convertLegacyTripRowsToDocument()` when no local document exists.

## Test plan
- Docs-only change: `git diff --check`


Made with [Cursor](https://cursor.com)