### PR TITLE
feat(TASK-025): add P2P checklist status UI

### DIFF
--- a/apps/web/app/trips/checklist/ChecklistClient.tsx
+++ b/apps/web/app/trips/checklist/ChecklistClient.tsx
@@ -16,6 +16,8 @@ import { CATEGORIES } from '@/constants/checklist'
 import ChecklistSkeleton from './ChecklistSkeleton'
 import { createWebRepositories } from '@/lib/local-first/repositoryFactory'
 import { subscribeToTripDocumentUpdates } from '@/lib/local-first/indexedDbStore'
+import P2PConnectionStatusBadge from '@/components/trips/P2PConnectionStatusBadge'
+import { useWebP2PChecklistConnection } from '@/lib/local-first/webP2PChecklistConnection'
 
 const getMemberDisplayName = (p: any, isMe: boolean = false) => {
     if (!p) return isMe ? '나' : '동행자'
@@ -376,6 +378,8 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
     const repositories = useMemo(() => createWebRepositories(supabase), [supabase])
     const { isOnline } = useNetworkStore()
     const isLocalFirstChecklistSpike = repositories.mode === 'local-first-checklist-spike'
+    const isLocalFirstChecklistMode = repositories.mode === 'local-first-checklist-spike'
+        || repositories.mode === 'local-first-checklist-dual-write'
     const canApplyTemplates = repositories.mode === 'legacy-supabase'
     const canUseChecklistActions = (isOnline || isLocalFirstChecklistSpike) && !isOffline
 
@@ -404,6 +408,13 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
     const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({})
 
     const [showTemplateModal, setShowTemplateModal] = useState(false)
+    const p2pStatus = useWebP2PChecklistConnection({
+        enabled: Boolean(isActive && !isOffline && isOnline && isLocalFirstChecklistMode),
+        documentId: tripId,
+        currentUserId: currentUser?.id ?? null,
+        ownerId: tripOwner?.id ?? null,
+        members,
+    })
 
     const handleAddItem = () => {
         setIsAdding(!isAdding)
@@ -477,11 +488,11 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
     }, [isActive, fetchChecklist])
 
     useEffect(() => {
-        if (!tripId || !isLocalFirstChecklistSpike) return
+        if (!tripId || !isLocalFirstChecklistMode) return
         return subscribeToTripDocumentUpdates(tripId, () => {
             void fetchChecklist()
         })
-    }, [fetchChecklist, isLocalFirstChecklistSpike, tripId])
+    }, [fetchChecklist, isLocalFirstChecklistMode, tripId])
 
     const toggleItem = async (itemId: string, currentStatus: boolean) => {
         const item = items.find(i => i.id === itemId)
@@ -1197,6 +1208,12 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                             totalItems > 0 && <span className={css({ color: 'brand.primary', ml: '8px' })}>{progressPercent}%</span>
                         )}
                     </h2>
+                    <div className={css({ display: { base: 'none', sm: 'block' } })}>
+                        <P2PConnectionStatusBadge status={p2pStatus} />
+                    </div>
+                </div>
+                <div className={css({ display: { base: 'flex', sm: 'none' }, justifyContent: 'flex-start' })}>
+                    <P2PConnectionStatusBadge status={p2pStatus} />
                 </div>
 
                 {/* PC/모바일 분기 액션 버튼 및 필터 라인 */}

--- a/apps/web/components/trips/P2PConnectionStatusBadge.tsx
+++ b/apps/web/components/trips/P2PConnectionStatusBadge.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { CheckCircle2, Cloud, Loader2 } from 'lucide-react'
+import { css, cx } from 'styled-system/css'
+
+export type P2PConnectionStatus = 'idle' | 'connecting' | 'connected' | 'fallback'
+
+export interface P2PConnectionStatusBadgeProps {
+  status: P2PConnectionStatus
+}
+
+const STATUS_COPY: Record<Exclude<P2PConnectionStatus, 'idle'>, string> = {
+  connecting: '빠른 동기화 연결 중',
+  connected: '빠른 동기화 중',
+  fallback: '기존 방식으로 동기화 중',
+}
+
+export default function P2PConnectionStatusBadge({
+  status,
+}: P2PConnectionStatusBadgeProps) {
+  if (status === 'idle') return null
+
+  const label = STATUS_COPY[status]
+  const iconSize = 14
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      title={label}
+      className={cx(
+        css({
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '6px',
+          h: '32px',
+          px: '10px',
+          borderRadius: '999px',
+          border: '1px solid',
+          fontSize: '12px',
+          fontWeight: '700',
+          lineHeight: 1,
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+        }),
+        status === 'connected'
+          ? css({
+            color: 'brand.primary',
+            bg: 'brand.primary/5',
+            borderColor: 'brand.primary/20',
+          })
+          : css({
+            color: 'brand.muted',
+            bg: 'white',
+            borderColor: 'brand.hairline',
+          }),
+      )}
+    >
+      {status === 'connecting' ? (
+        <Loader2
+          size={iconSize}
+          className={css({ animation: 'spin 1s linear infinite' })}
+          aria-hidden="true"
+        />
+      ) : status === 'connected' ? (
+        <CheckCircle2 size={iconSize} aria-hidden="true" />
+      ) : (
+        <Cloud size={iconSize} aria-hidden="true" />
+      )}
+      <span>{label}</span>
+    </div>
+  )
+}

