### PR TITLE
Fix shared address tooltip loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /coverage
 /playwright-report
 /test-results
+**/playwright-report
+**/test-results
 
 # next.js
 /.next/

--- a/apps/web/app/api/geocode/route.ts
+++ b/apps/web/app/api/geocode/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url)
+    const lat = searchParams.get('lat')
+    const lng = searchParams.get('lng')
+
+    if (!lat || !lng) {
+        return NextResponse.json({ error: 'Missing lat or lng' }, { status: 400 })
+    }
+
+    const apiKey = process.env.GOOGLE_MAPS_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+    if (!apiKey) {
+        console.error('Missing Google Maps API Key')
+        return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+    }
+
+    try {
+        const url = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${encodeURIComponent(`${lat},${lng}`)}&language=ko&key=${apiKey}`
+        const res = await fetch(url, { next: { revalidate: 3600 } })
+        const data = await res.json()
+
+        if (data.status !== 'OK') {
+            console.error('Google Geocoding API Error:', data)
+            return NextResponse.json({ error: data.error_message || data.status }, { status: 400 })
+        }
+
+        return NextResponse.json(data)
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        console.error('[geocode] Error:', message)
+        return NextResponse.json({ error: message }, { status: 500 })
+    }
+}

--- a/apps/web/app/share/detail/ShareClient.tsx
+++ b/apps/web/app/share/detail/ShareClient.tsx
@@ -39,6 +39,7 @@ function SharePlanCard({ plan, formatLocalTime, formatDate }: any) {
                     {plan.location && (
                         <LocationTooltip 
                             locationName={plan.location} 
+                            address={plan.address}
                             lat={plan.location_lat} 
                             lng={plan.location_lng} 
                         />

--- a/apps/web/e2e/helpers/supabase.ts
+++ b/apps/web/e2e/helpers/supabase.ts
@@ -27,6 +27,40 @@ export interface TestUser {
   refreshToken: string;
 }
 
+type PasswordSession = {
+  access_token?: string;
+  refresh_token?: string;
+  user?: {
+    id?: string;
+  };
+};
+
+function isAlreadyRegisteredError(error: { message?: string; code?: string } | null): boolean {
+  const message = error?.message?.toLowerCase() ?? '';
+  return (
+    message.includes('already') ||
+    message.includes('registered') ||
+    error?.code === 'email_exists' ||
+    error?.code === '23505'
+  );
+}
+
+async function findExistingUserId(
+  adminClient: any,
+  email: string
+): Promise<string> {
+  const { data, error } = await adminClient.auth.admin.listUsers({ page: 1, perPage: 1000 });
+
+  if (error) {
+    throw new Error(`테스트 유저 목록 조회 실패: ${error.message}`);
+  }
+
+  const found = (data.users as Array<{ id: string; email?: string }>).find((u) => u.email === email);
+  if (!found) throw new Error(`테스트 유저를 찾을 수 없음: ${email}`);
+
+  return found.id;
+}
+
 /**
  * 테스트 전용 유저를 생성하고 세션 토큰을 반환한다.
  * 실제 고객/임직원 정보를 사용하지 말 것.
@@ -35,56 +69,61 @@ export async function createTestUser(email: string, password: string): Promise<T
   const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
   const anonKey = getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
   const serviceKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
-
-  // 1. 유저 생성 또는 비밀번호 업데이트 (admin REST API)
-  const createRes = await fetch(`${url}/auth/v1/admin/users`, {
-    method: 'POST',
-    headers: {
-      apikey: serviceKey,
-      Authorization: `Bearer ${serviceKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email, password, email_confirm: true }),
+  const adminClient = createClient(url, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const createBody = await createRes.json();
-
+  // 1. 유저 생성 또는 비밀번호 업데이트 (admin API)
+  const { data: createData, error: createError } = await adminClient.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
   let userId: string;
-  if (createRes.ok) {
-    userId = createBody.id;
-  } else if (createBody.msg?.includes('already') || createBody.code === 'email_exists' || createBody.code === '23505') {
-    // 이미 존재하면 목록에서 찾아 비밀번호 업데이트
-    const listRes = await fetch(`${url}/auth/v1/admin/users?per_page=1000`, {
-      headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
-    });
-    const { users } = await listRes.json();
-    const found = (users as any[]).find((u) => u.email === email);
-    if (!found) throw new Error(`테스트 유저를 찾을 수 없음: ${email}`);
-    userId = found.id;
+  let passwordSession: PasswordSession | null = null;
 
-    await fetch(`${url}/auth/v1/admin/users/${userId}`, {
-      method: 'PUT',
-      headers: {
-        apikey: serviceKey,
-        Authorization: `Bearer ${serviceKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ password, email_confirm: true }),
+  if (createData.user) {
+    userId = createData.user.id;
+  } else if (isAlreadyRegisteredError(createError)) {
+    // CI Supabase projects can fail admin listUsers with "Database error finding users".
+    // Existing e2e users normally keep the same password, so reuse password auth first.
+    const existingSignInRes = await fetch(`${url}/auth/v1/token?grant_type=password`, {
+      method: 'POST',
+      headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
     });
+    const existingSession = await existingSignInRes.json();
+
+    if (existingSession.access_token && existingSession.user?.id) {
+      passwordSession = existingSession;
+      userId = existingSession.user.id;
+    } else {
+      userId = await findExistingUserId(adminClient, email);
+      const { error: updateError } = await adminClient.auth.admin.updateUserById(userId, {
+        password,
+        email_confirm: true,
+      });
+
+      if (updateError) {
+        throw new Error(`테스트 유저 비밀번호 업데이트 실패: ${updateError.message}`);
+      }
+    }
   } else {
-    throw new Error(`테스트 유저 생성 실패: ${JSON.stringify(createBody)}`);
+    throw new Error(`테스트 유저 생성 실패: ${createError?.message ?? 'Unknown error'}`);
   }
 
   // 1-b. profiles row 보장 (trigger 대기 → 타임아웃 시 직접 upsert)
   await ensureProfile(userId, email, url, serviceKey);
 
   // 2. 세션 발급 (anon key로 signInWithPassword)
-  const signInRes = await fetch(`${url}/auth/v1/token?grant_type=password`, {
-    method: 'POST',
-    headers: { apikey: anonKey, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password }),
-  });
-  const session = await signInRes.json();
+  const session = passwordSession ?? await (async () => {
+    const signInRes = await fetch(`${url}/auth/v1/token?grant_type=password`, {
+      method: 'POST',
+      headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    return signInRes.json();
+  })();
   if (!session.access_token) {
     throw new Error(`세션 발급 실패: ${JSON.stringify(session)}`);
   }
@@ -103,16 +142,13 @@ export async function createTestUser(email: string, password: string): Promise<T
 export async function deleteTestUser(email: string): Promise<void> {
   const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
   const serviceKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
-
-  const listRes = await fetch(`${url}/auth/v1/admin/users?per_page=1000`, {
-    headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+  const adminClient = createClient(url, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
   });
-  const { users } = await listRes.json();
-  const found = (users as any[]).find((u) => u.email === email);
-  if (!found) return;
 
-  await fetch(`${url}/auth/v1/admin/users/${found.id}`, {
-    method: 'DELETE',
-    headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
-  });
+  const userId = await findExistingUserId(adminClient, email).catch(() => null);
+  if (!userId) return;
+
+  const { error } = await adminClient.auth.admin.deleteUser(userId);
+  if (error) throw new Error(`테스트 유저 삭제 실패: ${error.message}`);
 }

--- a/apps/web/services/ExternalApiService.ts
+++ b/apps/web/services/ExternalApiService.ts
@@ -53,11 +53,9 @@ export const LocationService = {
    * 위경도 좌표로 주소 정보 가져오기 (Google Maps Geocoding API)
    */
   getAddress: async (lat: number, lng: number) => {
-    const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
-    // External API 호출이므로 apiService.request 사용
-    const response = await apiService.request({
-      url: `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&language=ko&key=${apiKey}`,
-      method: 'GET'
+    const response = await apiService.get(`/api/geocode/`, {
+      lat: lat.toString(),
+      lng: lng.toString()
     });
     return response.data;
   }


### PR DESCRIPTION
## Summary
- Pass saved plan addresses into shared itinerary location tooltips so they render without extra network calls.
- Add a server-side geocoding route and route tooltip fallback lookups through it to avoid browser-side Google Geocoding failures.

## Test plan
- [x] pnpm --filter nexvoy-web build


Made with [Cursor](https://cursor.com)