### PR TITLE
TASK-023: Mobile signaling channel wiring

### DIFF
--- a/apps/mobile/lib/local-first/signalingChannel.ts
+++ b/apps/mobile/lib/local-first/signalingChannel.ts
@@ -1,0 +1,112 @@
+import { subtle } from 'react-native-quick-crypto'
+import {
+  SIGNALING_BROADCAST_EVENT,
+  deriveSignalingRoomTopic,
+  parseSignalingMessage,
+  type SignalingMessage,
+  type SignalingRoomDigestProvider,
+} from '@nexvoy/core/sync/signalingChannel'
+import {
+  validateSignalingJoinPolicy,
+  type SignalingJoinDecision,
+} from '@nexvoy/core/sync/signalingPermissions'
+import type { DocumentMemberStatus, DocumentRole } from '@nexvoy/core/local-first/permissions'
+import { supabase } from '@/lib/supabase'
+
+export interface MobileSignalingChannelMembership {
+  role: DocumentRole | null | undefined
+  status: DocumentMemberStatus | null | undefined
+}
+
+export interface JoinMobileSignalingChannelInput {
+  documentId: string
+  userId: string
+  membership: MobileSignalingChannelMembership
+  onMessage: (message: SignalingMessage) => void
+}
+
+export interface MobileSignalingChannel {
+  readonly decision: SignalingJoinDecision
+  send(message: SignalingMessage): void
+  leave(): Promise<void>
+}
+
+export const mobileSignalingDigestProvider: SignalingRoomDigestProvider = {
+  async digest(algorithm, data) {
+    const digest = await subtle.digest(algorithm as never, data as never)
+    return toArrayBuffer(digest)
+  },
+}
+
+/**
+ * Joins the per-document Supabase Realtime Broadcast private channel used for
+ * mobile P2P signaling. validateSignalingJoinPolicy() is a client-side
+ * fail-fast guard only; Realtime Authorization RLS remains the server boundary.
+ */
+export async function joinMobileSignalingChannel(
+  input: JoinMobileSignalingChannelInput,
+): Promise<MobileSignalingChannel> {
+  const decision = validateSignalingJoinPolicy({
+    documentId: input.documentId,
+    userId: input.userId,
+    role: input.membership.role,
+    status: input.membership.status,
+    // Rotating room secret issuance is deferred by ADR-012; this mirrors the
+    // Web adapter while server-side Realtime Authorization enforces access.
+    hasValidRoomSecretProof: true,
+  })
+
+  if (!decision.allowed) {
+    return {
+      decision,
+      send: () => {},
+      leave: async () => {},
+    }
+  }
+
+  const topic = await deriveSignalingRoomTopic(input.documentId, mobileSignalingDigestProvider)
+  const channel = supabase.channel(topic, { config: { private: true } })
+
+  channel.on(
+    'broadcast',
+    { event: SIGNALING_BROADCAST_EVENT },
+    ({ payload }: { payload: unknown }) => {
+      const message = parseSignalingMessage(payload)
+      if (message && message.senderId !== input.userId) {
+        input.onMessage(message)
+      }
+    },
+  )
+
+  await new Promise<void>((resolve, reject) => {
+    channel.subscribe((status) => {
+      if (status === 'SUBSCRIBED') {
+        resolve()
+        return
+      }
+      if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+        reject(new Error(`signaling_channel_${status.toLowerCase()}`))
+      }
+    })
+  })
+
+  return {
+    decision,
+    send(message) {
+      if (!decision.canWrite) return
+      void channel.send({
+        type: 'broadcast',
+        event: SIGNALING_BROADCAST_EVENT,
+        payload: message,
+      })
+    },
+    async leave() {
+      await supabase.removeChannel(channel)
+    },
+  }
+}
+
+function toArrayBuffer(input: ArrayBuffer | ArrayBufferView): ArrayBuffer {
+  if (input instanceof ArrayBuffer) return input
+  return input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength) as ArrayBuffer
+}