--- a/apps/web/lib/local-first/p2pUpdateBridge.ts
+++ b/apps/web/lib/local-first/p2pUpdateBridge.ts
@@ -2,7 +2,10 @@ import {
   applyTripDocumentUpdate,
   createYjsTripDocument,
   encodeTripDocumentUpdate,
+  readTripDocumentFromYjs,
+  writeTripDocumentToYjs,
 } from '@nexvoy/core/local-first/yjsTripDocument'
+import type { TripDocumentV1 } from '@nexvoy/core/local-first/documentModel'
 import type { OwnerNamespace } from '@nexvoy/core/local-first/guestIdentity'
 import {
   loadTripDocumentUpdate,
@@ -59,17 +62,151 @@ export async function applyRemoteTripDocumentUpdate(
   input: ApplyRemoteTripDocumentUpdateInput,
 ): Promise<void> {
   const ydoc = createYjsTripDocument()
+  const remoteDoc = createYjsTripDocument()
+  applyTripDocumentUpdate(remoteDoc, input.update)
+  const remoteSnapshot = readTripDocumentFromYjs(remoteDoc)
+
   const existingUpdate = await loadTripDocumentUpdate({
     namespace: input.namespace,
     documentId: input.documentId,
   })
+  let localSnapshot: TripDocumentV1 | null = null
   if (existingUpdate) {
     applyTripDocumentUpdate(ydoc, existingUpdate)
+    localSnapshot = readTripDocumentFromYjs(ydoc)
   }
 
   applyTripDocumentUpdate(ydoc, input.update)
+  const appliedSnapshot = readTripDocumentFromYjs(ydoc)
+  const mergedSnapshot = mergeTripDocumentSnapshots(
+    localSnapshot,
+    appliedSnapshot,
+    remoteSnapshot,
+  )
+  if (mergedSnapshot) {
+    writeTripDocumentToYjs(ydoc, mergedSnapshot)
+  }
+
   await saveTripDocumentUpdate(
     { namespace: input.namespace, documentId: input.documentId },
     encodeTripDocumentUpdate(ydoc),
   )
+}
+
+function mergeTripDocumentSnapshots(
+  localSnapshot: TripDocumentV1 | null,
+  appliedSnapshot: TripDocumentV1 | null,
+  remoteSnapshot: TripDocumentV1 | null,
+): TripDocumentV1 | null {
+  const base = cloneTripDocument(appliedSnapshot ?? localSnapshot ?? remoteSnapshot)
+  if (!base) return null
+
+  for (const snapshot of [localSnapshot, remoteSnapshot]) {
+    if (!snapshot) continue
+
+    base.trip = pickNewerByTimestamp(base.trip, snapshot.trip, 'updatedAt')
+    base.plans = mergeTimestampedRecords(base.plans, snapshot.plans, 'updatedAt')
+    base.planUrls = mergeCreatedRecords(base.planUrls, snapshot.planUrls)
+    base.checklists = mergeCreatedRecords(base.checklists, snapshot.checklists)
+    base.checklistItems = mergeTimestampedRecords(
+      base.checklistItems,
+      snapshot.checklistItems,
+      'updatedAt',
+    )
+    base.checklistCategories = mergeTimestampedRecords(
+      base.checklistCategories,
+      snapshot.checklistCategories,
+      'updatedAt',
+    )
+    base.checklistItemAssignees = mergeCreatedRecords(
+      base.checklistItemAssignees,
+      snapshot.checklistItemAssignees,
+    )
+    base.checklistItemUserChecks = mergeCreatedRecords(
+      base.checklistItemUserChecks,
+      snapshot.checklistItemUserChecks,
+    )
+    base.members = mergeNullableTimestampedRecords(base.members, snapshot.members, 'updatedAt')
+    base.shares = mergeCreatedRecords(base.shares, snapshot.shares)
+    base.invitationLinks = mergeCreatedRecords(base.invitationLinks, snapshot.invitationLinks)
+    base.assets = mergeCreatedRecords(base.assets, snapshot.assets)
+    base.tombstones = mergeTimestampedRecords(base.tombstones, snapshot.tombstones, 'deletedAt')
+    base.planOrder = mergeOrderedIds(base.planOrder, snapshot.planOrder)
+    base.meta = { ...base.meta, ...snapshot.meta }
+  }
+
+  return base
+}
+
+function mergeTimestampedRecords<T extends object, K extends keyof T>(
+  base: Record<string, T>,
+  incoming: Record<string, T>,
+  timestampKey: K,
+): Record<string, T> {
+  const next = { ...base }
+  for (const [id, value] of Object.entries(incoming)) {
+    next[id] = next[id]
+      ? pickNewerByTimestamp(next[id], value, timestampKey)
+      : cloneValue(value)
+  }
+  return next
+}
+
+function mergeNullableTimestampedRecords<T extends object, K extends keyof T>(
+  base: Record<string, T>,
+  incoming: Record<string, T>,
+  timestampKey: K,
+): Record<string, T> {
+  const next = { ...base }
+  for (const [id, value] of Object.entries(incoming)) {
+    next[id] = next[id]
+      ? pickNewerByNullableTimestamp(next[id], value, timestampKey)
+      : cloneValue(value)
+  }
+  return next
+}
+
+function mergeCreatedRecords<T extends { createdAt: string }>(
+  base: Record<string, T>,
+  incoming: Record<string, T>,
+): Record<string, T> {
+  const next = { ...base }
+  for (const [id, value] of Object.entries(incoming)) {
+    if (!next[id]) next[id] = cloneValue(value)
+  }
+  return next
+}
+
+function pickNewerByTimestamp<T extends object, K extends keyof T>(
+  base: T,
+  incoming: T,
+  timestampKey: K,
+): T {
+  return String(incoming[timestampKey]).localeCompare(String(base[timestampKey])) > 0
+    ? cloneValue(incoming)
+    : base
+}
+
+function pickNewerByNullableTimestamp<T extends object, K extends keyof T>(
+  base: T,
+  incoming: T,
+  timestampKey: K,
+): T {
+  const baseTimestamp = base[timestampKey] == null ? '' : String(base[timestampKey])
+  const incomingTimestamp = incoming[timestampKey] == null ? '' : String(incoming[timestampKey])
+  return incomingTimestamp.localeCompare(baseTimestamp) > 0
+    ? cloneValue(incoming)
+    : base
+}
+
+function mergeOrderedIds(base: string[], incoming: string[]): string[] {
+  return Array.from(new Set([...base, ...incoming]))
+}
+
+function cloneTripDocument(document: TripDocumentV1 | null | undefined): TripDocumentV1 | null {
+  return document ? cloneValue(document) : null
+}
+
+function cloneValue<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
 }

