### PR TITLE
feat: hydrate local checklist from legacy rows

### DIFF
--- a/apps/web/lib/local-first/indexedDbStore.ts
+++ b/apps/web/lib/local-first/indexedDbStore.ts
@@ -23,6 +23,20 @@ export async function loadTripDocumentUpdate(documentId: string): Promise<Uint8A
   return row ? new Uint8Array(row.update) : null
 }
 
+export async function loadAllTripDocumentUpdates(): Promise<StoredTripDocumentUpdate[]> {
+  if (!canUseIndexedDb()) return []
+  const db = await openDatabase()
+  const rows = await runTransaction<StoredTripDocumentUpdate[]>(
+    db,
+    TRIP_DOCUMENT_STORE,
+    'readonly',
+    (store) => store.getAll(),
+  )
+  db.close()
+
+  return rows
+}
+
 export async function saveTripDocumentUpdate(
   documentId: string,
   update: Uint8Array,

--- a/apps/web/lib/local-first/localFirstChecklistRepository.ts
+++ b/apps/web/lib/local-first/localFirstChecklistRepository.ts
@@ -9,6 +9,7 @@ import type {
 } from '@nexvoy/types'
 import {
   createEmptyTripDocumentV1,
+  convertLegacyTripRowsToDocument,
   materializeChecklists,
   type ChecklistRepository,
   type ChecklistRepositorySnapshot,
@@ -25,7 +26,9 @@ import {
   writeTripDocumentToYjs,
 } from '@nexvoy/core/local-first/yjsTripDocument'
 import type { ChecklistItemInput } from '@nexvoy/core/supabase/queries'
+import { getLegacyTripRowBundle } from '@nexvoy/core/supabase/legacyRepository'
 import {
+  loadAllTripDocumentUpdates,
   loadTripDocumentUpdate,
   saveTripDocumentUpdate,
 } from './indexedDbStore'
@@ -38,7 +41,7 @@ export function createWebLocalFirstChecklistRepository(
   return {
     getChecklist: (tripId) => getLocalChecklistSnapshot(supabase, tripId),
     createItem: async (checklistId, input) => {
-      const tripId = parseTripIdFromChecklistId(checklistId)
+      const tripId = await resolveTripIdForChecklistId(checklistId)
       if (!tripId) throw new Error('Local-first checklist id is invalid.')
       let createdItemId = ''
       const document = await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
@@ -65,7 +68,7 @@ export function createWebLocalFirstChecklistRepository(
       return toMutationResult(document, createdItemId)
     },
     updateItem: async (itemId, input) => {
-      const tripId = parseTripIdFromItemId(itemId)
+      const tripId = await resolveTripIdForItemId(itemId)
       if (!tripId) throw new Error('Local-first item id is invalid.')
       const document = await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
         const item = tripDocument.checklistItems[itemId]
@@ -85,7 +88,7 @@ export function createWebLocalFirstChecklistRepository(
       return toMutationResult(document, itemId)
     },
     deleteItem: async (itemId) => {
-      const tripId = parseTripIdFromItemId(itemId)
+      const tripId = await resolveTripIdForItemId(itemId)
       if (!tripId) throw new Error('Local-first item id is invalid.')
       await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
         const now = new Date().toISOString()
@@ -99,7 +102,7 @@ export function createWebLocalFirstChecklistRepository(
       })
     },
     toggleItem: async (itemId, isChecked) => {
-      const tripId = parseTripIdFromItemId(itemId)
+      const tripId = await resolveTripIdForItemId(itemId)
       if (!tripId) throw new Error('Local-first item id is invalid.')
       await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
         const item = tripDocument.checklistItems[itemId]
@@ -109,8 +112,8 @@ export function createWebLocalFirstChecklistRepository(
       })
     },
     toggleItemForUser: async (input) => {
-      const tripId = parseTripIdFromChecklistId(input.item.checklist_id)
-        ?? parseTripIdFromItemId(input.item.id)
+      const tripId = await resolveTripIdForChecklistId(input.item.checklist_id)
+        ?? await resolveTripIdForItemId(input.item.id)
       if (!tripId) throw new Error('Local-first item id is invalid.')
       const document = await mutateLocalTripDocument(supabase, tripId, (tripDocument) => {
         const item = tripDocument.checklistItems[input.item.id]
@@ -204,6 +207,9 @@ async function createInitialTripDocument(
   supabase: SupabaseClient,
   tripId: string,
 ): Promise<TripDocumentV1> {
+  const hydratedDocument = await hydrateTripDocumentFromLegacyRows(supabase, tripId)
+  if (hydratedDocument) return hydratedDocument
+
   const now = new Date().toISOString()
   const ownerId = await getCurrentUserId(supabase) ?? SPIKE_USER_ID
   const checklistId = createLocalChecklistId(tripId)
@@ -238,6 +244,31 @@ async function createInitialTripDocument(
   }
 
   return tripDocument
+}
+
+async function hydrateTripDocumentFromLegacyRows(
+  supabase: SupabaseClient,
+  tripId: string,
+): Promise<TripDocumentV1 | null> {
+  try {
+    const bundle = await getLegacyTripRowBundle(supabase, tripId, await getCurrentUserId(supabase))
+    if (!bundle) return null
+
+    const result = convertLegacyTripRowsToDocument(bundle)
+    if (result.validationMessages.length > 0) {
+      console.warn('[local-first hydration]', {
+        tripId,
+        validationCodes: result.validationMessages.map((message) => message.code),
+      })
+    }
+    return result.document
+  } catch (error) {
+    console.warn('[local-first hydration] fallback to empty document', {
+      tripId,
+      error: error instanceof Error ? error.message : 'unknown error',
+    })
+    return null
+  }
 }
 
 function toChecklistRepositorySnapshot(
@@ -439,6 +470,29 @@ function parseTripIdFromItemId(itemId: string): string | null {
   if (!itemId.startsWith('local-item:')) return null
   const [, tripId] = itemId.split(':')
   return tripId || null
+}
+
+async function resolveTripIdForChecklistId(checklistId: string): Promise<string | null> {
+  return parseTripIdFromChecklistId(checklistId)
+    ?? findTripIdInLocalDocuments((tripDocument) => Boolean(tripDocument.checklists[checklistId]))
+}
+
+async function resolveTripIdForItemId(itemId: string): Promise<string | null> {
+  return parseTripIdFromItemId(itemId)
+    ?? findTripIdInLocalDocuments((tripDocument) => Boolean(tripDocument.checklistItems[itemId]))
+}
+
+async function findTripIdInLocalDocuments(
+  matches: (tripDocument: TripDocumentV1) => boolean,
+): Promise<string | null> {
+  const rows = await loadAllTripDocumentUpdates()
+  for (const row of rows) {
+    const ydoc = createYjsTripDocument()
+    applyTripDocumentUpdate(ydoc, new Uint8Array(row.update))
+    const tripDocument = readTripDocumentFromYjs(ydoc)
+    if (tripDocument && matches(tripDocument)) return tripDocument.trip.id
+  }
+  return null
 }
 
 function isPresent<T>(value: T | null | undefined): value is T {

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -66,9 +66,9 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-006-backup-schema-and-rls.md` | 완료 | 로컬 구현 및 검증 완료 |
 | `TASK-007-document-key-model.md` | 완료 | 로컬 구현 및 검증 완료 |
 | `TASK-008-backup-queue-and-restore.md` | 완료 | 로컬 구현 및 검증 완료 |
-| `TASK-008a-web-checklist-read-through-hydration.md` | 예정 | `localFirstChecklist=1` 최초 진입 시 legacy row → IndexedDB/Yjs hydration |
+| `TASK-008a-web-checklist-read-through-hydration.md` | 완료 | 로컬 구현 및 검증 완료 |
 
-현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`의 핵심 기반은 완료되었다. 다음 작업은 누락된 read-through 연결인 `TASK-008a: Web Checklist Read-through Hydration`이다.
+현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. 다음 작업은 `TASK-009: Mobile WebRTC Native Feasibility`다.
 
 ## Phase별 작업 목록
 
@@ -91,7 +91,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 
 ### Phase 2.5: Web Read-through 보완
 
-- [ ] `TASK-008a-web-checklist-read-through-hydration.md`: Web checklist local-first 최초 진입 시 기존 Supabase row를 document로 hydrate
+- [x] `TASK-008a-web-checklist-read-through-hydration.md`: Web checklist local-first 최초 진입 시 기존 Supabase row를 document로 hydrate
 
 ### Phase 3: P2P Optional Fast Path
 
@@ -110,8 +110,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 
 ## 권장 시작 순서
 
-1. `TASK-008a-web-checklist-read-through-hydration.md`
-2. `TASK-009-mobile-webrtc-native-feasibility.md`
-3. `TASK-010-cloudflare-ice-config.md`
+1. `TASK-009-mobile-webrtc-native-feasibility.md`
+2. `TASK-010-cloudflare-ice-config.md`
 
-TASK-001~008까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크, Supabase backup schema/RLS, document key model, backup queue 및 snapshot/update restore flow를 검증할 수 있는 상태가 되었다. 다만 `localFirstChecklist=1` 최초 진입 시 기존 Supabase row를 IndexedDB/Yjs 문서로 hydrate하는 runtime 연결이 누락되어 있으므로, WebRTC optional fast path 전에 이 보완 작업을 먼저 수행한다.
+TASK-001~008a까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크, Supabase backup schema/RLS, document key model, backup queue, snapshot/update restore flow, 기존 Supabase row 기반 read-through hydration을 검증할 수 있는 상태가 되었다. 다음은 모바일 WebRTC와 Cloudflare STUN/TURN을 optional fast path로 검증한다.

--- a/packages/core/src/supabase/legacyRepository.ts
+++ b/packages/core/src/supabase/legacyRepository.ts
@@ -20,6 +20,7 @@ import {
   updateTrip,
   type ChecklistItemInput,
 } from './queries'
+import type { LegacyTripRowBundle } from '../local-first/migrations'
 import type {
   ChecklistRepository,
   ChecklistRepositorySnapshot,
@@ -88,6 +89,102 @@ export function createSupabaseChecklistRepository(sb: SupabaseClient): Checklist
       return getChecklistItemUserChecks(sb, [input.item.id])
     },
   }
+}
+
+export async function getLegacyTripRowBundle(
+  sb: SupabaseClient,
+  tripId: string,
+  currentUserId?: string | null,
+): Promise<LegacyTripRowBundle | null> {
+  const { data: trip, error: tripError } = await sb
+    .from('trips')
+    .select('*')
+    .eq('id', tripId)
+    .maybeSingle()
+  if (tripError) throw tripError
+  if (!trip) return null
+
+  const [
+    plansRes,
+    checklistsRes,
+    checklistCategoriesRes,
+    membersRes,
+    sharesRes,
+    invitationLinksRes,
+  ] = await Promise.all([
+    sb.from('plans').select('*').eq('trip_id', tripId),
+    sb.from('checklists').select('*').eq('trip_id', tripId).order('created_at', { ascending: true }),
+    currentUserId
+      ? sb
+        .from('checklist_categories')
+        .select('*')
+        .or(`user_id.is.null,user_id.eq.${currentUserId}`)
+        .order('sort_order', { ascending: true })
+      : sb
+        .from('checklist_categories')
+        .select('*')
+        .is('user_id', null)
+        .order('sort_order', { ascending: true }),
+    sb
+      .from('trip_members')
+      .select('id, trip_id, user_id, invited_email, role, status, created_at, profiles(nickname, email)')
+      .eq('trip_id', tripId),
+    sb.from('trip_shares').select('*').eq('trip_id', tripId),
+    sb.from('trip_invitation_links').select('*').eq('trip_id', tripId),
+  ])
+
+  if (plansRes.error) throw plansRes.error
+  if (checklistsRes.error) throw checklistsRes.error
+  if (checklistCategoriesRes.error) throw checklistCategoriesRes.error
+  if (membersRes.error) throw membersRes.error
+  if (sharesRes.error) throw sharesRes.error
+  if (invitationLinksRes.error) throw invitationLinksRes.error
+
+  const checklists = checklistsRes.data ?? []
+  const checklistIds = checklists.map((checklist) => checklist.id)
+  const plans = plansRes.data ?? []
+  const planIds = plans.map((plan) => plan.id)
+
+  const [planUrlsRes, checklistItemsRes] = await Promise.all([
+    planIds.length > 0
+      ? sb.from('plan_urls').select('*').in('plan_id', planIds)
+      : Promise.resolve({ data: [], error: null }),
+    checklistIds.length > 0
+      ? sb.from('checklist_items').select('*').in('checklist_id', checklistIds).order('created_at', { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+  ])
+
+  if (planUrlsRes.error) throw planUrlsRes.error
+  if (checklistItemsRes.error) throw checklistItemsRes.error
+
+  const checklistItems = checklistItemsRes.data ?? []
+  const checklistItemIds = checklistItems.map((item) => item.id)
+  const [assigneesRes, userChecksRes] = await Promise.all([
+    checklistItemIds.length > 0
+      ? sb.from('checklist_item_assignees').select('*').in('item_id', checklistItemIds)
+      : Promise.resolve({ data: [], error: null }),
+    checklistItemIds.length > 0
+      ? sb.from('checklist_item_user_checks').select('*').in('item_id', checklistItemIds)
+      : Promise.resolve({ data: [], error: null }),
+  ])
+
+  if (assigneesRes.error) throw assigneesRes.error
+  if (userChecksRes.error) throw userChecksRes.error
+
+  return {
+    exportedAt: new Date().toISOString(),
+    trip,
+    plans,
+    planUrls: planUrlsRes.data ?? [],
+    checklists,
+    checklistItems,
+    checklistCategories: checklistCategoriesRes.data ?? [],
+    checklistItemAssignees: assigneesRes.data ?? [],
+    checklistItemUserChecks: userChecksRes.data ?? [],
+    members: (membersRes.data ?? []).map(normalizeLegacyTripMemberRow),
+    shares: sharesRes.data ?? [],
+    invitationLinks: invitationLinksRes.data ?? [],
+  } satisfies LegacyTripRowBundle
 }
 
 async function getLegacyChecklistSnapshot(
@@ -162,6 +259,32 @@ function toChecklistMemberSnapshot(member: {
     ...member,
     invited_email: member.invited_email ?? '',
     profiles: profile ?? undefined,
+  }
+}
+
+function normalizeLegacyTripMemberRow(member: {
+  id: string
+  trip_id: string
+  user_id: string | null
+  invited_email: string | null
+  role: string
+  status: string
+  created_at: string
+  updated_at?: string | null
+  profiles?: { nickname: string | null; email: string | null } | { nickname: string | null; email: string | null }[] | null
+}): NonNullable<LegacyTripRowBundle['members']>[number] {
+  const profile = Array.isArray(member.profiles) ? member.profiles[0] : member.profiles
+
+  return {
+    id: member.id,
+    trip_id: member.trip_id,
+    user_id: member.user_id,
+    invited_email: member.invited_email,
+    role: member.role,
+    status: member.status,
+    created_at: member.created_at,
+    updated_at: member.updated_at ?? member.created_at,
+    profiles: profile ?? null,
   }
 }
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,30 +1,26 @@
-# Walkthrough: TASK-008 Backup Queue 및 Restore Flow
+# Walkthrough: TASK-008a Web Checklist Read-through Hydration
 
 ## Summary
 
-Local-first write 이후 Supabase backup/update log로 업로드하고 snapshot + updates로 복원하는 기본 sync/restore foundation을 추가했다. 이번 단계는 platform adapter가 사용할 `@nexvoy/core` queue/state/restore/repository 기반이며, local write 실패와 backup upload 실패를 분리한다.
+`localFirstChecklist=1` 최초 진입 시 IndexedDB에 local-first 문서가 없으면 기존 Supabase row bundle을 읽어 `TripDocumentV1`로 변환하고 Yjs update로 저장하도록 연결했다. 이제 기존 체크리스트가 local-first mode에서도 빈 화면이 아니라 read-through hydrated document로 표시된다.
 
 ## Artifacts
 
-- `docs/refactor/tasks/TASK-008-backup-queue-and-restore.md`
+- `docs/refactor/tasks/TASK-008a-web-checklist-read-through-hydration.md`
 - `docs/refactor/TECHNICAL-SPEC.md`
 - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
-- `docs/refactor/adrs/ADR-004-p2p-signaling-strategy.md`
 
 ## Key Changes
 
-- `packages/core/src/sync/backupTypes.ts`에 pending update, snapshot/update record, queue state, restore plan 타입을 추가했다.
-- `packages/core/src/sync/syncState.ts`에 queue enqueue, upload start/success/failure, retry state, snapshot threshold, restore plan ordering, hash mismatch validation을 추가했다.
-- `packages/core/src/sync/restore.ts`에 encrypted snapshot/update replay helper를 추가했다. Hash 검증 후 Yjs update를 순서대로 적용해 `TripDocumentV1`을 복원한다.
-- `packages/core/src/supabase/backupRepository.ts`에 `documents` snapshot upsert, `document_updates` upload/list, restore plan download repository를 추가했다.
-- `packages/core` subpath export에 `sync/syncState`, `sync/restore`, `supabase/backupRepository`를 추가했다.
-- `packages/core/src/sync/__tests__/syncState.test.ts`와 `restore.test.ts`로 queue retry, snapshot threshold, restore ordering, hash mismatch, encrypted replay를 검증했다.
+- `packages/core/src/supabase/legacyRepository.ts`에 `getLegacyTripRowBundle()`을 추가해 Trip, Plan, Checklist, Member, Share row를 hydration용 bundle로 조회한다.
+- `apps/web/lib/local-first/localFirstChecklistRepository.ts`가 IndexedDB에 문서가 없을 때 `convertLegacyTripRowsToDocument()`로 Supabase row를 hydrate한다.
+- hydration validation warning은 code만 로그에 남기고 document payload는 기록하지 않는다.
+- hydration 실패 시 기존 spike 빈 문서 생성 fallback을 유지한다.
+- 기존 UUID 기반 checklist/item도 local mutation이 가능하도록 IndexedDB 문서에서 checklist/item id → trip id를 찾는 resolver를 추가했다.
+- `apps/web/lib/local-first/indexedDbStore.ts`에 저장된 trip document update 전체를 조회하는 helper를 추가했다.
 
 ## Verification
 
-- `supabase db reset --local` 성공
-- `docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d postgres < supabase/tests/task006_backup_rls.sql` 성공
-- `docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d postgres < supabase/tests/task007_document_keys_rls.sql` 성공
 - `pnpm --filter @nexvoy/core test` 성공
 - `pnpm --filter @nexvoy/core typecheck` 성공
 - `pnpm build` 성공
@@ -32,11 +28,9 @@ Local-first write 이후 Supabase backup/update log로 업로드하고 snapshot 
 
 ## Rollback
 
-문제 발생 시 local-first repository 기본값을 Supabase legacy repository로 유지하고, 새 `@nexvoy/core` sync helper import를 제거한다. Supabase backup table에 쌓인 테스트 document/update row는 cleanup script 또는 SQL로 삭제하며, 기존 row 기반 서비스 테이블은 유지한다.
+문제 발생 시 `localFirstChecklist` flag를 off로 유지하면 기존 Supabase repository 화면으로 돌아간다. 잘못 생성된 spike 문서는 DevTools에서 IndexedDB `onvoy-local-first-spike` DB를 삭제해 초기화할 수 있다.
 
 ## Notes
 
-- `packages/core`는 IndexedDB/SQLite/WebRTC/Next.js/RN API를 직접 import하지 않는다.
-- Web/RN platform adapters는 다음 단계에서 local persistence와 network 상태에 맞춰 `BackupQueueState`를 저장하고 `SupabaseBackupRepository`를 호출하면 된다.
-- Snapshot/update payload는 `TASK-007` encryption helper의 serialized encrypted payload를 저장하는 전제로 설계했다.
-- `packages/types/src/database.generated.ts`는 이번 작업에서 최종 변경하지 않았다. backup repository가 app layer에서 본격 소비될 때 local schema drift와 함께 재생성한다.
+- 이미 빈 spike 문서가 IndexedDB에 저장된 브라우저에서는 legacy hydration이 다시 실행되지 않는다. 해당 DB를 삭제한 뒤 `?localFirstChecklist=1`로 재진입해야 한다.
+- 이 단계는 Web checklist spike의 read-through hydration이며, 아직 document-primary 또는 dual-write 전환은 아니다.


### PR DESCRIPTION
## Summary
- Add legacy Supabase row bundle loading for trip/checklist hydration.
- Hydrate `localFirstChecklist=1` from Supabase rows into a Yjs Trip document when IndexedDB has no local document yet.
- Resolve legacy UUID checklist/item ids back to trip documents so local mutations continue after hydration.

## Test plan
- `pnpm --filter @nexvoy/core test`
- `pnpm --filter @nexvoy/core typecheck`
- `pnpm build`
- `pnpm build:mobile`

## Notes
- Existing browsers that already stored an empty spike document need IndexedDB `onvoy-local-first-spike` cleared to trigger first-time hydration again.


Made with [Cursor](https://cursor.com)