### PR TITLE
TASK-028: Harden signaling room topics

### DIFF
--- a/apps/mobile/lib/local-first/signalingChannel.ts
+++ b/apps/mobile/lib/local-first/signalingChannel.ts
@@ -1,7 +1,7 @@
 import { subtle } from 'react-native-quick-crypto'
 import {
   SIGNALING_BROADCAST_EVENT,
-  deriveSignalingRoomTopic,
+  isSignalingRoomTopic,
   parseSignalingMessage,
   type SignalingMessage,
   type SignalingRoomDigestProvider,
@@ -31,6 +31,19 @@ export interface MobileSignalingChannel {
   leave(): Promise<void>
 }
 
+interface SignalingRoomTopicRow {
+  room_topic: string
+  expires_at: string
+}
+
+type IssueSignalingRoomTopicRpc = (
+  fn: 'issue_document_signaling_room_topic',
+  args: { p_document_id: string },
+) => Promise<{
+  data: unknown
+  error: { message?: string } | null
+}>
+
 export const mobileSignalingDigestProvider: SignalingRoomDigestProvider = {
   async digest(algorithm, data) {
     const digest = await subtle.digest(algorithm as never, data as never)
@@ -46,14 +59,29 @@ export const mobileSignalingDigestProvider: SignalingRoomDigestProvider = {
 export async function joinMobileSignalingChannel(
   input: JoinMobileSignalingChannelInput,
 ): Promise<MobileSignalingChannel> {
+  const preliminaryDecision = validateSignalingJoinPolicy({
+    documentId: input.documentId,
+    userId: input.userId,
+    role: input.membership.role,
+    status: input.membership.status,
+    hasValidRoomSecretProof: true,
+  })
+
+  if (!preliminaryDecision.allowed) {
+    return {
+      decision: preliminaryDecision,
+      send: () => {},
+      leave: async () => {},
+    }
+  }
+
+  const topic = await fetchIssuedSignalingRoomTopic(input.documentId)
   const decision = validateSignalingJoinPolicy({
     documentId: input.documentId,
     userId: input.userId,
     role: input.membership.role,
     status: input.membership.status,
-    // Rotating room secret issuance is deferred by ADR-012; this mirrors the
-    // Web adapter while server-side Realtime Authorization enforces access.
-    hasValidRoomSecretProof: true,
+    hasValidRoomSecretProof: isSignalingRoomTopic(topic),
   })
 
   if (!decision.allowed) {
@@ -64,7 +92,6 @@ export async function joinMobileSignalingChannel(
     }
   }
 
-  const topic = await deriveSignalingRoomTopic(input.documentId, mobileSignalingDigestProvider)
   const channel = supabase.channel(topic, { config: { private: true } })
 
   channel.on(
@@ -104,6 +131,38 @@ export async function joinMobileSignalingChannel(
       await supabase.removeChannel(channel)
     },
   }
+}
+
+async function fetchIssuedSignalingRoomTopic(documentId: string): Promise<string> {
+  const issueTopic = supabase.rpc as unknown as IssueSignalingRoomTopicRpc
+  const { data, error } = await issueTopic('issue_document_signaling_room_topic', {
+    p_document_id: documentId,
+  })
+
+  if (error) {
+    throw new Error('signaling_topic_unavailable')
+  }
+
+  const topic = pickIssuedTopic(data)
+  if (!topic) {
+    throw new Error('invalid_signaling_topic')
+  }
+
+  return topic
+}
+
+function pickIssuedTopic(input: unknown): string | null {
+  if (!Array.isArray(input) || input.length === 0) return null
+  const [first] = input
+  if (!isSignalingRoomTopicRow(first)) return null
+  return isSignalingRoomTopic(first.room_topic) ? first.room_topic : null
+}
+
+function isSignalingRoomTopicRow(input: unknown): input is SignalingRoomTopicRow {
+  return typeof input === 'object'
+    && input !== null
+    && typeof (input as { room_topic?: unknown }).room_topic === 'string'
+    && typeof (input as { expires_at?: unknown }).expires_at === 'string'
 }
 
 function toArrayBuffer(input: ArrayBuffer | ArrayBufferView): ArrayBuffer {

--- a/apps/web/lib/local-first/signalingChannel.ts
+++ b/apps/web/lib/local-first/signalingChannel.ts
@@ -1,6 +1,6 @@
 import {
   SIGNALING_BROADCAST_EVENT,
-  deriveSignalingRoomTopic,
+  isSignalingRoomTopic,
   parseSignalingMessage,
   type SignalingMessage,
 } from '@nexvoy/core/sync/signalingChannel'
@@ -30,6 +30,19 @@ export interface WebSignalingChannel {
   leave(): Promise<void>
 }
 
+interface SignalingRoomTopicRow {
+  room_topic: string
+  expires_at: string
+}
+
+type IssueSignalingRoomTopicRpc = (
+  fn: 'issue_document_signaling_room_topic',
+  args: { p_document_id: string },
+) => Promise<{
+  data: unknown
+  error: { message?: string } | null
+}>
+
 /**
  * Joins the per-document Supabase Realtime Broadcast private channel used for
  * P2P signaling (ADR-012). The client-side validateSignalingJoinPolicy() check
@@ -41,15 +54,35 @@ export interface WebSignalingChannel {
 export async function joinWebSignalingChannel(
   input: JoinWebSignalingChannelInput,
 ): Promise<WebSignalingChannel> {
+  const preliminaryDecision = validateSignalingJoinPolicy({
+    documentId: input.documentId,
+    userId: input.userId,
+    role: input.membership.role,
+    status: input.membership.status,
+    hasValidRoomSecretProof: true,
+  })
+
+  if (!preliminaryDecision.allowed) {
+    logP2PEvent({
+      name: 'p2p_unavailable',
+      platform: 'web',
+      reason: preliminaryDecision.reason ?? 'signaling_join_denied',
+    })
+    return {
+      decision: preliminaryDecision,
+      send: () => {},
+      leave: async () => {},
+    }
+  }
+
+  const supabase = createClient()
+  const topic = await fetchIssuedSignalingRoomTopic(supabase, input.documentId)
   const decision = validateSignalingJoinPolicy({
     documentId: input.documentId,
     userId: input.userId,
     role: input.membership.role,
     status: input.membership.status,
-    // Rotating room secret issuance is deferred to a follow-up hardening task
-    // (ADR-012); the room topic + Realtime Authorization RLS are the actual
-    // access boundary for this phase, so this guard does not gate on it yet.
-    hasValidRoomSecretProof: true,
+    hasValidRoomSecretProof: isSignalingRoomTopic(topic),
   })
 
   if (!decision.allowed) {
@@ -65,8 +98,6 @@ export async function joinWebSignalingChannel(
     }
   }
 
-  const supabase = createClient()
-  const topic = await deriveSignalingRoomTopic(input.documentId, globalThis.crypto.subtle)
   const channel = supabase.channel(topic, { config: { private: true } })
 
   channel.on(
@@ -113,4 +144,41 @@ export async function joinWebSignalingChannel(
       await supabase.removeChannel(channel)
     },
   }
+}
+
+async function fetchIssuedSignalingRoomTopic(
+  supabase: ReturnType<typeof createClient>,
+  documentId: string,
+): Promise<string> {
+  const issueTopic = supabase.rpc as unknown as IssueSignalingRoomTopicRpc
+  const { data, error } = await issueTopic('issue_document_signaling_room_topic', {
+    p_document_id: documentId,
+  })
+
+  if (error) {
+    logP2PEvent({ name: 'p2p_unavailable', platform: 'web', reason: 'signaling_topic_unavailable' })
+    throw new Error('signaling_topic_unavailable')
+  }
+
+  const topic = pickIssuedTopic(data)
+  if (!topic) {
+    logP2PEvent({ name: 'p2p_unavailable', platform: 'web', reason: 'invalid_signaling_topic' })
+    throw new Error('invalid_signaling_topic')
+  }
+
+  return topic
+}
+
+function pickIssuedTopic(input: unknown): string | null {
+  if (!Array.isArray(input) || input.length === 0) return null
+  const [first] = input
+  if (!isSignalingRoomTopicRow(first)) return null
+  return isSignalingRoomTopic(first.room_topic) ? first.room_topic : null
+}
+
+function isSignalingRoomTopicRow(input: unknown): input is SignalingRoomTopicRow {
+  return typeof input === 'object'
+    && input !== null
+    && typeof (input as { room_topic?: unknown }).room_topic === 'string'
+    && typeof (input as { expires_at?: unknown }).expires_at === 'string'
 }

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -86,7 +86,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-025-p2p-connection-status-ui.md` | 완료 | Web 준비물 화면 P2P 연결 자동 시도 및 사용자 대상 연결 상태 UI 구현 |
 | `TASK-026-p2p-connection-lifecycle-hardening.md` | 완료 | Web checklist P2P 재연결/backoff, 탭 종료 정리, Mobile lifecycle hook point 구현 |
 | `TASK-027-mobile-yjs-runtime-adapter.md` | 완료 | Mobile Yjs runtime adapter, AsyncStorage persistence, P2P update apply 경로 구현 및 자동 검증 완료 |
-| `TASK-028-rotating-room-secret-hardening.md` | 계획됨 | signaling topic을 rotating room secret 기반으로 전환하는 후속 보안 하드닝, Issue [#312](https://github.com/ysjee141/nexvoy-frontend/issues/312) |
+| `TASK-028-rotating-room-secret-hardening.md` | 완료 | server-issued signaling topic, active topic RLS, Web/Mobile adapter 전환 구현, Issue [#312](https://github.com/ysjee141/nexvoy-frontend/issues/312) |
 
 현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `Phase 3`의 모바일 WebRTC native feasibility와 Cloudflare ICE config 발급 경로는 provider boundary, Edge Function, 검증 보고서로 정리했다. `Phase 4`의 dual-write 및 mismatch detector와 guest auth promotion은 Web-first 범위로 구현했다. `TASK-013`에서 초대/권한 registry, invite/share RPC, Web/Mobile join fallback을 구현했고, `TASK-014`에서 notification metadata, local notification scheduler, observability event boundary를 구현했다. `TASK-015`에서 owner/editor Web foreground document key provisioning과 pending/status UX를 구현했다. `TASK-016`은 Mobile Native Key Provisioning MVP를 구현하고 accepted scope 기준 검증했다. `TASK-017`은 Mobile background task 기반 provisioning retry path를 구현하고 Android-first 검증 범위에서 PASS를 받았다. `TASK-018`은 Android Keystore/iOS Keychain 기반 non-exportable key storage hardening을 구현하고 native preview build와 SQL smoke까지 검증했다. `TASK-019`는 Mobile-first owner bootstrap 후속 문서다. `TASK-020`은 `restore.ts`의 Yjs 비의존 부분(snapshot 복호화·hash 검증)을 `backupPayloadCodec.ts`/`mobileRestore.ts`로 분리해 Mobile 전용 encrypted snapshot restore 경로(`restoreMobileEncryptedSnapshot`)를 구현하고, `TASK-019`의 owner bootstrap 성공/provisioning completion 트리거에 재시도를 연결했다. updates replay(Web/Yjs 기반 최신 콘텐츠 반영)는 이번 범위에서 제외했다. `TASK-021`은 `ADR-004`가 유보했던 시그널링 전송 계층을 `ADR-012`(Supabase Realtime Broadcast)로 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 배선해 P2P fast path의 최초 연결을 증명했다. `TASK-022`는 일반 Web 로그인 trip이 `documents`/`document_members`에 등록되지 않던 선결 문제를 lazy bootstrap으로 해소했다. `TASK-023`은 같은 signaling 프로토콜과 room topic 파생 규칙을 Mobile까지 확장하고 native data-channel handshake/조립 지점을 추가했다. `TASK-024`는 Web-to-Web 범위에서 data channel로 Yjs update를 청킹/전송/재조립하고 IndexedDB 문서에 적용하는 fast path를 구현했다. `TASK-027`은 Mobile Yjs runtime adapter와 `react-native-quick-crypto` 기반 Metro shim을 추가해 Mobile도 같은 Yjs update format을 apply할 수 있게 했다.
 
@@ -94,8 +94,8 @@ TASK-008a-web-checklist-read-through-hydration.md
 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 연결해 P2P fast path의 최초 연결을 증명했다
 (PR #300, 자동 검증 완료·실브라우저 수동 검증 후속). 수동 검증 중 일반 trip이 `documents`/
 `document_members`에 전혀 등록되지 않는다는 선결 문제를 발견해 `TASK-022`로 분리했다. P2P를 완전한
-기능으로 만들기 위한 나머지 작업 중 `TASK-025` 사용자 UI와 `TASK-026` 생명주기 하드닝은 완료했고,
-rotating room secret 보안 하드닝은 `TASK-028`로 분리했다.
+기능으로 만들기 위한 나머지 작업 중 `TASK-025` 사용자 UI, `TASK-026` 생명주기 하드닝, `TASK-028`
+rotating room secret 보안 하드닝을 완료했다.
 
 ## Phase별 작업 목록
 
@@ -151,12 +151,10 @@ rotating room secret 보안 하드닝은 `TASK-028`로 분리했다.
 - [x] `TASK-025-p2p-connection-status-ui.md`: 사용자 대상 연결 상태 UI/UX
 - [x] `TASK-026-p2p-connection-lifecycle-hardening.md`: 재연결/생명주기 하드닝
 - [x] `TASK-027-mobile-yjs-runtime-adapter.md`: Mobile Yjs runtime adapter로 Web/Mobile 공통 update format 적용
-- [ ] `TASK-028-rotating-room-secret-hardening.md`: signaling topic rotating room secret 하드닝
+- [x] `TASK-028-rotating-room-secret-hardening.md`: signaling topic rotating room secret 하드닝
 
 ## 권장 시작 순서
 
-TASK-001~027까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크, Supabase backup schema/RLS, document key model, backup queue, snapshot/update restore flow, 기존 Supabase row 기반 read-through hydration, 모바일 WebRTC native runtime 조건, Cloudflare STUN/TURN ICE config 발급 경로, checklist dual-write/mismatch detector, guest auth promotion, 초대/권한 registry, notification/observability boundary, Web foreground owner-side key provisioning, Mobile native key provisioning MVP와 foreground/resume/background sync, native non-exportable key storage hardening, Mobile-first owner device key bootstrap, Mobile encrypted snapshot restore, Web/Mobile P2P signaling/data-channel wiring, Web-to-Web Yjs update exchange, P2P 연결 생명주기 하드닝, Mobile Yjs runtime adapter까지 검증을 완료했다.
+TASK-001~028까지 완료되어 Web checklist 도메인에서 local-first read/write 스파이크, Supabase backup schema/RLS, document key model, backup queue, snapshot/update restore flow, 기존 Supabase row 기반 read-through hydration, 모바일 WebRTC native runtime 조건, Cloudflare STUN/TURN ICE config 발급 경로, checklist dual-write/mismatch detector, guest auth promotion, 초대/권한 registry, notification/observability boundary, Web foreground owner-side key provisioning, Mobile native key provisioning MVP와 foreground/resume/background sync, native non-exportable key storage hardening, Mobile-first owner device key bootstrap, Mobile encrypted snapshot restore, Web/Mobile P2P signaling/data-channel wiring, Web-to-Web Yjs update exchange, P2P 연결 생명주기 하드닝, Mobile Yjs runtime adapter, signaling rotating room topic hardening까지 검증을 완료했다.
 
-`TASK-021`은 Web-to-Web P2P 연결을 최초로 증명했고, `TASK-022`는 일반 계정 trip의 document registry 등록 갭을 해소했다. `TASK-023`은 Mobile 배선까지 확장했고, `TASK-024`는 Web-to-Web Yjs update 교환을 구현했다. `TASK-027`은 Mobile도 같은 Yjs update format을 apply하도록 runtime adapter와 P2P apply 경로를 추가했다. `TASK-025`는 Web 준비물 화면에서 P2P 연결을 자동 시도하고 상태를 표시하도록 연결했다. `TASK-026`은 Web checklist P2P 재연결/backoff와 탭 종료 정리, Mobile lifecycle hook point를 추가했다. 다음 권장 순서는
-`TASK-028`(rotating room secret 하드닝)이다. 통합
-테스트 케이스/코드는 이 구현들이 어느 정도 갖춰진 뒤 별도로 작성한다.
+`TASK-021`은 Web-to-Web P2P 연결을 최초로 증명했고, `TASK-022`는 일반 계정 trip의 document registry 등록 갭을 해소했다. `TASK-023`은 Mobile 배선까지 확장했고, `TASK-024`는 Web-to-Web Yjs update 교환을 구현했다. `TASK-027`은 Mobile도 같은 Yjs update format을 apply하도록 runtime adapter와 P2P apply 경로를 추가했다. `TASK-025`는 Web 준비물 화면에서 P2P 연결을 자동 시도하고 상태를 표시하도록 연결했다. `TASK-026`은 Web checklist P2P 재연결/backoff와 탭 종료 정리, Mobile lifecycle hook point를 추가했다. `TASK-028`은 signaling topic을 server-issued active topic으로 전환하고 Realtime RLS를 강화했다. 다음 권장 순서는 P2P late join/peer discovery 개선 또는 통합 테스트 작성이다.

--- a/docs/refactor/tasks/TASK-028-rotating-room-secret-hardening.md
+++ b/docs/refactor/tasks/TASK-028-rotating-room-secret-hardening.md
@@ -73,3 +73,14 @@ topic을 예측 불가능하게 만든다.
 - signaling room topic이 고정된 결정적 해시가 아니라 회전하는 secret에 기반한다.
 - secret 없는 join/send가 서버 경계에서 거부된다.
 - rotation/fallback 상태가 원문 노출 없이 관측 가능하다.
+
+## 구현 결과
+
+- `document_signaling_room_topics` 테이블과 `issue_document_signaling_room_topic` RPC를 추가했다.
+- Web/Mobile signaling adapter가 deterministic `sha256(documentId)` topic 대신 server-issued opaque topic을
+  사용하도록 변경했다.
+- Realtime Authorization RLS를 active server-issued topic 기준으로 교체해 deterministic topic join/send를
+  서버 경계에서 거부한다.
+- 만료 2분 이내에는 새 topic을 발급하고 기존 unexpired topic은 자연 만료까지 유지해 old/new overlap
+  window를 제공한다.
+- topic 원문은 RPC 응답과 Realtime join에만 사용하고 observability/UI/log에는 남기지 않는다.

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,57 +1,59 @@
-# TASK-026 Implementation Plan
+# TASK-028 Implementation Plan
 
 ## Scope
 
-Implement the lifecycle hardening part of TASK-026 first:
+Implement rotating signaling room topic hardening for P2P:
 
-1. Web P2P reconnect/backoff for checklist connections.
-2. Web page lifecycle cleanup for active signaling/data-channel/peer connections.
-3. Mobile P2P adapter cleanup/reconnect primitives around background/foreground lifecycle.
-4. P2P lifecycle observability events without document content, raw document id, or signaling room id.
-5. Document the rotating room secret rollout boundary. Do not switch production signaling topics to secret-based derivation in the same change unless the RLS/RPC compatibility path is complete.
+1. Add a server-issued active signaling topic table and RPC.
+2. Replace Realtime Authorization policies so P2P signaling only works on active server-issued topics.
+3. Update Web and Mobile signaling adapters to fetch the topic before joining the private Realtime channel.
+4. Keep topic/secret/document content out of logs and observability.
 
-## Rationale
+## Design
 
-Web-to-Web checklist P2P is now manually verified. The next highest-risk area is keeping that path stable under common lifecycle events. Rotating room secret changes require coordinated changes across topic derivation, Realtime Authorization RLS, server-issued secret proof, Web, and Mobile. Combining that with reconnect changes would make rollback and debugging difficult.
+The client should not derive a joinable topic from the raw document id anymore. The server issues an opaque topic per
+document and time window. The topic is stored server-side for Realtime Authorization comparison, returned only through
+an authenticated RPC, and never logged by the adapters.
 
-## Planned Changes
+Data model:
 
-### Core
+- `document_signaling_room_topics`
+  - `document_id`
+  - `room_topic`
+  - `active_from`
+  - `expires_at`
+  - `revoked_at`
+  - `created_by`
 
-- Add platform-independent retry/backoff policy helpers.
-- Extend P2P observability event names for reconnect and lifecycle cleanup.
-- Keep `packages/core` free of DOM/RN/Supabase client APIs.
+RPC:
 
-### Web
+- `issue_document_signaling_room_topic(p_document_id uuid)`
+  - accepted `document_members` can fetch a topic
+  - legacy trip owner/member compatibility is preserved while the transition still depends on legacy trip snapshots
+  - reuses an unexpired active topic; creates a new one if needed
+  - returns `{ room_topic, expires_at }`
 
-- Add bounded reconnect loop to `useWebP2PChecklistConnection`.
-- Ensure connection cleanup cancels retry timers and offer retry timers.
-- Add page lifecycle cleanup (`pagehide`/`beforeunload`) for active Web P2P connection.
-- Preserve current status UI contract: `connecting`, `connected`, `fallback`.
+Realtime Authorization:
 
-### Mobile
+- SELECT: accepted member or legacy trip member can receive only when `realtime.topic()` equals an active topic for that document.
+- INSERT: owner/editor or legacy owner/editor can send only when `realtime.topic()` equals an active topic for that document.
+- deterministic `signaling:<sha256(documentId)>` topics are no longer authorized.
 
-- Make mobile P2P connection close idempotent.
-- Add lifecycle-safe hook points around AppState transitions where current adapter users can close/reconnect without leaking channels.
-- Avoid adding screen UI in this task.
+## Rollout Boundary
 
-### Rotating Room Secret
-
-- Keep current deterministic topic plus Realtime Authorization RLS active for this PR.
-- Add design notes in TASK-026/README for the required future migration path:
-  - server-issued room secret,
-  - topic derivation `hash(documentId + secret)`,
-  - RLS validation against active secret window,
-  - overlap window for old/new topics.
+This PR updates Web and Mobile adapters in the same change as the RLS migration. Older clients using deterministic
+topics will fail P2P signaling and fall back to Supabase backup/legacy sync. That is acceptable for the refactor branch
+because P2P remains optional fast path.
 
 ## Verification
 
 - `pnpm --filter @nexvoy/core test`
 - `pnpm typecheck`
 - `pnpm build`
-- `pnpm build:mobile`
 - `pnpm --filter nexvoy-app lint`
+- `pnpm build:mobile`
 
 ## Rollback
 
-Remove the reconnect/lifecycle helpers and return to TASK-025 behavior. Since no production topic derivation change is planned in this PR, rollback does not require data migration.
+Revert this PR to restore deterministic topic derivation and the TASK-025 Realtime Authorization policies. The new
+topic table is independent of document content and can be left unused if rollback is needed.

--- a/packages/core/src/sync/__tests__/signalingChannel.test.ts
+++ b/packages/core/src/sync/__tests__/signalingChannel.test.ts
@@ -1,6 +1,8 @@
 import {
   SIGNALING_BROADCAST_EVENT,
+  deriveRotatingSignalingRoomTopic,
   deriveSignalingRoomTopic,
+  isSignalingRoomTopic,
   parseSignalingMessage,
   serializeSignalingMessage,
   type SignalingMessage,
@@ -74,5 +76,22 @@ async function run(): Promise<void> {
 
   if (rnShapedTopic !== topic) {
     throw new Error('React Native-shaped digest provider must derive the same signaling room topic.')
+  }
+
+  const rotatingTopic = await deriveRotatingSignalingRoomTopic({
+    documentId,
+    roomSecret: 'server-issued-secret',
+  }, globalThis.crypto.subtle)
+
+  if (!isSignalingRoomTopic(rotatingTopic)) {
+    throw new Error('Rotating signaling room topic should use the signaling:<sha256> format.')
+  }
+
+  if (rotatingTopic === topic) {
+    throw new Error('Rotating signaling room topic must not equal the deterministic document-id topic.')
+  }
+
+  if (isSignalingRoomTopic(`signaling:${documentId}`) || isSignalingRoomTopic('not-a-topic')) {
+    throw new Error('Signaling room topic validator should reject raw or malformed topics.')
   }
 }

--- a/packages/core/src/sync/signalingChannel.ts
+++ b/packages/core/src/sync/signalingChannel.ts
@@ -29,6 +29,7 @@ export type SignalingMessage =
 export const SIGNALING_BROADCAST_EVENT = 'signal'
 
 const SIGNALING_TOPIC_PREFIX = 'signaling:'
+const SIGNALING_TOPIC_HASH_PATTERN = /^[0-9a-f]{64}$/
 
 /**
  * Matches public.document_registry_hash() in
@@ -39,6 +40,10 @@ const SIGNALING_TOPIC_PREFIX = 'signaling:'
  */
 export type SignalingRoomDigestProvider = Pick<SubtleCrypto, 'digest'>
 
+/**
+ * Legacy deterministic topic used by TASK-021~TASK-027. Kept for tests and
+ * rollback compatibility; TASK-028 adapters should use server-issued topics.
+ */
 export async function deriveSignalingRoomTopic(
   documentId: string,
   provider: SignalingRoomDigestProvider,
@@ -46,6 +51,24 @@ export async function deriveSignalingRoomTopic(
   const encoded = new TextEncoder().encode(documentId)
   const hashBuffer = await provider.digest('SHA-256', encoded)
   return `${SIGNALING_TOPIC_PREFIX}${bufferToHex(hashBuffer)}`
+}
+
+export async function deriveRotatingSignalingRoomTopic(
+  input: {
+    documentId: string
+    roomSecret: string
+  },
+  provider: SignalingRoomDigestProvider,
+): Promise<string> {
+  const encoded = new TextEncoder().encode(`${input.documentId}:${input.roomSecret}`)
+  const hashBuffer = await provider.digest('SHA-256', encoded)
+  return `${SIGNALING_TOPIC_PREFIX}${bufferToHex(hashBuffer)}`
+}
+
+export function isSignalingRoomTopic(input: unknown): input is string {
+  return typeof input === 'string'
+    && input.startsWith(SIGNALING_TOPIC_PREFIX)
+    && SIGNALING_TOPIC_HASH_PATTERN.test(input.slice(SIGNALING_TOPIC_PREFIX.length))
 }
 
 export function serializeSignalingMessage(message: SignalingMessage): string {

--- a/supabase/migrations/20260714000001_task028_rotating_signaling_room_topics.sql
+++ b/supabase/migrations/20260714000001_task028_rotating_signaling_room_topics.sql
@@ -1,0 +1,239 @@
+-- TASK-028: rotating room topics for P2P signaling.
+--
+-- P2P signaling topics should not be derivable from raw document ids. This
+-- migration introduces server-issued opaque topics and tightens Realtime
+-- Authorization so only active server-issued topics are accepted.
+
+CREATE TABLE IF NOT EXISTS public.document_signaling_room_topics (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id uuid NOT NULL,
+  room_topic text NOT NULL UNIQUE,
+  active_from timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  revoked_at timestamptz,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT document_signaling_room_topics_topic_format_check
+    CHECK (room_topic ~ '^signaling:[0-9a-f]{64}$'),
+  CONSTRAINT document_signaling_room_topics_valid_window_check
+    CHECK (expires_at > active_from)
+);
+
+CREATE INDEX IF NOT EXISTS document_signaling_room_topics_document_active_idx
+  ON public.document_signaling_room_topics(document_id, expires_at)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS document_signaling_room_topics_room_topic_idx
+  ON public.document_signaling_room_topics(room_topic);
+
+ALTER TABLE public.document_signaling_room_topics ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.document_signaling_room_topics FROM anon, authenticated;
+
+DROP POLICY IF EXISTS "deny direct signaling topic reads" ON public.document_signaling_room_topics;
+DROP POLICY IF EXISTS "deny direct signaling topic writes" ON public.document_signaling_room_topics;
+
+CREATE POLICY "deny direct signaling topic reads"
+ON public.document_signaling_room_topics
+FOR SELECT
+TO authenticated
+USING (false);
+
+CREATE POLICY "deny direct signaling topic writes"
+ON public.document_signaling_room_topics
+FOR ALL
+TO authenticated
+USING (false)
+WITH CHECK (false);
+
+CREATE OR REPLACE FUNCTION public.issue_document_signaling_room_topic(p_document_id uuid)
+RETURNS TABLE (
+  room_topic text,
+  expires_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  selected_topic public.document_signaling_room_topics%ROWTYPE;
+  topic_seed text;
+  topic_ttl interval := interval '1 hour';
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_document_id IS NULL THEN
+    RAISE EXCEPTION 'missing_document_id' USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT (
+    EXISTS (
+      SELECT 1
+      FROM public.document_members dm
+      WHERE dm.document_id = p_document_id
+        AND dm.user_id = current_user_id
+        AND dm.status = 'accepted'
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = p_document_id
+        AND (
+          public.check_is_trip_owner(t.id, current_user_id)
+          OR public.check_is_trip_member(t.id, current_user_id)
+        )
+    )
+  ) THEN
+    RAISE EXCEPTION 'signaling_topic_forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT *
+  INTO selected_topic
+  FROM public.document_signaling_room_topics dst
+  WHERE dst.document_id = p_document_id
+    AND dst.revoked_at IS NULL
+    AND dst.active_from <= now()
+    AND dst.expires_at > now() + interval '2 minutes'
+  ORDER BY dst.expires_at DESC
+  LIMIT 1;
+
+  IF selected_topic.id IS NULL THEN
+    UPDATE public.document_signaling_room_topics dst
+    SET revoked_at = now()
+    WHERE dst.document_id = p_document_id
+      AND dst.revoked_at IS NULL
+      AND dst.expires_at <= now();
+
+    topic_seed := p_document_id::text || ':' || gen_random_uuid()::text || ':' || extract(epoch FROM clock_timestamp())::text;
+
+    INSERT INTO public.document_signaling_room_topics (
+      document_id,
+      room_topic,
+      active_from,
+      expires_at,
+      created_by
+    )
+    VALUES (
+      p_document_id,
+      'signaling:' || public.document_registry_hash(topic_seed),
+      now(),
+      now() + topic_ttl,
+      current_user_id
+    )
+    RETURNING * INTO selected_topic;
+  END IF;
+
+  room_topic := selected_topic.room_topic;
+  expires_at := selected_topic.expires_at;
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.issue_document_signaling_room_topic(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.issue_document_signaling_room_topic(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.can_receive_document_signaling_topic(
+  p_room_topic text,
+  p_user_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT p_room_topic IS NOT NULL
+    AND p_user_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public.document_signaling_room_topics dst
+      WHERE dst.room_topic = p_room_topic
+        AND dst.revoked_at IS NULL
+        AND dst.active_from <= now()
+        AND dst.expires_at > now()
+        AND (
+          EXISTS (
+            SELECT 1
+            FROM public.document_members dm
+            WHERE dm.document_id = dst.document_id
+              AND dm.user_id = p_user_id
+              AND dm.status = 'accepted'
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM public.trips t
+            WHERE t.id = dst.document_id
+              AND (
+                public.check_is_trip_owner(t.id, p_user_id)
+                OR public.check_is_trip_member(t.id, p_user_id)
+              )
+          )
+        )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_send_document_signaling_topic(
+  p_room_topic text,
+  p_user_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT p_room_topic IS NOT NULL
+    AND p_user_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public.document_signaling_room_topics dst
+      WHERE dst.room_topic = p_room_topic
+        AND dst.revoked_at IS NULL
+        AND dst.active_from <= now()
+        AND dst.expires_at > now()
+        AND (
+          EXISTS (
+            SELECT 1
+            FROM public.document_members dm
+            WHERE dm.document_id = dst.document_id
+              AND dm.user_id = p_user_id
+              AND dm.status = 'accepted'
+              AND dm.role IN ('owner', 'editor')
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM public.trips t
+            WHERE t.id = dst.document_id
+              AND (
+                public.check_is_trip_owner(t.id, p_user_id)
+                OR public.check_is_trip_editor(t.id, p_user_id)
+              )
+          )
+        )
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.can_receive_document_signaling_topic(text, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.can_send_document_signaling_topic(text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.can_receive_document_signaling_topic(text, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.can_send_document_signaling_topic(text, uuid) TO authenticated;
+
+DROP POLICY IF EXISTS "accepted document members can receive signaling broadcast"
+ON realtime.messages;
+
+DROP POLICY IF EXISTS "accepted non-viewer document members can send signaling broadcast"
+ON realtime.messages;
+
+CREATE POLICY "accepted document members can receive signaling broadcast"
+ON realtime.messages
+FOR SELECT
+TO authenticated
+USING (public.can_receive_document_signaling_topic(realtime.topic(), (SELECT auth.uid())));
+
+CREATE POLICY "accepted non-viewer document members can send signaling broadcast"
+ON realtime.messages
+FOR INSERT
+TO authenticated
+WITH CHECK (public.can_send_document_signaling_topic(realtime.topic(), (SELECT auth.uid())));

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,47 @@
+# Walkthrough: TASK-028 Rotating Room Secret Hardening
+
+## Summary
+
+TASK-028은 P2P signaling room topic을 deterministic `sha256(documentId)`에서 server-issued opaque topic으로 전환했다. 클라이언트는 `issue_document_signaling_room_topic` RPC로 active topic을 받은 뒤 Supabase Realtime private channel에 join하며, Realtime Authorization RLS는 active server-issued topic만 허용한다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-028-rotating-room-secret-hardening.md`
+- `implementation_plan.md`
+- `_workspace/01_planner_analysis.md`
+- `_workspace/02b_frontend_changes.md`
+- `_workspace/02c_backend_changes.md`
+- `_workspace/03_review_result.md`
+- `_workspace/04_qa_result.md`
+
+## Key Changes
+
+- `supabase/migrations/20260714000001_task028_rotating_signaling_room_topics.sql`(신규): `document_signaling_room_topics` table, topic issuing RPC, active topic permission helpers, Realtime Authorization policy 교체.
+- `packages/core/src/sync/signalingChannel.ts`: rotating topic derivation helper와 topic format validator 추가. legacy deterministic helper는 rollback/test compatibility를 위해 유지.
+- `apps/web/lib/local-first/signalingChannel.ts`: deterministic topic derivation 대신 server-issued topic fetch 후 Realtime channel join.
+- `apps/mobile/lib/local-first/signalingChannel.ts`: Web과 동일하게 RPC-issued topic을 사용하도록 변경.
+- `docs/refactor/tasks/README.md`, `TASK-028`: TASK-028 완료 상태와 구현 결과 반영.
+
+## Verification
+
+- `pnpm --filter @nexvoy/core test` 성공
+- `pnpm typecheck` 성공
+- `pnpm build` 성공
+- `pnpm --filter nexvoy-app lint` 성공. 기존 Mobile 파일 warning 7건은 이번 변경과 무관하다.
+- `pnpm build:mobile` 성공
+
+## Rollback
+
+이번 PR을 되돌리면 TASK-025/026의 deterministic topic policy와 client derivation으로 복귀한다. 신규 topic table은 document content와 독립적이므로, rollback 시 사용 중지만으로 충분하다.
+
+## Notes
+
+- topic 원문은 RPC 응답과 Realtime join에만 사용하고 observability/UI/log에는 남기지 않는다.
+- 만료 2분 이내에는 새 topic을 발급하고 기존 unexpired topic은 자연 만료까지 유지해 old/new overlap window를 제공한다.
+- P2P late join/peer discovery 개선은 별도 후속 작업이다.
+
+---
+
 # Walkthrough: TASK-026 P2P Connection Lifecycle Hardening
 
 ## Summary


### PR DESCRIPTION
## Summary

- Add server-issued P2P signaling room topics and issuing RPC
- Replace Realtime Authorization policies so deterministic document-id topics are no longer authorized
- Update Web/Mobile signaling adapters to join RPC-issued active topics
- Add shared topic validation/rotating derivation helpers while keeping deterministic helper for rollback/tests
- Update TASK docs and walkthrough

## Verification

- pnpm --filter @nexvoy/core test
- pnpm typecheck
- pnpm build
- pnpm --filter nexvoy-app lint
- pnpm build:mobile

Notes: Mobile lint still reports 7 existing warnings in unrelated files.

Resolves #312
