### PR TITLE
TASK-029: Define full Local-first product scope

### DIFF
--- a/docs/refactor/TECHNICAL-SPEC.md
+++ b/docs/refactor/TECHNICAL-SPEC.md
@@ -5,6 +5,7 @@
 OnVoy의 데이터 통신 구조를 Supabase 원본 DB 중심에서 Local-first 원본 저장소 중심으로 전환한다. 클라이언트는 로컬 저장소와 CRDT(Yjs)를 우선 사용하고, P2P(WebRTC)로 실시간 협업을 수행한다. Supabase는 사용자 인증, 권한 registry, 백업, 복구, 초대/공유 bootstrap, 첨부 파일 저장을 담당한다.
 
 본 문서는 실제 구현을 위한 기술 명세다. 최종 아키텍처 결정은 `docs/refactor/adrs/ADR-001-local-first-data-engine.md`를 따른다.
+전체 제품 범위와 document boundary, legacy migration/rollback 정책은 `docs/refactor/adrs/ADR-013-full-local-first-product-scope.md`를 따른다.
 
 ## 2. 범위
 
@@ -156,6 +157,9 @@ export interface ChecklistRepository {
 ## 7. Trip Document Model
 
 저장 단위는 Trip 단위 단일 Yjs 문서다. `ADR-005` 결정에 따라 초기 구현은 Trip 하나를 하나의 CRDT document로 저장한다. 기존 row id를 내부 id로 유지한다.
+`ADR-013` 결정에 따라 trip-scoped 데이터는 `TripDocumentV1`에 두고, 개인/공유/공개 템플릿은 별도
+`TemplateDocumentV1` boundary로 분리한다. 템플릿을 준비물에 적용할 때는 Template document snapshot을
+읽어 Trip document의 checklist item mutation으로 복사한다.
 
 ```ts
 export interface TripDocumentV1 {
@@ -261,6 +265,15 @@ Yjs 내부 표현:
 ### Collaboration
 
 `trip_members`, `trip_shares`, `trip_invitation_links`는 document 내부에도 snapshot을 보관하지만, 최종 권한 검증과 초대 수락은 Supabase registry를 source of authority로 둔다.
+
+### Template
+
+`checklist_templates`, `checklist_template_items`, `checklist_template_shares`는 `ADR-013`에 따라
+`TemplateDocumentV1`로 migration한다. Template document는 Trip document와 다른 owner/share/public
+visibility boundary를 가진다.
+
+Trip document에는 template 적용 결과로 생성된 checklist item과 출처 metadata만 저장한다. Template document
+본문을 Trip document에서 live reference로 유지하지 않는다.
 
 ## 9. Supabase 백업 스키마
 
@@ -601,7 +614,8 @@ interface TombstoneNode {
 목표:
 
 - Local-first repository를 기본값으로 전환
-- Supabase row는 fallback/read-only
+- Supabase row는 migration source와 fallback/read-only 경로로 축소
+- 신규 write는 document repository로 전환
 - backup/update log를 안정화
 
 ### Phase 5: Legacy Reduction
@@ -611,6 +625,15 @@ interface TombstoneNode {
 - 신규 기능은 document model만 사용
 - legacy row sync 제거 후보 식별
 - 통계/search index 별도 구축
+
+### Phase 6: Full Product Cutover
+
+목표:
+
+- Web/Mobile 준비물, 일정, 템플릿, 동행자/권한 UI를 document-primary 경로로 전환
+- 모든 document-primary mutation을 encrypted backup sync와 P2P fast path에 연결
+- legacy row는 장기 dual-write 대상이 아니라 read-only migration source/rollback fallback으로 유지
+- 전체 기능 통합테스트 통과 후 Closed Beta 준비
 
 ## 17. Data Compatibility Requirements
 
@@ -755,16 +778,16 @@ E2E:
 | 초대 방식과 권한 authority를 어떻게 둘 것인가? | `docs/refactor/adrs/ADR-008-invitation-and-permission-registry.md` | 채택됨: 권장안 |
 | 푸시 알림과 로컬 알림을 어떻게 분리할 것인가? | `docs/refactor/adrs/ADR-009-notification-strategy.md` | 채택됨: Option B |
 | 초기 운영 인프라와 비용 제어 기준은 무엇인가? | `docs/refactor/adrs/ADR-010-operating-cost-and-infrastructure.md` | 후속 검토 |
+| 전체 제품 Local-first scope와 document boundary, legacy migration/rollback 정책은 무엇인가? | `docs/refactor/adrs/ADR-013-full-local-first-product-scope.md` | 채택됨: Full product document-primary |
 
 ## 24. Immediate Next Tasks
 
-1. `ADR-010` 비용/인프라 후속 검토
-2. 체크리스트 스파이크 범위 확정
-3. repository interface 초안 작성
-4. row/document 변환기 초안 작성
-5. encrypted backup schema 및 `document_keys` migration 초안 작성
-6. Web IndexedDB persistence PoC
-7. Mobile WebRTC/Yjs native build feasibility PoC
-8. guest document promotion PoC
-9. invitation/permission registry PoC
-10. notification metadata + local notification PoC
+TASK-001~029의 결정과 foundation 구현 이후 다음 작업은 full product document-primary 전환이다.
+
+1. `TASK-030-document-primary-repository-layer.md`
+2. `TASK-031-web-full-document-primary-transition.md`
+3. `TASK-032-mobile-full-document-primary-transition.md`
+4. `TASK-033-backup-sync-productization.md`
+5. `TASK-034-p2p-all-domain-wiring.md`
+6. `TASK-035-full-integration-test-suite.md`
+7. `TASK-036-closed-beta-readiness.md`

--- a/docs/refactor/adrs/ADR-013-full-local-first-product-scope.md
+++ b/docs/refactor/adrs/ADR-013-full-local-first-product-scope.md
@@ -1,0 +1,247 @@
+# ADR-013: Full Local-first Product Scope
+
+- 상태: 채택됨
+- 결정일: 2026-07-14
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/progress.md`
+  - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+  - `docs/refactor/adrs/ADR-005-document-granularity.md`
+  - `docs/refactor/adrs/ADR-008-invitation-and-permission-registry.md`
+  - `docs/refactor/adrs/ADR-011-invitation-key-provisioning-strategy.md`
+  - `docs/refactor/tasks/TASK-029-full-local-first-product-scope-adr.md`
+
+---
+
+## 문제 정의
+
+TASK-001~028은 Local-first foundation, encrypted backup/key provisioning, Web/Mobile P2P signaling, Web
+checklist 중심 Yjs update exchange를 구현했다. 하지만 제품 관점에서는 아직 checklist pilot 단계다.
+
+다음 단계에서 바로 통합테스트나 Closed Beta를 진행하면 준비물 외 일정, 템플릿, 동행자 초대/수락/거부,
+권한 변경, Web/Mobile cross-device restore/sync가 서로 다른 데이터 경로를 타게 된다. 이는 사용자에게
+"일부 기능만 빠른 동기화/오프라인 지원"처럼 보이고, Closed Beta에서 검증하려는 완성 제품 기준과 맞지
+않는다.
+
+따라서 TASK-030 이후 구현 전에 전체 제품 scope, document boundary, legacy row migration 전략,
+rollout/rollback 기준을 확정한다.
+
+---
+
+## 결정해야 할 질문
+
+1. 어떤 기능을 Local-first 제품 완료 범위로 볼 것인가?
+2. 템플릿은 `TripDocumentV1` 내부에 둘 것인가, 별도 document로 둘 것인가?
+3. Supabase row table은 전환 기간에 어떤 역할만 맡길 것인가?
+4. 언제 통합테스트와 Closed Beta로 넘어갈 수 있는가?
+
+---
+
+## 선택지
+
+### Option A: Checklist 중심 pilot을 유지하고 나머지는 legacy row로 둔다
+
+장점:
+
+- 단기 구현량이 가장 작다.
+- 이미 검증한 Web checklist P2P 경로를 빠르게 확장해 보일 수 있다.
+
+단점:
+
+- 일정, 템플릿, 초대/권한이 legacy row 중심으로 남아 제품 전체가 local-first가 아니다.
+- Web/Mobile 간 데이터 경로가 달라져 통합테스트 기준이 모호하다.
+- Closed Beta에서 핵심 기능별 품질 편차가 노출된다.
+
+결론: 채택하지 않는다.
+
+### Option B: 모든 기존 row 기능을 장기간 dual-write로 유지한다
+
+장점:
+
+- legacy 화면 rollback이 쉽다.
+- row 기반 E2E와 운영 tooling을 오래 재사용할 수 있다.
+
+단점:
+
+- dual-write mismatch 탐지와 보정 범위가 준비물에서 일정/템플릿/권한까지 커진다.
+- P2P/backup/Yjs update와 Supabase row mutation을 계속 맞춰야 하므로 구현 속도가 느려진다.
+- "Local-first document가 primary"라는 목표가 지연된다.
+
+결론: 전환 초기에 제한적으로만 사용하고 장기 전략으로 채택하지 않는다.
+
+### Option C: Full product document-primary 전환
+
+장점:
+
+- Web/Mobile의 데이터 모델과 동기화 경로가 하나로 정리된다.
+- P2P와 encrypted backup이 같은 Yjs update format을 공유한다.
+- legacy row는 migration source/read fallback으로 축소되어 구현 복잡도가 줄어든다.
+- 전체 기능 완료 후 통합테스트/Closed Beta라는 제품 목표와 일치한다.
+
+단점:
+
+- Plan/Template/Member repository와 Web/Mobile 화면 전환 작업량이 크다.
+- migration/restore 실패가 고객 데이터 접근에 직접 영향을 줄 수 있다.
+- template boundary와 permission registry 책임을 명확히 나누지 않으면 모델이 다시 복잡해진다.
+
+결론: 채택한다.
+
+---
+
+## 결정
+
+Option C를 채택한다. TASK-030 이후 작업은 checklist pilot 확대가 아니라 **전체 제품 document-primary 전환**으로
+진행한다.
+
+Local-first 완료 범위는 다음 기능 전체다.
+
+- 준비물 CRUD/check/toggle/assignee/template apply
+- 일정 CRUD/order/url/place/visited/memo/cost/alarm metadata
+- 템플릿 list/detail/create/edit/delete/share/apply
+- 동행자 초대 / 수락 / 거부
+- owner/editor/viewer role 변경과 revoke
+- Web/Mobile local persistence
+- Web/Mobile encrypted backup restore/sync
+- Web/Web, Web/Mobile, Mobile/Mobile P2P fast path
+- offline write 후 비동시 기기 eventual sync
+
+통합테스트와 Closed Beta는 위 범위가 제품 경로에 올라간 뒤 진행한다. 일부 기능만 Local-first인 상태에서는
+Closed Beta를 시작하지 않는다.
+
+---
+
+## Document Boundary 결정
+
+### Trip-scoped 데이터
+
+`ADR-005`의 초기 결정을 유지한다. 여행 단위 데이터는 하나의 `TripDocumentV1`을 root document로 둔다.
+
+`TripDocumentV1`에 포함되는 제품 범위:
+
+- trip root metadata
+- plans, plan order, plan urls
+- checklists, checklist items, categories, assignees, user checks
+- members snapshot
+- shares/invitation links snapshot
+- trip asset references
+- tombstones
+
+Trip document는 여행 화면의 primary source다. Web/Mobile 여행 상세, 일정, 준비물, 동행자 UI는 최종적으로
+Trip document materialized read model과 repository contract만 사용한다.
+
+### Template 데이터
+
+템플릿은 `TripDocumentV1` 내부에 넣지 않고 별도 `TemplateDocumentV1` boundary로 둔다.
+
+이유:
+
+- 템플릿은 특정 trip에 종속되지 않는다.
+- 개인 템플릿, 공유 템플릿, 공개 템플릿은 trip collaborator 범위와 다르다.
+- template share 권한은 trip owner/editor/viewer 권한과 독립적이다.
+- 공개 템플릿은 여러 trip에 적용될 수 있어 Trip document 내부 entity로 두면 중복과 권한 충돌이 생긴다.
+
+`TemplateDocumentV1` 최소 범위:
+
+- template root metadata
+- template items/categories
+- owner/shared/public visibility snapshot
+- template share snapshot
+- tombstones
+
+템플릿을 여행 준비물에 적용할 때는 Template document를 읽고, 결과 아이템을 `TripDocumentV1.checklistItems`
+mutation으로 복사한다. Trip document에는 적용 출처를 위한 `sourceTemplateName` 또는 후속 확장
+`sourceTemplateId`만 보관하고, template 본문을 reference live-link로 유지하지 않는다.
+
+### Permission/registry 데이터
+
+권한의 최종 authority는 계속 Supabase registry다.
+
+- `document_members`
+- `document_invitation_links`
+- `document_share_tokens`
+- `document_keys`
+- user/device key material registry
+
+Trip/Template document 내부 member/share snapshot은 UI guard와 offline 표시용이다. backup upload,
+restore read, P2P write propagation, invitation accept, role change, revoke는 Supabase registry/RLS/RPC가
+최종 판단한다.
+
+---
+
+## Legacy Row Migration 결정
+
+기존 Supabase row table은 document-primary 전환 이후 primary sync 경로가 아니다.
+
+전환 정책:
+
+1. 기존 row 데이터는 최초 진입 또는 migration job에서 document로 변환한다.
+2. 변환된 document는 encrypted snapshot/update backup의 source가 된다.
+3. 기능별 document-primary 전환이 끝나면 해당 기능의 신규 write는 document repository로만 간다.
+4. legacy row는 필요한 기간 동안 read-only migration source와 rollback fallback으로 유지한다.
+5. 장기 dual-write는 채택하지 않는다. dual-write는 이미 존재하는 checklist 검증 범위와 짧은 cutover 기간에만 허용한다.
+6. row table을 실시간 mirror로 유지하지 않는다. post-cutover 변경을 row에 계속 맞추는 작업은 TASK-030 이후 기본 범위에서 제외한다.
+
+이 결정은 구현 속도를 우선한다. legacy row를 계속 실시간 동기화 대상으로 유지하는 대신, document migration과
+encrypted backup restore/sync를 제품 경로로 빠르게 완성한다.
+
+---
+
+## Rollout 및 Rollback 기준
+
+### Rollout
+
+rollout은 기능 단위로 진행하되, Closed Beta gate는 전체 기능 완료 후에만 연다.
+
+1. TASK-030: document-primary repository layer와 shared mutation/update contract 확정
+2. TASK-031: Web 핵심 기능 document-primary 전환
+3. TASK-032: Mobile 핵심 기능 document-primary 전환
+4. TASK-033: 모든 document-primary mutation을 encrypted backup sync에 연결
+5. TASK-034: 모든 도메인 mutation을 P2P fast path에 연결
+6. TASK-035: 전체 제품 통합 테스트
+7. TASK-036: Closed Beta readiness
+
+### Rollback
+
+rollback은 단계별로 다르게 본다.
+
+- cutover 전: feature flag로 legacy row 화면/repository fallback을 사용할 수 있다.
+- cutover 중: document migration 실패 시 해당 trip/template은 legacy row read-through를 재시도한다.
+- cutover 후: local document와 encrypted backup이 primary이므로 rollback은 row mirror가 아니라 backup restore와
+  document repository fallback을 우선한다.
+- post-cutover 변경을 legacy row에 자동 재수출하는 것은 기본 rollback 전략이 아니다. 필요하면 별도 emergency
+  export script로 다룬다.
+
+rollback 판단 기준:
+
+- document migration이 기존 row 의미를 보존하지 못함
+- encrypted backup restore가 반복적으로 실패함
+- owner/editor/viewer 권한 검증이 registry와 충돌함
+- Web/Mobile 중 한 플랫폼에서 document-primary write가 고객 데이터 접근을 막음
+
+---
+
+## 완료 기준
+
+Full Local-first product 완료는 다음 조건을 모두 만족해야 한다.
+
+- Web/Mobile에서 준비물, 일정, 템플릿, 동행자/권한 기능이 document repository를 통해 동작한다.
+- 모든 local mutation은 local persistence에 먼저 기록된다.
+- owner/editor mutation은 encrypted backup update queue에 들어간다.
+- 동시 접속 peer는 P2P로 같은 Yjs update를 주고받는다.
+- 비동시 기기는 Supabase backup pull/restore로 eventually sync 된다.
+- viewer/revoked member는 UI edit, backup upload, P2P write propagation에서 차단된다.
+- 기존 row 데이터는 손실 없이 Trip/Template document로 migration 된다.
+- 통합테스트는 legacy row assertion이 아니라 document-primary/P2P/backup restore 기준으로 통과한다.
+
+---
+
+## 후속 작업
+
+- `TASK-030-document-primary-repository-layer.md`
+- `TASK-031-web-full-document-primary-transition.md`
+- `TASK-032-mobile-full-document-primary-transition.md`
+- `TASK-033-backup-sync-productization.md`
+- `TASK-034-p2p-all-domain-wiring.md`
+- `TASK-035-full-integration-test-suite.md`
+- `TASK-036-closed-beta-readiness.md`

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -27,7 +27,7 @@
 
 | 영역 | 현재 상태 | 판정 |
 |------|----------|------|
-| TripDocumentV1 모델 | trips/plans/checklists/members/assets/tombstones 기반 있음. templates는 document boundary 확정 필요 | 기반 완료, templates 후속 |
+| TripDocumentV1 모델 | trips/plans/checklists/members/assets/tombstones 기반 있음. templates는 ADR-013에 따라 별도 `TemplateDocumentV1` boundary | 기반 완료, templates 후속 |
 | legacy row -> document 변환 | trip/plans/checklists/members 변환 기반 있음 | 기반 완료 |
 | Web 준비물 | local-first/dual-write/P2P 화면 연결됨 | 부분 완료 |
 | Mobile 준비물 | Yjs runtime/apply adapter는 있으나 화면 write path는 legacy 중심 | 미완료 |
@@ -133,14 +133,9 @@
 - 기존 Supabase row 기반 템플릿 기능 유지
 - Local-first document와 템플릿 도메인의 결합은 미완성
 
-결정이 필요한 부분:
+결정:
 
-- 템플릿을 trip document 내부 entity로 넣을지, 별도 template document로 둘지 결정해야 한다.
-- 공개 템플릿/개인 템플릿은 공유 범위가 trip document와 다르므로 별도 document boundary가 더 안전할 수 있다.
-
-권장 방향:
-
-- 개인/공개 템플릿은 `TemplateDocumentV1` 또는 별도 local-first repository로 분리한다.
+- 개인/공개/공유 템플릿은 ADR-013에 따라 별도 `TemplateDocumentV1` boundary로 분리한다.
 - trip checklist에 템플릿을 적용할 때는 템플릿 snapshot을 읽어 TripDocumentV1 checklist item mutation으로 복사한다.
 
 남은 작업:
@@ -238,13 +233,13 @@
 
 목적:
 
-- TripDocumentV1 하나에 모든 기능을 넣을지, TemplateDocumentV1 등 subdocument를 둘지 결정
-- legacy row migration 전략 결정
-- document-primary 전환 순서 확정
+- TripDocumentV1은 trip-scoped 데이터 root로 유지하고, 템플릿은 `TemplateDocumentV1`로 분리한다고 결정
+- legacy row는 migration source/read-only fallback으로 축소한다고 결정
+- TASK-030~036 document-primary 전환 순서 확정
 
 산출물:
 
-- ADR
+- `docs/refactor/adrs/ADR-013-full-local-first-product-scope.md`
 - 전체 task map
 - migration/rollback 전략
 

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -88,7 +88,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-026-p2p-connection-lifecycle-hardening.md` | 완료 | Web checklist P2P 재연결/backoff, 탭 종료 정리, Mobile lifecycle hook point 구현 |
 | `TASK-027-mobile-yjs-runtime-adapter.md` | 완료 | Mobile Yjs runtime adapter, AsyncStorage persistence, P2P update apply 경로 구현 및 자동 검증 완료 |
 | `TASK-028-rotating-room-secret-hardening.md` | 완료 | server-issued signaling topic, active topic RLS, Web/Mobile adapter 전환 구현, Issue [#312](https://github.com/ysjee141/nexvoy-frontend/issues/312) |
-| `TASK-029-full-local-first-product-scope-adr.md` | 계획됨 | 전체 제품 Local-first 범위, document boundary, migration/rollback 정책 ADR |
+| `TASK-029-full-local-first-product-scope-adr.md` | 완료 | ADR-013으로 전체 제품 Local-first 범위, `TemplateDocumentV1` boundary, migration/rollback 정책 채택, Issue [#316](https://github.com/ysjee141/nexvoy-frontend/issues/316) |
 | `TASK-030-document-primary-repository-layer.md` | 계획됨 | checklist/plans/templates/members 공통 document-primary repository 계약 |
 | `TASK-031-web-full-document-primary-transition.md` | 계획됨 | Web checklist/plans/templates/collaborators document-primary 전환 |
 | `TASK-032-mobile-full-document-primary-transition.md` | 계획됨 | Mobile checklist/plans/templates/collaborators document-primary 전환 |
@@ -164,7 +164,7 @@ rotating room secret 보안 하드닝을 완료했다.
 
 ### Phase 7: Full Product Document-primary 전환
 
-- [ ] `TASK-029-full-local-first-product-scope-adr.md`: 전체 제품 Local-first 범위와 migration/rollback 정책 확정
+- [x] `TASK-029-full-local-first-product-scope-adr.md`: 전체 제품 Local-first 범위와 migration/rollback 정책 확정
 - [ ] `TASK-030-document-primary-repository-layer.md`: 모든 핵심 도메인의 공통 document-primary repository 계약 도입
 - [ ] `TASK-031-web-full-document-primary-transition.md`: Web 핵심 기능을 document-primary read/write로 전환
 - [ ] `TASK-032-mobile-full-document-primary-transition.md`: Mobile 핵심 기능을 document-primary read/write로 전환
@@ -181,9 +181,8 @@ TASK-001~028까지 완료되어 Web checklist 도메인에서 local-first read/w
 
 다음 권장 순서는 partial checklist pilot을 확장하는 방식이 아니라 전체 제품 Local-first 완료를 목표로 한다.
 
-1. `TASK-029`: 전체 제품 Local-first 범위, document boundary, legacy migration/rollback 정책을 ADR로 확정한다.
-2. `TASK-030`: checklist/plans/templates/members 공통 document-primary repository 계약을 만든다.
-3. `TASK-031`과 `TASK-032`: Web/App의 준비물, 일정, 템플릿, 동행자 초대/수락/거부를 document-primary로 전환한다.
-4. `TASK-033`과 `TASK-034`: 모든 도메인 mutation을 encrypted backup sync와 P2P fast path에 연결한다.
-5. `TASK-035`: 전체 기능이 구현된 뒤 Web/App 통합 테스트와 실기기 smoke를 수행한다.
-6. `TASK-036`: 완성된 제품 기준으로 Closed Beta 출시 준비를 완료한다.
+1. `TASK-030`: checklist/plans/templates/members 공통 document-primary repository 계약을 만든다.
+2. `TASK-031`과 `TASK-032`: Web/App의 준비물, 일정, 템플릿, 동행자 초대/수락/거부를 document-primary로 전환한다.
+3. `TASK-033`과 `TASK-034`: 모든 도메인 mutation을 encrypted backup sync와 P2P fast path에 연결한다.
+4. `TASK-035`: 전체 기능이 구현된 뒤 Web/App 통합 테스트와 실기기 smoke를 수행한다.
+5. `TASK-036`: 완성된 제품 기준으로 Closed Beta 출시 준비를 완료한다.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,38 @@
+# Walkthrough: TASK-029 Full Local-first Product Scope ADR
+
+## Summary
+
+TASK-029는 checklist pilot 이후의 작업 축을 전체 제품 document-primary 전환으로 확정했다. ADR-013에서
+Web/Mobile의 준비물, 일정, 템플릿, 동행자 초대/수락/거부, 권한 변경, backup restore/sync, P2P fast path를
+모두 Local-first 완료 범위로 정의했다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-029-full-local-first-product-scope-adr.md`
+- `docs/refactor/adrs/ADR-013-full-local-first-product-scope.md`
+- `docs/refactor/progress.md`
+- `docs/refactor/TECHNICAL-SPEC.md`
+- `_workspace/01_planner_analysis.md`
+
+## Key Decisions
+
+- `TripDocumentV1`은 trip-scoped 데이터의 root document로 유지한다.
+- 개인/공유/공개 템플릿은 trip collaborator 범위와 다르므로 별도 `TemplateDocumentV1` boundary로 분리한다.
+- 템플릿 적용은 Template document snapshot을 읽어 `TripDocumentV1` checklist item mutation으로 복사한다.
+- Supabase row table은 장기 dual-write 대상이 아니라 migration source와 read-only rollback fallback으로 축소한다.
+- 통합테스트와 Closed Beta는 일부 기능이 아니라 전체 핵심 기능이 document-primary 제품 경로에 올라간 뒤 진행한다.
+
+## Verification
+
+- `git diff --check` 성공
+- 문서 변경만 수행했고 코드/DB migration/API 변경은 없다.
+
+## Next
+
+- `TASK-030-document-primary-repository-layer.md`: checklist/plans/templates/members 공통 document-primary repository 계약 도입
+
+---
+
 # Walkthrough: TASK-028 Rotating Room Secret Hardening
 
 ## Summary


### PR DESCRIPTION
## Summary
 Add ADR-013 to define the full-product Local-first document-primary scope
- Decide that trip-scoped data remains in TripDocumentV1 while personal/shared/public templates move to a separate TemplateDocumentV1 boundary
- Clarify that legacy Supabase rows become migration source/read-only fallback instead of long-term dual-write sync targets
- Update refactor progress, technical spec, task README, and walkthrough for TASK-029 completion

## Verification
- git diff --check\n- Documentation-only change; no code, DB migration, or API changes

Resolves #316