--- a/apps/mobile/lib/local-first/webP2PConnection.ts
+++ b/apps/mobile/lib/local-first/webP2PConnection.ts
@@ -1,0 +1,156 @@
+import { RTCPeerConnection } from 'react-native-webrtc'
+import type { SignalingMessage } from '@nexvoy/core/sync/signalingChannel'
+import {
+  createMobileHandshakeDataChannel,
+  createMobileWebRtcProvider,
+  wireMobileHandshakeDataChannel,
+  type MobileWebRtcDataChannelHandshakeResult,
+} from './webRtcProvider.native'
+import {
+  joinMobileSignalingChannel,
+  type MobileSignalingChannelMembership,
+} from './signalingChannel'
+import { fetchMobileIceServerConfig } from './iceServers'
+
+export interface ConnectMobileP2PPeerInput {
+  documentId: string
+  userId: string
+  membership: MobileSignalingChannelMembership
+  /** Caller decides which side offers; a viewer (canWrite=false) is never allowed to act as initiator. */
+  isInitiator: boolean
+  onHandshakeComplete?: (result: MobileWebRtcDataChannelHandshakeResult) => void
+}
+
+export interface MobileP2PConnection {
+  readonly peerConnection: RTCPeerConnection
+  close(): Promise<void>
+}
+
+export class MobileP2PSignalingDeniedError extends Error {
+  constructor(readonly reason: string | null) {
+    super(`mobile_p2p_signaling_denied:${reason ?? 'unknown'}`)
+  }
+}
+
+/**
+ * Ties the mobile signaling channel and native WebRTC provider together for
+ * Web-Mobile and Mobile-Mobile connectivity validation. Yjs update exchange is
+ * intentionally out of scope for TASK-023.
+ */
+export async function connectMobileP2PPeer(
+  input: ConnectMobileP2PPeerInput,
+): Promise<MobileP2PConnection> {
+  let peerConnection: RTCPeerConnection | null = null
+  let sendSignalingMessage: (message: SignalingMessage) => void = () => {}
+  const pendingMessages: SignalingMessage[] = []
+
+  const signaling = await joinMobileSignalingChannel({
+    documentId: input.documentId,
+    userId: input.userId,
+    membership: input.membership,
+    onMessage: (message) => {
+      if (!peerConnection) {
+        pendingMessages.push(message)
+        return
+      }
+      void handleSignalingMessage(peerConnection, sendSignalingMessage, input.userId, message)
+    },
+  })
+
+  if (!signaling.decision.allowed) {
+    throw new MobileP2PSignalingDeniedError(signaling.decision.reason)
+  }
+
+  sendSignalingMessage = signaling.send
+  let provider: ReturnType<typeof createMobileWebRtcProvider> | null = null
+
+  try {
+    const isInitiator = input.isInitiator && signaling.decision.canWrite
+    const iceConfig = await fetchMobileIceServerConfig()
+    provider = createMobileWebRtcProvider({ iceServers: iceConfig.iceServers })
+    peerConnection = await provider.createPeerConnection() as RTCPeerConnection
+
+    const peerConnectionEvents = peerConnection as unknown as {
+      addEventListener?: (
+        eventName: 'icecandidate' | 'datachannel',
+        listener: (event: {
+          candidate?: { candidate: string; sdpMid?: string | null; sdpMLineIndex?: number | null }
+          channel?: Parameters<typeof wireMobileHandshakeDataChannel>[0]
+        }) => void,
+      ) => void
+    }
+
+    peerConnectionEvents.addEventListener?.('icecandidate', (event) => {
+      if (!event.candidate) return
+      signaling.send({
+        type: 'ice-candidate',
+        senderId: input.userId,
+        candidate: event.candidate.candidate,
+        sdpMid: event.candidate.sdpMid ?? null,
+        sdpMLineIndex: event.candidate.sdpMLineIndex ?? null,
+      })
+    })
+
+    if (isInitiator) {
+      const dataChannel = createMobileHandshakeDataChannel(peerConnection)
+      wireMobileHandshakeDataChannel(dataChannel, {
+        onHandshakeComplete: input.onHandshakeComplete,
+      })
+
+      const offer = await peerConnection.createOffer()
+      await peerConnection.setLocalDescription(offer)
+      signaling.send({ type: 'offer', senderId: input.userId, sdp: offer.sdp ?? '' })
+    } else {
+      peerConnectionEvents.addEventListener?.('datachannel', (event) => {
+        if (!event.channel) return
+        wireMobileHandshakeDataChannel(event.channel, {
+          onHandshakeComplete: input.onHandshakeComplete,
+        })
+      })
+    }
+
+    for (const message of pendingMessages.splice(0)) {
+      void handleSignalingMessage(peerConnection, sendSignalingMessage, input.userId, message)
+    }
+  } catch (error) {
+    await signaling.leave()
+    await provider?.close()
+    throw error
+  }
+
+  return {
+    peerConnection,
+    async close() {
+      await signaling.leave()
+      await provider.close()
+    },
+  }
+}
+
+async function handleSignalingMessage(
+  peerConnection: RTCPeerConnection,
+  send: (message: SignalingMessage) => void,
+  userId: string,
+  message: SignalingMessage,
+): Promise<void> {
+  if (message.senderId === userId) return
+
+  if (message.type === 'offer') {
+    await peerConnection.setRemoteDescription({ type: 'offer', sdp: message.sdp })
+    const answer = await peerConnection.createAnswer()
+    await peerConnection.setLocalDescription(answer)
+    send({ type: 'answer', senderId: userId, sdp: answer.sdp ?? '' })
+    return
+  }
+
+  if (message.type === 'answer') {
+    await peerConnection.setRemoteDescription({ type: 'answer', sdp: message.sdp })
+    return
+  }
+
+  await peerConnection.addIceCandidate({
+    candidate: message.candidate,
+    sdpMid: message.sdpMid,
+    sdpMLineIndex: message.sdpMLineIndex ?? undefined,
+  })
+}