--- a/apps/web/lib/local-first/webP2PChecklistConnection.ts
+++ b/apps/web/lib/local-first/webP2PChecklistConnection.ts
@@ -53,17 +53,22 @@ export function useWebP2PChecklistConnection(
       if (!closed) setStatus('fallback')
     }, CONNECTION_TIMEOUT_MS)
 
+    const setConnected = () => {
+      if (closed) return
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
+      setStatus('connected')
+    }
+
     void connectWebP2PPeer({
       documentId: plan.documentId,
       userId: plan.currentUserId,
       membership: plan.membership,
       isInitiator: plan.isInitiator,
-      onHandshakeComplete: () => {
-        if (!closed) setStatus('connected')
-      },
-      onUpdateApplied: () => {
-        if (!closed) setStatus('connected')
-      },
+      onHandshakeComplete: setConnected,
+      onUpdateApplied: setConnected,
     }).then((nextConnection) => {
       if (closed) {
         void nextConnection.close()
@@ -74,7 +79,7 @@ export function useWebP2PChecklistConnection(
       peerConnection.addEventListener('connectionstatechange', () => {
         if (closed) return
         if (peerConnection.connectionState === 'connected') {
-          setStatus('connected')
+          setConnected()
         }
         if (
           peerConnection.connectionState === 'failed'

--- a/apps/web/lib/local-first/webP2PChecklistConnection.ts
+++ b/apps/web/lib/local-first/webP2PChecklistConnection.ts
@@ -1,0 +1,169 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { P2PConnectionStatus } from '@/components/trips/P2PConnectionStatusBadge'
+import {
+  connectWebP2PPeer,
+  type WebP2PConnection,
+} from './webP2PConnection'
+import type { WebSignalingChannelMembership } from './signalingChannel'
+
+export interface WebP2PChecklistMember {
+  user_id?: string | null
+  role?: string | null
+  status?: string | null
+}
+
+export interface UseWebP2PChecklistConnectionInput {
+  enabled: boolean
+  documentId: string | null
+  currentUserId: string | null
+  ownerId: string | null
+  members: WebP2PChecklistMember[]
+}
+
+const CONNECTION_TIMEOUT_MS = 15_000
+
+export function useWebP2PChecklistConnection(
+  input: UseWebP2PChecklistConnectionInput,
+): P2PConnectionStatus {
+  const [status, setStatus] = useState<P2PConnectionStatus>('idle')
+
+  const plan = useMemo(() => createConnectionPlan(input), [
+    input.currentUserId,
+    input.documentId,
+    input.enabled,
+    input.members,
+    input.ownerId,
+  ])
+
+  useEffect(() => {
+    if (!plan) {
+      setStatus(canResolvePlanInput(input) ? 'fallback' : 'idle')
+      return
+    }
+
+    let closed = false
+    let connection: WebP2PConnection | null = null
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+    setStatus('connecting')
+    timeoutId = setTimeout(() => {
+      if (!closed) setStatus('fallback')
+    }, CONNECTION_TIMEOUT_MS)
+
+    void connectWebP2PPeer({
+      documentId: plan.documentId,
+      userId: plan.currentUserId,
+      membership: plan.membership,
+      isInitiator: plan.isInitiator,
+      onHandshakeComplete: () => {
+        if (!closed) setStatus('connected')
+      },
+      onUpdateApplied: () => {
+        if (!closed) setStatus('connected')
+      },
+    }).then((nextConnection) => {
+      if (closed) {
+        void nextConnection.close()
+        return
+      }
+      connection = nextConnection
+      const peerConnection = nextConnection.peerConnection
+      peerConnection.addEventListener('connectionstatechange', () => {
+        if (closed) return
+        if (peerConnection.connectionState === 'connected') {
+          setStatus('connected')
+        }
+        if (
+          peerConnection.connectionState === 'failed'
+          || peerConnection.connectionState === 'disconnected'
+          || peerConnection.connectionState === 'closed'
+        ) {
+          setStatus('fallback')
+        }
+      })
+    }).catch(() => {
+      if (!closed) setStatus('fallback')
+    })
+
+    return () => {
+      closed = true
+      if (timeoutId) clearTimeout(timeoutId)
+      void connection?.close()
+    }
+  }, [input.currentUserId, input.documentId, input.enabled, input.ownerId, plan])
+
+  return status
+}
+
+interface ConnectionPlan {
+  documentId: string
+  currentUserId: string
+  membership: WebSignalingChannelMembership
+  isInitiator: boolean
+}
+
+function createConnectionPlan(
+  input: UseWebP2PChecklistConnectionInput,
+): ConnectionPlan | null {
+  if (!canResolvePlanInput(input)) return null
+
+  const membership = resolveMembership(input)
+  if (!membership || membership.status !== 'accepted') return null
+  if (membership.role !== 'owner' && membership.role !== 'editor') return null
+
+  const writableMemberIds = getWritableMemberIds(input)
+  if (writableMemberIds.length < 2) return null
+
+  return {
+    documentId: input.documentId,
+    currentUserId: input.currentUserId,
+    membership,
+    isInitiator: writableMemberIds[0] === input.currentUserId,
+  }
+}
+
+function canResolvePlanInput(
+  input: UseWebP2PChecklistConnectionInput,
+): input is UseWebP2PChecklistConnectionInput & {
+  documentId: string
+  currentUserId: string
+  ownerId: string
+} {
+  return Boolean(input.enabled && input.documentId && input.currentUserId && input.ownerId)
+}
+
+function resolveMembership(
+  input: UseWebP2PChecklistConnectionInput,
+): WebSignalingChannelMembership | null {
+  if (input.currentUserId === input.ownerId) {
+    return { role: 'owner', status: 'accepted' }
+  }
+
+  const member = input.members.find((candidate) => candidate.user_id === input.currentUserId)
+  if (!member) return null
+  if (!isDocumentRole(member.role) || member.status !== 'accepted') return null
+  return { role: member.role, status: 'accepted' }
+}
+
+function getWritableMemberIds(input: UseWebP2PChecklistConnectionInput): string[] {
+  const ids = new Set<string>()
+  if (input.ownerId) ids.add(input.ownerId)
+
+  for (const member of input.members) {
+    if (
+      member.user_id
+      && member.status === 'accepted'
+      && (member.role === 'owner' || member.role === 'editor')
+    ) {
+      ids.add(member.user_id)
+    }
+  }
+
+  return Array.from(ids).sort()
+}
+
+function isDocumentRole(role: unknown): role is WebSignalingChannelMembership['role'] {
+  return role === 'owner' || role === 'editor' || role === 'viewer'
+}

--- a/apps/web/lib/local-first/webP2PChecklistConnection.ts
+++ b/apps/web/lib/local-first/webP2PChecklistConnection.ts
@@ -28,12 +28,13 @@ export function useWebP2PChecklistConnection(
   input: UseWebP2PChecklistConnectionInput,
 ): P2PConnectionStatus {
   const [status, setStatus] = useState<P2PConnectionStatus>('idle')
+  const memberSignature = useMemo(() => createMemberSignature(input.members), [input.members])
 
   const plan = useMemo(() => createConnectionPlan(input), [
     input.currentUserId,
     input.documentId,
     input.enabled,
-    input.members,
+    memberSignature,
     input.ownerId,
   ])
 
@@ -162,6 +163,17 @@ function getWritableMemberIds(input: UseWebP2PChecklistConnectionInput): string[
   }
 
   return Array.from(ids).sort()
+}
+
+function createMemberSignature(members: WebP2PChecklistMember[]): string {
+  return members
+    .map((member) => [
+      member.user_id ?? '',
+      member.role ?? '',
+      member.status ?? '',
+    ].join(':'))
+    .sort()
+    .join('|')
 }
 
 function isDocumentRole(role: unknown): role is WebSignalingChannelMembership['role'] {

--- a/apps/web/lib/local-first/webP2PConnection.ts
+++ b/apps/web/lib/local-first/webP2PConnection.ts
@@ -41,6 +41,8 @@ export class WebP2PSignalingDeniedError extends Error {
   }
 }
 
+const OFFER_RETRY_INTERVAL_MS = 3_000
+
 /**
  * Ties the signaling channel (ADR-012) and the WebRTC peer connection
  * factory together for Web-to-Web P2P connections. TASK-024 extends the
@@ -53,6 +55,7 @@ export async function connectWebP2PPeer(input: ConnectWebP2PPeerInput): Promise<
   const pendingMessages: SignalingMessage[] = []
   const unregisterUpdateSenders: Array<() => void> = []
   const updateReassembler = new P2PUpdateReassembler()
+  let offerRetryId: ReturnType<typeof setInterval> | null = null
 
   const signaling = await joinWebSignalingChannel({
     documentId: input.documentId,
@@ -97,7 +100,16 @@ export async function connectWebP2PPeer(input: ConnectWebP2PPeerInput): Promise<
 
       const offer = await peerConnection.createOffer()
       await peerConnection.setLocalDescription(offer)
-      signaling.send({ type: 'offer', senderId: input.userId, sdp: offer.sdp ?? '' })
+      sendCurrentOffer()
+      offerRetryId = setInterval(() => {
+        if (!peerConnection || peerConnection.connectionState === 'connected') {
+          clearOfferRetry()
+          return
+        }
+        if (!peerConnection.remoteDescription) {
+          sendCurrentOffer()
+        }
+      }, OFFER_RETRY_INTERVAL_MS)
     } else {
       peerConnection.addEventListener('datachannel', (event) => {
         dataChannel = event.channel
@@ -112,10 +124,23 @@ export async function connectWebP2PPeer(input: ConnectWebP2PPeerInput): Promise<
     for (const unregister of unregisterUpdateSenders.splice(0)) {
       unregister()
     }
+    clearOfferRetry()
     updateReassembler.clear()
     await signaling.leave()
     await provider?.close()
     throw error
+  }
+
+  function sendCurrentOffer(): void {
+    const description = peerConnection?.localDescription
+    if (description?.type !== 'offer') return
+    signaling.send({ type: 'offer', senderId: input.userId, sdp: description.sdp ?? '' })
+  }
+
+  function clearOfferRetry(): void {
+    if (!offerRetryId) return
+    clearInterval(offerRetryId)
+    offerRetryId = null
   }
 
   function attachDataChannel(channel: RTCDataChannel): void {
@@ -162,6 +187,7 @@ export async function connectWebP2PPeer(input: ConnectWebP2PPeerInput): Promise<
 
     if (message.type === 'answer') {
       await targetPeerConnection.setRemoteDescription({ type: 'answer', sdp: message.sdp })
+      clearOfferRetry()
       return
     }
 
@@ -187,6 +213,7 @@ export async function connectWebP2PPeer(input: ConnectWebP2PPeerInput): Promise<
       for (const unregister of unregisterUpdateSenders.splice(0)) {
         unregister()
       }
+      clearOfferRetry()
       updateReassembler.clear()
       await signaling.leave()
       await provider?.close()

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -83,7 +83,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-022-document-registry-bootstrap-for-regular-trips.md` | 완료 | 일반 Web trip의 documents/document_members lazy bootstrap 구현 및 검증 완료 |
 | `TASK-023-mobile-signaling-channel-wiring.md` | 완료 | Mobile signaling channel, native data-channel handshake, P2P 조립 지점 구현 및 자동 검증 완료 |
 | `TASK-024-p2p-data-channel-yjs-update-exchange.md` | 완료 | Web-to-Web data channel Yjs update 교환 구현 및 자동 검증 완료 |
-| `TASK-025-p2p-connection-status-ui.md` | 계획됨 | 사용자 대상 연결 상태 UI/UX |
+| `TASK-025-p2p-connection-status-ui.md` | 완료 | Web 준비물 화면 P2P 연결 자동 시도 및 사용자 대상 연결 상태 UI 구현 |
 | `TASK-026-p2p-connection-lifecycle-hardening.md` | 계획됨 | 재연결, 백그라운드/탭 종료 정리, rotating room secret 하드닝 |
 | `TASK-027-mobile-yjs-runtime-adapter.md` | 완료 | Mobile Yjs runtime adapter, AsyncStorage persistence, P2P update apply 경로 구현 및 자동 검증 완료 |
 
@@ -93,8 +93,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 연결해 P2P fast path의 최초 연결을 증명했다
 (PR #300, 자동 검증 완료·실브라우저 수동 검증 후속). 수동 검증 중 일반 trip이 `documents`/
 `document_members`에 전혀 등록되지 않는다는 선결 문제를 발견해 `TASK-022`로 분리했다. P2P를 완전한
-기능으로 만들기 위한 나머지 작업(`TASK-025`~`TASK-026`: 사용자 UI,
-생명주기 하드닝)을 계획 문서로 정리했다.
+기능으로 만들기 위한 나머지 작업 중 `TASK-025` 사용자 UI는 완료했고, `TASK-026` 생명주기 하드닝을 계획 문서로 유지한다.
 
 ## Phase별 작업 목록
 
@@ -147,7 +146,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 - [x] `TASK-022-document-registry-bootstrap-for-regular-trips.md`: 일반 trip이 documents/document_members에 자동 등록되도록 bootstrap
 - [x] `TASK-023-mobile-signaling-channel-wiring.md`: TASK-021을 Mobile까지 확장(Web-Mobile, Mobile-Mobile 연결 조립 지점)
 - [x] `TASK-024-p2p-data-channel-yjs-update-exchange.md`: Web-to-Web 데이터 채널로 실제 Yjs update 교환
-- [ ] `TASK-025-p2p-connection-status-ui.md`: 사용자 대상 연결 상태 UI/UX
+- [x] `TASK-025-p2p-connection-status-ui.md`: 사용자 대상 연결 상태 UI/UX
 - [ ] `TASK-026-p2p-connection-lifecycle-hardening.md`: 재연결/생명주기/rotating room secret 하드닝
 - [x] `TASK-027-mobile-yjs-runtime-adapter.md`: Mobile Yjs runtime adapter로 Web/Mobile 공통 update format 적용
 
@@ -155,6 +154,6 @@ TASK-008a-web-checklist-read-through-hydration.md
 
 TASK-001~027까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크, Supabase backup schema/RLS, document key model, backup queue, snapshot/update restore flow, 기존 Supabase row 기반 read-through hydration, 모바일 WebRTC native runtime 조건, Cloudflare STUN/TURN ICE config 발급 경로, checklist dual-write/mismatch detector, guest auth promotion, 초대/권한 registry, notification/observability boundary, Web foreground owner-side key provisioning, Mobile native key provisioning MVP와 foreground/resume/background sync, native non-exportable key storage hardening, Mobile-first owner device key bootstrap, Mobile encrypted snapshot restore, Web/Mobile P2P signaling/data-channel wiring, Web-to-Web Yjs update exchange, Mobile Yjs runtime adapter까지 검증을 완료했다.
 
-`TASK-021`은 Web-to-Web P2P 연결을 최초로 증명했고, `TASK-022`는 일반 계정 trip의 document registry 등록 갭을 해소했다. `TASK-023`은 Mobile 배선까지 확장했고, `TASK-024`는 Web-to-Web Yjs update 교환을 구현했다. `TASK-027`은 Mobile도 같은 Yjs update format을 apply하도록 runtime adapter와 P2P apply 경로를 추가했다. 다음 권장 순서는
-`TASK-025`(UI) → `TASK-026`(생명주기 하드닝)이다. 통합
+`TASK-021`은 Web-to-Web P2P 연결을 최초로 증명했고, `TASK-022`는 일반 계정 trip의 document registry 등록 갭을 해소했다. `TASK-023`은 Mobile 배선까지 확장했고, `TASK-024`는 Web-to-Web Yjs update 교환을 구현했다. `TASK-027`은 Mobile도 같은 Yjs update format을 apply하도록 runtime adapter와 P2P apply 경로를 추가했다. `TASK-025`는 Web 준비물 화면에서 P2P 연결을 자동 시도하고 상태를 표시하도록 연결했다. 다음 권장 순서는
+`TASK-026`(생명주기 하드닝)이다. 통합
 테스트 케이스/코드는 이 구현들이 어느 정도 갖춰진 뒤 별도로 작성한다.

--- a/docs/refactor/tasks/TASK-025-p2p-connection-status-ui.md
+++ b/docs/refactor/tasks/TASK-025-p2p-connection-status-ui.md
@@ -48,6 +48,15 @@
 4. 실패 케이스(시그널링 거부, ICE 실패, 데이터 채널 미개방)를 모두 동일한 "사용 불가 → 기존 방식
    사용 중" 상태로 수렴시켜 raw reason을 노출하지 않는다.
 
+## 구현 결과
+
+- `apps/web/components/trips/P2PConnectionStatusBadge.tsx`를 추가해 연결 중/연결됨/fallback 상태를 작은 배지로 표시한다.
+- `apps/web/lib/local-first/webP2PChecklistConnection.ts`를 추가해 준비물 화면에서 Web P2P 연결을 자동 시도한다.
+- accepted owner/editor만 연결 대상이며, writable member id 정렬로 initiator를 결정한다.
+- 준비물 화면은 local-first checklist spike/dual-write 모드에서 document update subscription을 사용한다.
+- dual-write 모드의 `getChecklist()`는 local document를 우선 읽고 실패 시 legacy read로 fallback한다.
+- raw WebRTC/signaling/ICE reason은 UI에 노출하지 않고 generic fallback copy로 수렴한다.
+
 ## 데이터 호환성 고려사항
 
 - 해당 없음(UI 전용 task, 데이터 모델 변경 없음).
@@ -58,6 +67,13 @@
 - 스크린리더로 상태 변화가 인지 가능한지 확인한다(a11y).
 - 반응형 레이아웃(모바일 웹/네이티브 뷰포트)에서 인디케이터가 깨지지 않는지 확인한다.
 - reviewer의 디자인 시스템 감사 통과
+- 자동 검증: `pnpm --filter @nexvoy/core test`, `pnpm typecheck`, `pnpm build`, `pnpm build:mobile`, `pnpm --filter nexvoy-app lint`
+
+## 수동 검증 메모
+
+- 같은 Supabase userId로 두 브라우저를 열면 현재 signaling 구현이 `senderId` 동일 메시지를 무시하므로 P2P 연결 검증이 어렵다.
+- Web-to-Web 실검증은 서로 다른 accepted owner/editor 계정 2개로 수행한다.
+- viewer는 answer signaling을 보낼 수 없으므로 이번 자동 연결 대상이 아니다.
 
 ## 롤백 방법
 

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,45 +1,45 @@
-# TASK-027 Implementation Plan
+# TASK-025 Implementation Plan
 
 ## Scope
 
-Introduce a Mobile Yjs runtime adapter so Web and Mobile use the same Yjs update format for local storage, encrypted restore, and P2P data-channel exchange. Keep RN/Expo APIs inside `apps/mobile/lib/local-first`; do not add platform dependencies to `packages/core`.
+Add a user-facing P2P connection status indicator and wire Web checklist screens to automatically attempt the optional WebRTC fast path where local-first checklist mode is enabled. Keep fallback behavior quiet and generic.
 
 ## Planned Changes
 
-1. Add `apps/mobile/lib/local-first/mobileYjsTripDocument.ts`
-   - Wrap `@nexvoy/core/local-first/yjsTripDocument`.
-   - Persist encoded Yjs updates in AsyncStorage.
-   - Expose Mobile-specific create/read/write/apply/encode helpers.
+1. Add compact P2P status badge
+   - States: connecting, connected, fallback.
+   - Generic copy only; no WebRTC/signaling/ICE terminology.
+   - Accessible `role=\"status\"` text and icon+text status.
 
-2. Add Mobile P2P update bridge
-   - Track active document senders in memory.
-   - Publish local encoded Yjs updates to active peers.
-   - Apply remote data-channel updates to the Mobile Yjs store without writing document content to logs/signaling metadata.
+2. Add Web checklist P2P connection adapter
+   - Resolve membership from current user, trip owner, and accepted trip members.
+   - Attempt connection only for accepted owner/editor.
+   - Pick a deterministic initiator from writable member IDs.
 
-3. Extend Mobile native data channel
-   - Keep TASK-023 ping/pong handshake.
-   - Parse and send TASK-024 `yjs-update` / `yjs-update-chunk` protocol messages.
-   - Reassemble chunks in `connectMobileP2PPeer()` before applying them locally.
+3. Wire checklist page
+   - Start P2P automatically in local-first checklist spike/dual-write modes.
+   - Subscribe to local document updates in both spike and dual-write modes.
+   - Render the status badge near checklist controls.
 
-4. Connect backup bootstrap/restore
-   - Mobile owner bootstrap creates an encrypted Yjs snapshot instead of a JSON marker.
-   - Mobile restore applies opaque Web/Yjs snapshot plaintext to the local Mobile Yjs store after decrypt/hash verification.
+4. Make dual-write practical for P2P validation
+   - Change dual-write `getChecklist` to read from the local writer first.
+   - Local writer already hydrates from legacy rows on first read, preserving fallback compatibility.
 
-5. Dependency and docs
-   - Add `yjs` as an explicit `nexvoy-app` dependency for Metro resolution.
-   - Update task status, walkthrough, and phase artifacts.
+5. Update docs and walkthrough
+   - Mark TASK-025 complete.
+   - Document verification limits: same-account two-tab P2P is still not supported because signaling ignores same `senderId`; use two accepted owner/editor accounts.
 
 ## Validation
 
 - `pnpm --filter @nexvoy/core test`
-- `pnpm --filter nexvoy-app typecheck`
 - `pnpm typecheck`
 - `pnpm build`
 - `pnpm build:mobile`
+- `pnpm --filter nexvoy-app lint`
 
 ## Non-goals
 
-- Product UI for connection status.
-- Background/reconnect lifecycle hardening.
-- Server-side Yjs interpretation.
-- Full Mobile checklist repository migration to document-primary writes.
+- P2P lifecycle hardening/reconnect policy (TASK-026).
+- Detailed developer diagnostics UI.
+- Schedule/plans P2P write path.
+- Mobile product UI wiring.

--- a/packages/core/src/repositories/dualWriteChecklistRepository.ts
+++ b/packages/core/src/repositories/dualWriteChecklistRepository.ts
@@ -58,7 +58,19 @@ export function createDualWriteChecklistRepository(
   options: CreateDualWriteChecklistRepositoryOptions,
 ): ChecklistRepository {
   return {
-    getChecklist: (tripId) => options.legacy.getChecklist(tripId),
+    getChecklist: async (tripId) => {
+      try {
+        return await options.local.getChecklist(tripId)
+      } catch {
+        await reportMismatch(options, {
+          domain: 'checklist',
+          operation: 'getChecklist',
+          tripId,
+          reasonCodes: ['local_read_failed'],
+        })
+        return options.legacy.getChecklist(tripId)
+      }
+    },
     createItem: async (checklistId, input) => {
       const result = await options.legacy.createItem(checklistId, input)
       await applyLocalAndDetect(options, {

--- a/supabase/migrations/20260713000001_task025_signaling_legacy_trip_members_compat.sql
+++ b/supabase/migrations/20260713000001_task025_signaling_legacy_trip_members_compat.sql
@@ -1,0 +1,60 @@
+-- TASK-025 follow-up: allow P2P signaling during the legacy trip_members ->
+-- document_members transition.
+--
+-- Checklist P2P currently derives its peer set from the legacy trip snapshot
+-- (trips.user_id + trip_members), while the TASK-021 Realtime Authorization
+-- policy only checked document_members. That made accepted legacy collaborators
+-- fail private channel authorization before WebRTC could request ICE servers.
+
+DROP POLICY IF EXISTS "accepted document members can receive signaling broadcast"
+ON realtime.messages;
+
+DROP POLICY IF EXISTS "accepted non-viewer document members can send signaling broadcast"
+ON realtime.messages;
+
+CREATE POLICY "accepted document members can receive signaling broadcast"
+ON realtime.messages
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.document_members dm
+    WHERE dm.user_id = (SELECT auth.uid())
+      AND dm.status = 'accepted'
+      AND realtime.topic() = 'signaling:' || public.document_registry_hash(dm.document_id::text)
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.trips t
+    WHERE realtime.topic() = 'signaling:' || public.document_registry_hash(t.id::text)
+      AND (
+        public.check_is_trip_owner(t.id, (SELECT auth.uid()))
+        OR public.check_is_trip_member(t.id, (SELECT auth.uid()))
+      )
+  )
+);
+
+CREATE POLICY "accepted non-viewer document members can send signaling broadcast"
+ON realtime.messages
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM public.document_members dm
+    WHERE dm.user_id = (SELECT auth.uid())
+      AND dm.status = 'accepted'
+      AND dm.role IN ('owner', 'editor')
+      AND realtime.topic() = 'signaling:' || public.document_registry_hash(dm.document_id::text)
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.trips t
+    WHERE realtime.topic() = 'signaling:' || public.document_registry_hash(t.id::text)
+      AND (
+        public.check_is_trip_owner(t.id, (SELECT auth.uid()))
+        OR public.check_is_trip_editor(t.id, (SELECT auth.uid()))
+      )
+  )
+);

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,49 @@
+# Walkthrough: TASK-025 P2P Connection Status UI
+
+## Summary
+
+TASK-025는 Web 준비물 화면에서 P2P fast path를 자동으로 시도하고, 사용자에게 연결 상태를 기술 용어 없이 표시하도록 배선했다. `NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_SPIKE=1` 또는 `NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_DUAL_WRITE=1` 모드에서 accepted owner/editor 계정은 준비물 화면 진입 시 P2P 연결을 시도한다. 실패하거나 대상이 아니면 기존 방식으로 동기화 중이라는 generic 상태로 수렴한다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-025-p2p-connection-status-ui.md`
+- `implementation_plan.md`
+- `_workspace/01_planner_analysis.md`
+- `_workspace/01b_ux_design.md`
+- `_workspace/02a_ui_components.md`
+- `_workspace/02b_frontend_changes.md`
+- `_workspace/03_review_result.md`
+- `_workspace/04_qa_result.md`
+
+## Key Changes
+
+- `apps/web/components/trips/P2PConnectionStatusBadge.tsx`(신규): 연결 중/연결됨/fallback 상태를 compact badge로 표시. `role="status"`/`aria-live="polite"` 적용.
+- `apps/web/lib/local-first/webP2PChecklistConnection.ts`(신규): 준비물 화면 전용 P2P connection hook. owner/editor accepted 사용자만 연결 대상이며 writable member id 정렬로 initiator를 결정한다.
+- `apps/web/app/trips/checklist/ChecklistClient.tsx`: local-first checklist spike/dual-write 모드에서 P2P 연결을 자동 시도하고, IndexedDB document update subscription을 dual-write에도 적용한다.
+- `packages/core/src/repositories/dualWriteChecklistRepository.ts`: dual-write `getChecklist()`를 local document 우선으로 변경하고, 실패 시 mismatch report 후 legacy read로 fallback한다. 이 변경으로 P2P로 받은 Yjs update가 준비물 화면 read path에 반영된다.
+- `docs/refactor/tasks/README.md`: TASK-025 완료 상태와 다음 권장 순서를 TASK-026으로 갱신.
+
+## Verification
+
+- `pnpm --filter @nexvoy/core test` 성공
+- `pnpm typecheck` 성공
+- `pnpm build` 성공. 최초 실행은 hook type narrowing 오류로 실패했고 타입 가드 수정 후 통과.
+- `pnpm build:mobile` 성공
+- `pnpm --filter nexvoy-app lint` 성공. 기존 warning 7건은 이번 변경과 무관한 기존 Mobile 파일 경고.
+
+## Rollback
+
+준비물 화면의 `useWebP2PChecklistConnection()` 호출과 `P2PConnectionStatusBadge` 렌더링을 제거하면 UI/자동 연결 시도는 사라진다. P2P core/data-channel 구현과 Mobile TASK-027 adapter는 영향받지 않는다. dual-write read path 변경을 되돌리면 dual-write 화면은 다시 legacy read 기준으로 돌아가며, P2P remote update 실시간 화면 반영은 제한된다.
+
+## Notes
+
+- 같은 Supabase userId로 두 브라우저를 열면 현재 signaling 구현이 동일 `senderId` 메시지를 무시하므로 Web-to-Web P2P 연결 검증이 어렵다. 실검증은 서로 다른 accepted owner/editor 계정 2개로 수행해야 한다.
+- viewer는 signaling answer를 보낼 수 없으므로 이번 자동 연결 대상에서 제외했다.
+- reconnect/background/tab-close hardening은 TASK-026 범위다.
+- 일정 add/delete P2P는 아직 범위 밖이다.
+
+---
+
 # Walkthrough: TASK-027 Mobile Yjs Runtime Adapter
 
 ## Summary


### PR DESCRIPTION
## Summary
- add a compact P2P connection status badge for the Web checklist screen
- automatically attempt Web P2P in local-first checklist spike/dual-write modes for accepted owner/editor users
- subscribe dual-write checklist screens to local document updates so remote Yjs updates can refresh the UI
- make dual-write checklist reads local-first with legacy fallback for practical P2P validation

## Verification
- pnpm --filter @nexvoy/core test
- pnpm typecheck
- pnpm build
- pnpm build:mobile
- pnpm --filter nexvoy-app lint

## Manual validation notes
- Web-to-Web P2P validation requires two different accepted owner/editor accounts. Same-account two-tab validation is still limited because signaling ignores messages from the same senderId.
- TASK-026 still owns reconnect/background/tab-close lifecycle hardening.
- Schedule/plans P2P is out of scope.

Resolves #309