--- a/apps/mobile/lib/local-first/webRtcProvider.native.ts
+++ b/apps/mobile/lib/local-first/webRtcProvider.native.ts
@@ -1,5 +1,6 @@
 import { AppState, Platform } from 'react-native'
 import { RTCPeerConnection } from 'react-native-webrtc'
+import type RTCDataChannel from 'react-native-webrtc/lib/typescript/RTCDataChannel'
 import type { P2PObservabilityEvent } from '@nexvoy/core/sync/iceServers'
 import {
   REACT_NATIVE_WEBRTC_FEASIBILITY,
@@ -7,6 +8,15 @@ import {
   type MobileWebRtcProviderDiagnostics,
   type MobileWebRtcProviderOptions,
 } from './webRtcProvider.types'
+
+export interface MobileWebRtcDataChannelHandshakeResult {
+  rttMs: number
+}
+
+export interface WireMobileHandshakeDataChannelOptions {
+  onEvent?: (event: P2PObservabilityEvent) => void
+  onHandshakeComplete?: (result: MobileWebRtcDataChannelHandshakeResult) => void
+}
 
 function createDiagnostics(
   availability: MobileWebRtcProviderDiagnostics['availability'],
@@ -24,6 +34,48 @@ function createDiagnostics(
     requiredPackages: REACT_NATIVE_WEBRTC_FEASIBILITY.requiredPackages,
     fallbackReason,
   }
+}
+
+/** The initiator side creates this channel; the answerer receives it through the peer connection's `datachannel` event. */
+export function createMobileHandshakeDataChannel(
+  peerConnection: RTCPeerConnection,
+  label = 'signaling-handshake',
+): RTCDataChannel {
+  return peerConnection.createDataChannel(label)
+}
+
+/**
+ * Wires a minimal ping/pong round trip used to prove the RN data channel is
+ * open end-to-end. Payload is fixed to { type, ts }; no document content or
+ * CRDT updates are sent in TASK-023.
+ */
+export function wireMobileHandshakeDataChannel(
+  dataChannel: RTCDataChannel,
+  options: WireMobileHandshakeDataChannelOptions = {},
+): void {
+  const eventTarget = dataChannel as unknown as {
+    addEventListener?: (eventName: 'open' | 'message', listener: (event: { data?: unknown }) => void) => void
+  }
+
+  eventTarget.addEventListener?.('open', () => {
+    emitEvent(options, {
+      name: 'p2p_data_channel_open',
+      platform: getDiagnosticsPlatform(),
+    })
+    dataChannel.send(JSON.stringify({ type: 'ping', ts: Date.now() }))
+  })
+
+  eventTarget.addEventListener?.('message', (event) => {
+    const parsed = parseHandshakePayload(event.data)
+    if (!parsed) return
+
+    if (parsed.type === 'ping') {
+      dataChannel.send(JSON.stringify({ type: 'pong', ts: parsed.ts }))
+      return
+    }
+
+    options.onHandshakeComplete?.({ rttMs: Date.now() - parsed.ts })
+  })
 }
 
 export function createMobileWebRtcProvider(
@@ -73,6 +125,24 @@ export function createMobileWebRtcProvider(
       return undefined
     },
   }
+}
+
+function parseHandshakePayload(raw: unknown): { type: 'ping' | 'pong'; ts: number } | null {
+  if (typeof raw !== 'string') return null
+
+  try {
+    const data: unknown = JSON.parse(raw)
+    if (
+      isRecord(data)
+      && (data.type === 'ping' || data.type === 'pong')
+      && typeof data.ts === 'number'
+    ) {
+      return { type: data.type, ts: data.ts }
+    }
+  } catch {
+    return null
+  }
+  return null
 }
 
 function getDiagnosticsPlatform(): P2PObservabilityEvent['platform'] {

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -81,19 +81,19 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-020-mobile-encrypted-snapshot-restore.md` | 완료 | 로컬 구현 및 검증 완료 (reviewer APPROVE, qa-engineer PASS) |
 | `TASK-021-web-signaling-channel-and-data-channel-handshake.md` | PR 리뷰 대기 | typecheck/test/build 통과, PR [#300](https://github.com/ysjee141/nexvoy-frontend/pull/300), 실브라우저 2세션 수동 검증은 후속 |
 | `TASK-022-document-registry-bootstrap-for-regular-trips.md` | 완료 | 일반 Web trip의 documents/document_members lazy bootstrap 구현 및 검증 완료 |
-| `TASK-023-mobile-signaling-channel-wiring.md` | 계획됨 | TASK-021을 Mobile까지 확장(Web-Mobile, Mobile-Mobile 연결) |
+| `TASK-023-mobile-signaling-channel-wiring.md` | 완료 | Mobile signaling channel, native data-channel handshake, P2P 조립 지점 구현 및 자동 검증 완료 |
 | `TASK-024-p2p-data-channel-yjs-update-exchange.md` | 계획됨 | 데이터 채널로 실제 Yjs update 교환(연결 증명 이후 실질적 동기화 가속) |
 | `TASK-025-p2p-connection-status-ui.md` | 계획됨 | 사용자 대상 연결 상태 UI/UX |
 | `TASK-026-p2p-connection-lifecycle-hardening.md` | 계획됨 | 재연결, 백그라운드/탭 종료 정리, rotating room secret 하드닝 |
 
-현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `Phase 3`의 모바일 WebRTC native feasibility와 Cloudflare ICE config 발급 경로는 provider boundary, Edge Function, 검증 보고서로 정리했다. `Phase 4`의 dual-write 및 mismatch detector와 guest auth promotion은 Web-first 범위로 구현했다. `TASK-013`에서 초대/권한 registry, invite/share RPC, Web/Mobile join fallback을 구현했고, `TASK-014`에서 notification metadata, local notification scheduler, observability event boundary를 구현했다. `TASK-015`에서 owner/editor Web foreground document key provisioning과 pending/status UX를 구현했다. `TASK-016`은 Mobile Native Key Provisioning MVP를 구현하고 accepted scope 기준 검증했다. `TASK-017`은 Mobile background task 기반 provisioning retry path를 구현하고 Android-first 검증 범위에서 PASS를 받았다. `TASK-018`은 Android Keystore/iOS Keychain 기반 non-exportable key storage hardening을 구현하고 native preview build와 SQL smoke까지 검증했다. `TASK-019`는 Mobile-first owner bootstrap 후속 문서다. `TASK-020`은 `restore.ts`의 Yjs 비의존 부분(snapshot 복호화·hash 검증)을 `backupPayloadCodec.ts`/`mobileRestore.ts`로 분리해 Mobile 전용 encrypted snapshot restore 경로(`restoreMobileEncryptedSnapshot`)를 구현하고, `TASK-019`의 owner bootstrap 성공/provisioning completion 트리거에 재시도를 연결했다. updates replay(Web/Yjs 기반 최신 콘텐츠 반영)는 이번 범위에서 제외했다. `TASK-021`은 `ADR-004`가 유보했던 시그널링 전송 계층을 `ADR-012`(Supabase Realtime Broadcast)로 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 배선해 P2P fast path의 최초 연결을 증명했다. `TASK-022`는 일반 Web 로그인 trip이 `documents`/`document_members`에 등록되지 않던 선결 문제를 lazy bootstrap으로 해소했다. Mobile 배선과 Yjs update 실제 교환은 후속 TASK로 이관했다.
+현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `Phase 3`의 모바일 WebRTC native feasibility와 Cloudflare ICE config 발급 경로는 provider boundary, Edge Function, 검증 보고서로 정리했다. `Phase 4`의 dual-write 및 mismatch detector와 guest auth promotion은 Web-first 범위로 구현했다. `TASK-013`에서 초대/권한 registry, invite/share RPC, Web/Mobile join fallback을 구현했고, `TASK-014`에서 notification metadata, local notification scheduler, observability event boundary를 구현했다. `TASK-015`에서 owner/editor Web foreground document key provisioning과 pending/status UX를 구현했다. `TASK-016`은 Mobile Native Key Provisioning MVP를 구현하고 accepted scope 기준 검증했다. `TASK-017`은 Mobile background task 기반 provisioning retry path를 구현하고 Android-first 검증 범위에서 PASS를 받았다. `TASK-018`은 Android Keystore/iOS Keychain 기반 non-exportable key storage hardening을 구현하고 native preview build와 SQL smoke까지 검증했다. `TASK-019`는 Mobile-first owner bootstrap 후속 문서다. `TASK-020`은 `restore.ts`의 Yjs 비의존 부분(snapshot 복호화·hash 검증)을 `backupPayloadCodec.ts`/`mobileRestore.ts`로 분리해 Mobile 전용 encrypted snapshot restore 경로(`restoreMobileEncryptedSnapshot`)를 구현하고, `TASK-019`의 owner bootstrap 성공/provisioning completion 트리거에 재시도를 연결했다. updates replay(Web/Yjs 기반 최신 콘텐츠 반영)는 이번 범위에서 제외했다. `TASK-021`은 `ADR-004`가 유보했던 시그널링 전송 계층을 `ADR-012`(Supabase Realtime Broadcast)로 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 배선해 P2P fast path의 최초 연결을 증명했다. `TASK-022`는 일반 Web 로그인 trip이 `documents`/`document_members`에 등록되지 않던 선결 문제를 lazy bootstrap으로 해소했다. `TASK-023`은 같은 signaling 프로토콜과 room topic 파생 규칙을 Mobile까지 확장하고 native data-channel handshake/조립 지점을 추가했다. Yjs update 실제 교환은 후속 TASK로 이관했다.
 
 `TASK-021`은 `ADR-004`가 유보했던 시그널링 전송 계층을 `ADR-012`(Supabase Realtime Broadcast)로
 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 연결해 P2P fast path의 최초 연결을 증명했다
 (PR #300, 자동 검증 완료·실브라우저 수동 검증 후속). 수동 검증 중 일반 trip이 `documents`/
 `document_members`에 전혀 등록되지 않는다는 선결 문제를 발견해 `TASK-022`로 분리했다. P2P를 완전한
-기능으로 만들기 위한 나머지 작업(`TASK-023`~`TASK-026`: Mobile 배선, 실제 데이터 교환, 사용자 UI,
-생명주기 하드닝)을 계획 문서로 정리했다 — 구현은 아직 착수하지 않았다.
+기능으로 만들기 위한 나머지 작업(`TASK-024`~`TASK-026`: 실제 데이터 교환, 사용자 UI,
+생명주기 하드닝)을 계획 문서로 정리했다.
 
 ## Phase별 작업 목록
 
@@ -144,7 +144,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 
 - [x] `TASK-021-web-signaling-channel-and-data-channel-handshake.md`: Web 시그널링 채널(Supabase Realtime Broadcast) + 데이터 채널 배선으로 P2P fast path 최초 연결 증명 (PR #300, 실브라우저 2세션 수동 검증은 후속)
 - [x] `TASK-022-document-registry-bootstrap-for-regular-trips.md`: 일반 trip이 documents/document_members에 자동 등록되도록 bootstrap
-- [ ] `TASK-023-mobile-signaling-channel-wiring.md`: TASK-021을 Mobile까지 확장(Web-Mobile, Mobile-Mobile 연결)
+- [x] `TASK-023-mobile-signaling-channel-wiring.md`: TASK-021을 Mobile까지 확장(Web-Mobile, Mobile-Mobile 연결 조립 지점)
 - [ ] `TASK-024-p2p-data-channel-yjs-update-exchange.md`: 데이터 채널로 실제 Yjs update 교환
 - [ ] `TASK-025-p2p-connection-status-ui.md`: 사용자 대상 연결 상태 UI/UX
 - [ ] `TASK-026-p2p-connection-lifecycle-hardening.md`: 재연결/생명주기/rotating room secret 하드닝
@@ -153,6 +153,6 @@ TASK-008a-web-checklist-read-through-hydration.md
 
 TASK-001~022까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크, Supabase backup schema/RLS, document key model, backup queue, snapshot/update restore flow, 기존 Supabase row 기반 read-through hydration, 모바일 WebRTC native runtime 조건, Cloudflare STUN/TURN ICE config 발급 경로, checklist dual-write/mismatch detector, guest auth promotion, 초대/권한 registry, notification/observability boundary, Web foreground owner-side key provisioning, Mobile native key provisioning MVP와 foreground/resume/background sync, native non-exportable key storage hardening, Mobile-first owner device key bootstrap, Mobile encrypted snapshot restore(updates replay 제외), Web P2P signaling 최초 연결, 일반 Web trip document registry bootstrap까지 검증을 완료했다.
 
-`TASK-021`은 Web-to-Web P2P 연결을 최초로 증명했고, `TASK-022`는 일반 계정 trip의 document registry 등록 갭을 해소했다. 다음 권장 순서는
-`TASK-023`(Mobile 배선) → `TASK-024`(실제 데이터 교환) → `TASK-025`(UI) → `TASK-026`(생명주기 하드닝)이다. 통합
+`TASK-021`은 Web-to-Web P2P 연결을 최초로 증명했고, `TASK-022`는 일반 계정 trip의 document registry 등록 갭을 해소했다. `TASK-023`은 Mobile 배선까지 확장했다. 다음 권장 순서는
+`TASK-024`(실제 데이터 교환) → `TASK-025`(UI) → `TASK-026`(생명주기 하드닝)이다. 통합
 테스트 케이스/코드는 이 구현들이 어느 정도 갖춰진 뒤 별도로 작성한다.

--- a/packages/core/src/sync/__tests__/signalingChannel.test.ts
+++ b/packages/core/src/sync/__tests__/signalingChannel.test.ts
@@ -62,4 +62,17 @@ async function run(): Promise<void> {
   if (topic !== topicAgain) {
     throw new Error('Signaling room topic derivation must be deterministic.')
   }
+
+  const rnShapedTopic = await deriveSignalingRoomTopic(documentId, {
+    digest: async (algorithm, data) => {
+      // Mobile passes a SubtleCrypto-shaped provider from react-native-quick-crypto.
+      // This checks that the shared derivation contract only relies on digest()
+      // semantics and produces the exact same room topic as Web/server.
+      return globalThis.crypto.subtle.digest(algorithm, data)
+    },
+  })
+
+  if (rnShapedTopic !== topic) {
+    throw new Error('React Native-shaped digest provider must derive the same signaling room topic.')
+  }
 }

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -210,3 +210,50 @@ document registry를 보장하도록 TASK-022를 구현했다.
 - 이번 작업은 Web local-first adapter 배선이다. Mobile은 TASK-019 owner bootstrap 경로를 유지한다.
 - 실제 Supabase row 생성 E2E 수동 확인은 dual-write 모드와 로컬/개발 Supabase 인스턴스가 필요하다. 이번 세션에서는 코드 레벨 통합 정합성과 빌드 검증까지 완료했다.
 - 다음 권장 작업은 TASK-023 Mobile signaling channel wiring이다.
+
+---
+
+# Walkthrough: TASK-023 Mobile Signaling Channel Wiring
+
+## Summary
+
+TASK-021에서 Web-to-Web으로만 증명했던 Supabase Realtime signaling channel과 WebRTC data-channel handshake를 Mobile까지 확장했다. Mobile은 Web과 같은 `@nexvoy/core/sync/signalingChannel` 메시지 타입과 `signaling:<sha256(documentId)>` room topic 규칙을 재사용한다. Yjs update 실제 교환, 사용자 UI, background/reconnect lifecycle은 후속 TASK-024~026 범위로 유지한다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-023-mobile-signaling-channel-wiring.md`
+- GitHub Issue [#303](https://github.com/ysjee141/nexvoy-frontend/issues/303)
+- 브랜치: `feature/task-023-mobile-signaling-channel-wiring-303`
+- `_workspace/01_planner_analysis.md`
+- `_workspace/02b_frontend_changes.md`
+- `_workspace/03_review_result.md`
+- `_workspace/04_qa_result.md`
+
+## Key Changes
+
+- `apps/mobile/lib/local-first/signalingChannel.ts`(신규): RN Supabase client로 private Realtime Broadcast channel에 join. `validateSignalingJoinPolicy()`는 Web과 동일하게 client-side fail-fast guard로만 사용하고, 접근 경계는 TASK-021 Realtime Authorization RLS에 둔다.
+- `mobileSignalingDigestProvider`: `react-native-quick-crypto`의 `subtle.digest()`를 `SignalingRoomDigestProvider` 형태로 감싸 core의 `deriveSignalingRoomTopic()`을 그대로 재사용한다.
+- `apps/mobile/lib/local-first/webRtcProvider.native.ts`: `createMobileHandshakeDataChannel()` / `wireMobileHandshakeDataChannel()` 추가. `{type, ts}` 고정 스키마의 ping/pong만 전송하며 document content나 CRDT update는 보내지 않는다.
+- `apps/mobile/lib/local-first/webP2PConnection.ts`(신규): `connectMobileP2PPeer()`로 ICE config, mobile WebRTC provider, mobile signaling channel을 조립해 offer/answer/ICE candidate를 교환한다. signaling join 이후 peer connection 생성 실패 시 channel/provider cleanup을 수행한다.
+- `packages/core/src/sync/__tests__/signalingChannel.test.ts`: RN-shaped digest provider도 Web/server와 같은 room topic을 산출하는지 검증을 추가했다.
+- `docs/refactor/tasks/README.md`: TASK-023 상태를 완료로 갱신하고 다음 권장 순서를 TASK-024부터로 조정했다.
+
+## Verification
+
+- `pnpm --filter @nexvoy/core test` 성공
+- `pnpm --filter @nexvoy/core typecheck` 성공
+- `pnpm --filter nexvoy-app typecheck` 성공
+- `pnpm --filter nexvoy-app lint` 성공(기존 warning 7건 유지, 신규 warning 없음)
+- `pnpm --filter nexvoy-app build` 성공
+- `pnpm typecheck` 성공
+- `pnpm build` 성공
+- `pnpm build:mobile` 성공
+
+## Rollback
+
+신규 조립 지점(`webP2PConnection.ts`)은 아직 UI에서 호출하지 않으므로 파일 제거 또는 import 차단만으로 기존 기능 영향 없이 비활성화할 수 있다. DB schema 변경은 없고, TASK-021의 signaling RLS도 변경하지 않았다.
+
+## Notes
+
+- 실제 Web-Mobile, Mobile-Mobile 연결 수동 검증은 dev client와 두 세션/두 기기 환경이 필요해 이번 세션에서는 수행하지 못했다. 자동 검증은 room topic 계약, 타입/빌드 정합성, payload 제한을 확인하는 수준이다.
+- Mobile background 전환 시 연결 유지/정리와 reconnect 정책은 TASK-026 범위로 유지한다.


### PR DESCRIPTION
## Summary
- Add Mobile Supabase Realtime Broadcast signaling channel using the shared TASK-021 signaling message protocol.
- Reuse core room topic derivation with a React Native quick-crypto digest provider.
- Add native WebRTC data-channel ping/pong handshake helpers and a Mobile P2P connection assembly point.
- Update refactor task status and walkthrough for TASK-023.

## Verification
- pnpm --filter @nexvoy/core test
- pnpm --filter @nexvoy/core typecheck
- pnpm --filter nexvoy-app typecheck
- pnpm --filter nexvoy-app lint (passes with existing warnings only)
- pnpm --filter nexvoy-app build
- pnpm typecheck
- pnpm build
- pnpm build:mobile

## Notes
- No DB schema/RLS changes; this reuses TASK-021 Realtime Authorization.
- Actual Web-Mobile and Mobile-Mobile runtime verification still requires dev client/two-session device setup.

Resolves #303