### PR TITLE
TASK-031: Web full document-primary transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ✈️ OnVoy (nexvoy-frontend)
+# ✈️ 온여정 (OnVoy)
 
 **OnVoy**는 복잡한 여행 계획을 한눈에 정리하고, 현지 시간과 체크리스트를 스마트하게 관리할 수 있도록 돕는 프리미엄 여행 플래너 웹 앱입니다.
 
-![OnVoy UI Mockup](https://via.placeholder.com/800x400.png?text=OnVoy+Smart+Travel+Planner) *<!-- 실제 이미지가 있다면 교체 가능 -->*
+![온여정 UI Mockup](https://via.placeholder.com/800x400.png?text=OnVoy+Smart+Travel+Planner) *<!-- 실제 이미지가 있다면 교체 가능 -->*
 
 ## 🤖 AI 어시스턴트를 위한 가이드 (For AI Assistants)
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "NexVoy",
+    "name": "온여정",
     "slug": "nexvoy-app",
     "version": "0.1.0",
     "orientation": "portrait",

--- a/apps/web/app/templates/page.tsx
+++ b/apps/web/app/templates/page.tsx
@@ -7,11 +7,12 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Skeleton from '@/components/ui/Skeleton'
 import CommonListSkeleton from '@/components/common/CommonListSkeleton'
-import { formatDate, getTemplatesWithPreview } from '@nexvoy/core'
+import { formatDate } from '@nexvoy/core'
 import type { TemplateWithPreview } from '@nexvoy/types'
 
 import { useUIStore } from '@/stores/useUIStore'
 import { CacheUtil } from '@/lib/cache'
+import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
 
 export default function TemplatesPage() {
     const supabase = createClient()
@@ -37,7 +38,21 @@ export default function TemplatesPage() {
                 return
             }
 
-            setTemplates(await getTemplatesWithPreview(supabase, user.id))
+            const repositories = await createWebDocumentPrimaryRepositories(supabase)
+            const templateSummaries = await repositories.templates.listTemplates(user.id)
+            setTemplates(templateSummaries.map((template) => ({
+                id: template.id,
+                title: template.title,
+                user_id: template.ownerId,
+                item_count: template.itemCount,
+                preview_items: template.previewItems,
+                created_at: template.updatedAt,
+                access: template.ownerId === user.id
+                    ? 'owner'
+                    : template.visibility === 'public'
+                        ? 'default'
+                        : 'viewer',
+            })))
             setLoading(false)
         }
 

--- a/apps/web/app/trips/checklist/ChecklistClient.tsx
+++ b/apps/web/app/trips/checklist/ChecklistClient.tsx
@@ -380,7 +380,9 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
     const isLocalFirstChecklistSpike = repositories.mode === 'local-first-checklist-spike'
     const isLocalFirstChecklistMode = repositories.mode === 'local-first-checklist-spike'
         || repositories.mode === 'local-first-checklist-dual-write'
+        || repositories.mode === 'document-primary'
     const canApplyTemplates = repositories.mode === 'legacy-supabase'
+        || repositories.mode === 'document-primary'
     const canUseChecklistActions = (isOnline || isLocalFirstChecklistSpike) && !isOffline
 
     const [isLoading, setIsLoading] = useState(true)
@@ -441,7 +443,7 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
 
             // 2. 네트워크 확인
             const { isOfflineMode } = useNetworkStore.getState()
-            if (!isLocalFirstChecklistSpike && (!isOnline || isOfflineMode)) {
+            if (!isLocalFirstChecklistMode && (!isOnline || isOfflineMode)) {
                 setIsLoading(false)
                 return
             }
@@ -695,6 +697,9 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
     }
 
     const participants = getParticipants()
+    const currentUserRole = currentUser?.id === tripOwner?.id
+        ? 'owner'
+        : members.find((member) => member.user_id === currentUser?.id)?.role ?? null
     const totalMembersCount = participants.length
     const getAssignedUserIds = (item: any): string[] => {
         const assigned = itemAssignees
@@ -1651,6 +1656,8 @@ export default function ChecklistPage({ isActive = true, tripId: propsTripId, is
                     isOpen={isTemplateModalOpen}
                     onClose={() => setIsTemplateModalOpen(false)}
                     checklistId={checklistId}
+                    tripId={tripId!}
+                    currentUserRole={currentUserRole}
                     currentUser={currentUser}
                     onSuccess={(newItems) => {
                         setItems(prev => [...prev, ...newItems])

--- a/apps/web/app/trips/detail/TripClient.tsx
+++ b/apps/web/app/trips/detail/TripClient.tsx
@@ -20,6 +20,9 @@ import { DownloadService } from '@/services/DownloadService'
 import { PlanPhotoStorageService } from '@/services/PlanPhotoStorageService'
 import { Download, CloudDownload, CloudCheck, Loader2 } from 'lucide-react'
 import TripDetailSkeleton from './TripDetailSkeleton'
+import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import type { PlanTimelineItemReadModel } from '@nexvoy/core/local-first/materialize'
+import type { CreatePlanMutationInput } from '@nexvoy/core/local-first/documentMutationWriter'
 const CustomTimeDropdown = ({ timeDisplayMode, setTimeDisplayMode }: any) => {
     const [isOpen, setIsOpen] = useState(false);
     const options = [
@@ -185,8 +188,9 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             if (bundle?.trip) setTrip(bundle.trip)
             return
         }
-        const { data } = await supabase.from('trips').select('*').eq('id', tripId).single()
-        if (data) setTrip(data)
+        const repositories = await createWebDocumentPrimaryRepositories(supabase)
+        const data = await repositories.trips.getTrip(tripId)
+        if (data) setTrip(toLegacyTripRow(data))
     }, [tripId, supabase, isOffline])
 
     const fetchPlans = useCallback(async () => {
@@ -207,36 +211,10 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                 return
             }
 
-            const { data: planRows, error: plansError } = await supabase
-                .from('plans')
-                .select('*')
-                .eq('trip_id', tripId)
-                .order('start_datetime_local', { ascending: true })
-            if (plansError) throw plansError
-
-            const planIds = (planRows || []).map((plan: any) => plan.id)
-            let urlsByPlan = new Map<string, any[]>()
-            if (planIds.length > 0) {
-                const { data: urlRows, error: urlsError } = await supabase
-                    .from('plan_urls')
-                    .select('*')
-                    .in('plan_id', planIds)
-                if (urlsError) {
-                    console.warn('Plan URL fetch failed; rendering plans without attached URLs', urlsError)
-                } else {
-                    ;(urlRows || []).forEach((url: any) => {
-                        urlsByPlan.set(url.plan_id, [
-                            ...(urlsByPlan.get(url.plan_id) || []),
-                            url,
-                        ])
-                    })
-                }
-            }
-
-            const data = (planRows || []).map((plan: any) => ({
-                ...plan,
-                plan_urls: urlsByPlan.get(plan.id) || [],
-            }))
+            const repositories = await createWebDocumentPrimaryRepositories(supabase)
+            const data = (await repositories.plans.listPlans(tripId)).map((plan) =>
+                toLegacyPlanRow(tripId, plan),
+            )
 
             if (data) {
                 setPlans(data)
@@ -254,7 +232,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
         } finally {
             setIsLoading(false)
         }
-    }, [tripId, supabase, isOnline, plans.length])
+    }, [tripId, supabase, isOnline])
 
     const fetchUserRole = useCallback(async () => {
         if (!tripId) return
@@ -272,6 +250,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
 
 
     const handleDeletePlan = async (planId: string) => {
+        if (!tripId) return
         if (!confirm('이 일정을 삭제하시겠습니까? (연결된 정보도 함께 삭제됩니다)')) return
 
         // Storage cleanup은 best-effort: 실패해도 plan DELETE는 계속 진행
@@ -283,12 +262,13 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             }
         }
 
-        const { error } = await supabase.from('plans').delete().eq('id', planId)
-        if (error) {
-            alert('삭제에 실패했습니다.')
-        } else {
+        try {
+            const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+            await repositories.plans.deletePlan(tripId, planId)
             setActiveDropdown(null)
-            fetchPlans() // 목록 리프레시
+            fetchPlans()
+        } catch {
+            alert('삭제에 실패했습니다.')
         }
     }
 
@@ -300,15 +280,20 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
         setSelectedPlanForDetail((cur: any) => (
             cur && cur.id === planId ? { ...cur, image_url: newImageUrl } : cur
         ))
-    }, [])
+        if (tripId && (userRole === 'owner' || userRole === 'editor')) {
+            createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+                .then((repositories) => repositories.plans.updatePlan(tripId, {
+                    planId,
+                    patch: { imageUrl: newImageUrl },
+                }))
+                .catch((err) => console.warn('[TripClient] imageUrl document update failed', err))
+        }
+    }, [supabase, tripId])
 
     const handleEditPlan = async (plan: any) => {
-        // 편집을 위해, 해당 Plan에 연결된 url들도 같이 가져옵니다
-        const { data: urlsData } = await supabase.from('plan_urls').select('url').eq('plan_id', plan.id)
-
         setEditingPlan({
             ...plan,
-            plan_urls: urlsData || []
+            plan_urls: plan.plan_urls || []
         })
         setActiveDropdown(null)
         setIsModalOpen(true) // Edit 모드로 모달 열기
@@ -324,17 +309,47 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
     }
 
     const handleToggleVisit = async (planId: string, isVisited: boolean) => {
+        if (!tripId) return
         // 낙관적 UI 업데이트
         setPlans(prev => prev.map(p => p.id === planId ? { ...p, is_visited: isVisited } : p))
         // 디테일 모달이 열려 있으면 선택된 plan도 업데이트
         setSelectedPlanForDetail((prev: any) => prev && prev.id === planId ? { ...prev, is_visited: isVisited } : prev)
-        const { error } = await supabase.from('plans').update({ is_visited: isVisited }).eq('id', planId)
-        if (error) {
+        try {
+            const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+            await repositories.plans.updatePlan(tripId, {
+                planId,
+                patch: { isVisited },
+            })
+        } catch {
             // 실패 시 롤백
             setPlans(prev => prev.map(p => p.id === planId ? { ...p, is_visited: !isVisited } : p))
             setSelectedPlanForDetail((prev: any) => prev && prev.id === planId ? { ...prev, is_visited: !isVisited } : prev)
         }
     }
+
+    const handleSavePlan = useCallback(async ({ plan, editPlanId }: {
+        plan: any
+        editPlanId?: string
+    }): Promise<string> => {
+        if (!tripId) throw new Error('여행 정보를 찾을 수 없어요.')
+        if (userRole !== 'owner' && userRole !== 'editor') {
+            throw new Error('일정을 수정할 권한이 없습니다.')
+        }
+        const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+        const planId = editPlanId ?? createLocalPlanId()
+        const input = toDocumentPlanInput(planId, plan)
+
+        if (editPlanId) {
+            await repositories.plans.updatePlan(tripId, {
+                planId,
+                patch: input,
+            })
+        } else {
+            await repositories.plans.createPlan(tripId, input)
+        }
+
+        return planId
+    }, [supabase, tripId, userRole])
 
     const handlePlanDetail = (plan: any) => {
         setSelectedPlanForDetail(plan)
@@ -548,6 +563,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                     tripStartDate={trip?.start_date}
                     tripEndDate={trip?.end_date}
                     onPlanImageUpdated={handlePlanImageRecovered}
+                    onSavePlan={handleSavePlan}
                 />
             )}
             {tripId && (
@@ -596,4 +612,109 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             )}
         </div>
     )
+}
+
+function toLegacyTripRow(trip: {
+    id: string
+    ownerId: string
+    destination: string
+    startDate: string
+    endDate: string
+    adultsCount: number
+    childrenCount: number
+    coverImageRef: string | null
+    bgColor: string | null
+}) {
+    return {
+        id: trip.id,
+        user_id: trip.ownerId,
+        destination: trip.destination,
+        start_date: trip.startDate,
+        end_date: trip.endDate,
+        adults_count: trip.adultsCount,
+        children_count: trip.childrenCount,
+        cover_image_ref: trip.coverImageRef,
+        bg_color: trip.bgColor,
+    }
+}
+
+function toLegacyPlanRow(tripId: string, plan: PlanTimelineItemReadModel) {
+    return {
+        id: plan.id,
+        trip_id: tripId,
+        title: plan.title,
+        location: plan.location,
+        address: plan.address,
+        location_lat: plan.coordinates?.lat ?? 0,
+        location_lng: plan.coordinates?.lng ?? 0,
+        google_place_id: plan.googlePlaceId,
+        image_url: plan.imageUrl,
+        photo_reference: plan.photoReference,
+        start_datetime_local: plan.startDateTimeLocal,
+        end_datetime_local: plan.endDateTimeLocal,
+        timezone_string: plan.timezone,
+        alarm_minutes_before: plan.alarmMinutesBefore,
+        alarm_sent_at: plan.alarmSentAt,
+        cost: plan.cost,
+        memo: plan.memo,
+        is_completed: plan.isCompleted,
+        is_visited: plan.isVisited,
+        plan_urls: plan.urls.map((url) => ({
+            id: url.id,
+            plan_id: url.planId,
+            url: url.url,
+            created_at: url.createdAt,
+        })),
+    }
+}
+
+function toDocumentPlanInput(planId: string, plan: {
+    title: string
+    location: string | null
+    address: string | null
+    location_lat?: number | null
+    location_lng?: number | null
+    google_place_id?: string | null
+    image_url?: string | null
+    photo_reference?: string | null
+    start_datetime_local: string
+    end_datetime_local: string
+    timezone_string?: string | null
+    alarm_minutes_before?: number | null
+    alarm_sent_at?: string | null
+    cost?: number | null
+    memo?: string | null
+    is_completed?: boolean | null
+    is_visited?: boolean | null
+}): CreatePlanMutationInput {
+    const now = new Date().toISOString()
+    const lat = plan.location_lat ?? null
+    const lng = plan.location_lng ?? null
+
+    return {
+        id: planId,
+        title: plan.title,
+        location: plan.location,
+        address: plan.address,
+        coordinates: lat === null || lng === null ? null : { lat, lng },
+        googlePlaceId: plan.google_place_id ?? null,
+        imageUrl: plan.image_url ?? null,
+        photoReference: plan.photo_reference ?? null,
+        startDateTimeLocal: plan.start_datetime_local,
+        endDateTimeLocal: plan.end_datetime_local,
+        timezone: plan.timezone_string ?? 'Asia/Seoul',
+        alarmMinutesBefore: plan.alarm_minutes_before ?? null,
+        alarmSentAt: plan.alarm_sent_at ?? null,
+        cost: plan.cost ?? 0,
+        memo: plan.memo ?? null,
+        isCompleted: plan.is_completed ?? false,
+        isVisited: plan.is_visited ?? false,
+        createdAt: now,
+        updatedAt: now,
+    }
+}
+
+function createLocalPlanId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+    return `plan-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }

--- a/apps/web/components/template/EditTemplateModal.tsx
+++ b/apps/web/components/template/EditTemplateModal.tsx
@@ -20,6 +20,7 @@ import {
     updateTemplateShareRole,
 } from '@nexvoy/core'
 import type { ChecklistCategory, ChecklistTemplateShareWithProfile } from '@nexvoy/types'
+import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
 
 interface EditTemplateModalProps {
     isOpen: boolean
@@ -53,25 +54,17 @@ export default function EditTemplateModal({ isOpen, onClose, templateId, onSucce
         
         setFetching(true)
         try {
-            const { data, error } = await supabase
-                .from('checklist_templates')
-                .select(`
-                    id, 
-                    user_id,
-                    title, 
-                    checklist_template_items (id, item_name, category, is_private)
-                `)
-                .eq('id', templateId)
-                .single()
+            const repositories = await createWebDocumentPrimaryRepositories(supabase)
+            const data = await repositories.templates.getTemplate(templateId)
 
             if (data) {
-                setOwnerId(data.user_id)
+                setOwnerId(data.ownerId)
                 setTitle(data.title)
-                const mappedItems = (data.checklist_template_items || []).map((item: any) => ({
+                const mappedItems = data.items.map((item) => ({
                     id: item.id,
-                    item_name: item.item_name,
-                    category: item.category || '기타',
-                    is_private: item.is_private || false,
+                    item_name: item.name,
+                    category: item.categoryName || '기타',
+                    is_private: item.isPrivate || false,
                     isNew: false
                 }))
                 setItems(mappedItems)
@@ -82,13 +75,20 @@ export default function EditTemplateModal({ isOpen, onClose, templateId, onSucce
                 if (session?.user.id) {
                     const [categoryData, shareData] = await Promise.all([
                         getChecklistCategories(supabase, session.user.id),
-                        getTemplateShares(supabase, templateId),
+                        Promise.resolve(data.shares.map((share) => ({
+                            id: share.id,
+                            template_id: share.templateId,
+                            shared_with_user_id: share.sharedWithUserId,
+                            role: share.role,
+                            created_by: share.createdBy,
+                            created_at: share.createdAt,
+                            profiles: null,
+                        } satisfies ChecklistTemplateShareWithProfile))),
                     ])
                     setCategories(categoryData)
                     setShares(shareData)
                 }
-            } else if (error) {
-                console.error("Fetch template error:", error)
+            } else {
                 alert('템플릿 정보를 불러오는 데 실패했어요.')
                 onClose()
             }
@@ -120,8 +120,8 @@ export default function EditTemplateModal({ isOpen, onClose, templateId, onSucce
 
         setLoading(true)
         try {
-            const { error } = await supabase.from('checklist_templates').delete().eq('id', templateId)
-            if (error) throw error
+            const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+            await repositories.templates.deleteTemplate(templateId)
             
             if (onSuccess) onSuccess()
             onClose()
@@ -154,49 +154,19 @@ export default function EditTemplateModal({ isOpen, onClose, templateId, onSucce
         setLoading(true)
 
         try {
-            // 1. 타이틀 업데이트
-            const { error: titleError } = await supabase
-                .from('checklist_templates')
-                .update({ title: title.trim() })
-                .eq('id', templateId)
-
-            if (titleError) throw titleError
-
-            // 2. 삭제된 항목 처리
-            // UI에서 제거된 항목들 중 원래 DB에 있던 것들 찾기
-            const currentItemIds = items.map(i => i.id)
-            const itemsToDelete = originalItemIds.filter(id => !currentItemIds.includes(id))
-            
-            if (itemsToDelete.length > 0) {
-                await supabase.from('checklist_template_items').delete().in('id', itemsToDelete)
-            }
-
-            // 3. Upsert / Insert
-            const existingItems = validItems.filter(i => !i.isNew)
-            const newItems = validItems.filter(i => i.isNew)
-
-            if (existingItems.length > 0) {
-                await supabase.from('checklist_template_items').upsert(
-                    existingItems.map(i => ({
-                        id: i.id,
-                        template_id: templateId,
-                        item_name: i.item_name.trim(),
-                        category: i.category,
-                        is_private: i.is_private
-                    }))
-                )
-            }
-
-            if (newItems.length > 0) {
-                await supabase.from('checklist_template_items').insert(
-                    newItems.map(i => ({
-                        template_id: templateId,
-                        item_name: i.item_name.trim(),
-                        category: i.category,
-                        is_private: i.is_private
-                    }))
-                )
-            }
+            const repositories = await createWebDocumentPrimaryRepositories(supabase, {
+                actorRole: canManageShares ? 'owner' : 'editor',
+            })
+            await repositories.templates.updateTemplate(templateId, { title: title.trim() })
+            await repositories.templates.replaceItems(templateId, {
+                items: validItems.map((item, index) => ({
+                    id: item.isNew ? createLocalTemplateItemId() : item.id,
+                    name: item.item_name.trim(),
+                    categoryName: item.category,
+                    isPrivate: item.is_private,
+                    sortOrder: index,
+                })),
+            })
 
             if (onSuccess) onSuccess()
             onClose()
@@ -432,4 +402,9 @@ export default function EditTemplateModal({ isOpen, onClose, templateId, onSucce
             </div>
         </div>
     )
+}
+
+function createLocalTemplateItemId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+    return `template-item-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }

--- a/apps/web/components/template/NewTemplateModal.tsx
+++ b/apps/web/components/template/NewTemplateModal.tsx
@@ -7,6 +7,7 @@ import { X, Sparkles } from 'lucide-react'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useRouter } from 'next/navigation'
 import TemplateForm, { TemplateItemInput } from './TemplateForm'
+import { createWebTemplateDocument } from '@/lib/local-first/documentPrimaryRepositories'
 import {
     createChecklistCategory,
     deleteChecklistCategory,
@@ -99,37 +100,20 @@ export default function NewTemplateModal({ isOpen, onClose, onSuccess }: NewTemp
             const { data: { session } } = await supabase.auth.getSession()
             if (!session?.user) throw new Error('인증 정보가 없습니다.')
 
-            // 1. 템플릿 레코드 생성
-            const { data: newTemplate, error: templateError } = await supabase
-                .from('checklist_templates')
-                .insert({
-                    user_id: session.user.id,
-                    title: title.trim()
-                })
-                .select()
-                .single()
-
-            if (templateError) throw templateError
-
-            // 2. 템플릿 하위 항목 생성
-            const itemsToInsert = validItems.map((item) => ({
-                template_id: newTemplate.id,
-                item_name: item.item_name.trim(),
-                category: item.category,
-                is_private: item.is_private
-            }))
-
-            const { error: itemsError } = await supabase
-                .from('checklist_template_items')
-                .insert(itemsToInsert)
-
-            if (itemsError) throw itemsError
+            await createWebTemplateDocument({
+                supabase,
+                title: title.trim(),
+                items: validItems.map((item) => ({
+                    item_name: item.item_name.trim(),
+                    category: item.category,
+                    is_private: item.is_private,
+                })),
+            })
 
             resetForm()
             if (onSuccess) onSuccess()
             onClose()
             router.refresh()
-
         } catch (error: any) {
             console.error('Error creating template:', error)
             alert('저장 중에 잠시 문제가 생겼어요. 다시 한번 시도해 주시겠어요?')

--- a/apps/web/components/trips/CollaboratorModal.tsx
+++ b/apps/web/components/trips/CollaboratorModal.tsx
@@ -15,6 +15,7 @@ import {
     type DocumentKeyProvisioningStatus,
 } from './DocumentKeyProvisioningStatus'
 import { ensureWebDeviceKeyMaterial, runWebForegroundKeyProvisioning } from '@/lib/local-first/keyProvisioningService'
+import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
 
 interface CollaboratorModalProps {
     isOpen: boolean
@@ -128,6 +129,7 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
         }))
 
         setCollaborators(formatted)
+        await syncCollaboratorSnapshot(formatted)
     }
 
     const handleInvite = async (e: React.FormEvent) => {
@@ -174,6 +176,10 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
             setCollaborators(prev =>
                 prev.map(m => m.memberId === memberId ? { ...m, role: newRole } : m)
             )
+            const member = collaborators.find((candidate) => candidate.memberId === memberId)
+            if (member) {
+                await upsertCollaboratorSnapshot({ ...member, role: newRole })
+            }
         }
         setEditingRoleId(null)
     }
@@ -186,11 +192,52 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
             alert((isSelf ? '나가기 실패: ' : '멤버 삭제 실패: ') + formatErrorMessage(error))
         } else {
             if (isSelf) {
+                await revokeCollaboratorSnapshot(memberId)
                 onClose()
                 window.location.href = '/'
             } else {
+                await revokeCollaboratorSnapshot(memberId)
                 fetchCollaborators()
             }
+        }
+    }
+
+    const syncCollaboratorSnapshot = async (members: Collaborator[]) => {
+        try {
+            const repositories = await createWebDocumentPrimaryRepositories(supabase, {
+                actorRole: currentMemberRole ?? null,
+            })
+            await Promise.all(members.map((member) =>
+                repositories.members.upsertMember(tripId, {
+                    member: toTripMemberNode(member),
+                }),
+            ))
+        } catch (err) {
+            console.warn('[CollaboratorModal] member snapshot sync failed', err)
+        }
+    }
+
+    const upsertCollaboratorSnapshot = async (member: Collaborator) => {
+        try {
+            const repositories = await createWebDocumentPrimaryRepositories(supabase, {
+                actorRole: currentMemberRole ?? null,
+            })
+            await repositories.members.upsertMember(tripId, {
+                member: toTripMemberNode(member),
+            })
+        } catch (err) {
+            console.warn('[CollaboratorModal] member snapshot upsert failed', err)
+        }
+    }
+
+    const revokeCollaboratorSnapshot = async (memberId: string) => {
+        try {
+            const repositories = await createWebDocumentPrimaryRepositories(supabase, {
+                actorRole: currentMemberRole ?? null,
+            })
+            await repositories.members.revokeMember(tripId, memberId)
+        } catch (err) {
+            console.warn('[CollaboratorModal] member snapshot revoke failed', err)
         }
     }
 
@@ -600,6 +647,25 @@ function formatErrorMessage(error: unknown): string {
     if (typeof error === 'string') return error
     if (error instanceof Error) return error.message
     return '잠시 후 다시 시도해 주세요.'
+}
+
+function toTripMemberNode(member: Collaborator) {
+    const now = new Date().toISOString()
+    return {
+        id: member.memberId,
+        userId: member.userId,
+        invitedEmail: member.userId ? null : member.email,
+        role: member.role,
+        status: member.status === 'revoked'
+            ? 'revoked' as const
+            : member.status === 'pending'
+                ? 'pending' as const
+                : 'accepted' as const,
+        nickname: member.nickname,
+        email: member.email,
+        createdAt: member.joined_at || now,
+        updatedAt: now,
+    }
 }
 
 function getMemberKeyProvisioningStatus(

--- a/apps/web/components/trips/NewPlanModal.tsx
+++ b/apps/web/components/trips/NewPlanModal.tsx
@@ -43,6 +43,10 @@ interface NewPlanModalProps {
      * 부모가 plans 리스트의 해당 항목 image_url을 패치할 때 사용.
      */
     onPlanImageUpdated?: (planId: string, imageUrl: string) => void
+    onSavePlan?: (input: {
+        plan: PlanInsert
+        editPlanId?: string
+    }) => Promise<string>
 }
 
 // ── 핵심 타입 정의 ──
@@ -69,6 +73,7 @@ export default function NewPlanModal({
     tripEndDate = '',
     editData,
     onPlanImageUpdated,
+    onSavePlan,
 }: NewPlanModalProps) {
     const supabase = createClient()
     const [step, setStep] = useState(1) // 1: 장소검색, 2: 상세입력
@@ -320,7 +325,12 @@ export default function NewPlanModal({
             }
 
             let savedPlanId: string | null = null
-            if (editData?.id) {
+            if (onSavePlan) {
+                savedPlanId = await onSavePlan({
+                    plan: planData,
+                    editPlanId: editData?.id,
+                })
+            } else if (editData?.id) {
                 const result = await supabase
                     .from('plans')
                     .update(planData)

--- a/apps/web/components/trips/TemplateModal.tsx
+++ b/apps/web/components/trips/TemplateModal.tsx
@@ -6,17 +6,19 @@ import { X, Copy, Loader2 } from 'lucide-react'
 import { useScrollLock } from '@/hooks/useScrollLock'
 import { analytics } from '@/services/AnalyticsService'
 import { createClient } from '@/lib/supabase/client'
-import { applyTemplateToChecklist, getTemplatesWithPreview } from '@nexvoy/core'
+import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
 
 interface TemplateModalProps {
     isOpen: boolean
     onClose: () => void
     checklistId: string
+    tripId: string
+    currentUserRole: 'owner' | 'editor' | 'viewer' | null
     currentUser: any
     onSuccess: (newItems: any[]) => void
 }
 
-export default function TemplateModal({ isOpen, onClose, checklistId, currentUser, onSuccess }: TemplateModalProps) {
+export default function TemplateModal({ isOpen, onClose, checklistId, tripId, currentUserRole, currentUser, onSuccess }: TemplateModalProps) {
     const supabase = createClient()
     const [templates, setTemplates] = useState<any[]>([])
     const [loading, setLoading] = useState(false)
@@ -31,7 +33,17 @@ export default function TemplateModal({ isOpen, onClose, checklistId, currentUse
             setLoading(true)
 
             if (currentUser?.id) {
-                setTemplates(await getTemplatesWithPreview(supabase, currentUser.id))
+                const repositories = await createWebDocumentPrimaryRepositories(supabase)
+                const summaries = await repositories.templates.listTemplates(currentUser.id)
+                setTemplates(summaries.map((template) => ({
+                    id: template.id,
+                    title: template.title,
+                    access: template.ownerId === currentUser.id
+                        ? 'owner'
+                        : template.visibility === 'public'
+                            ? 'default'
+                            : 'viewer',
+                })))
             }
             setLoading(false)
         }
@@ -44,7 +56,32 @@ export default function TemplateModal({ isOpen, onClose, checklistId, currentUse
         setLoadingTemplateId(templateId)
 
         try {
-            const insertedItems = await applyTemplateToChecklist(supabase, checklistId, templateId, currentUser?.id)
+            const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: currentUserRole })
+            const template = await repositories.templates.getTemplate(templateId)
+            if (!template) throw new Error('Template document was not found.')
+            const result = await repositories.checklists.applyTemplate(
+                tripId,
+                checklistId,
+                templateId,
+                template.items.map(() => createLocalChecklistItemId()),
+            )
+            const insertedItems = result.changedEntities
+                .filter((entity) => entity.entityType === 'checklistItem')
+                .map((entity) => result.document.checklistItems[entity.entityId])
+                .filter(Boolean)
+                .map((item) => ({
+                    id: item.id,
+                    checklist_id: item.checklistId,
+                    item_name: item.name,
+                    category: item.categoryName,
+                    is_checked: item.legacyIsChecked,
+                    is_private: item.isPrivate,
+                    assignment_type: item.assignmentType,
+                    assigned_user_id: item.assignedUserId,
+                    source_template_name: item.sourceTemplateName,
+                    created_at: item.createdAt,
+                    updated_at: item.updatedAt,
+                }))
             if (insertedItems.length === 0) {
                 alert('완전해요! 해당 템플릿의 모든 항목이 이미 체크리스트에 들어있어요.')
                 return
@@ -142,4 +179,9 @@ export default function TemplateModal({ isOpen, onClose, checklistId, currentUse
             </div>
         </div>
     )
+}
+
+function createLocalChecklistItemId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+    return `checklist-item-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }

--- a/apps/web/lib/local-first/documentPrimaryChecklistRepository.ts
+++ b/apps/web/lib/local-first/documentPrimaryChecklistRepository.ts
@@ -1,0 +1,276 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type {
+  ChecklistItem,
+  ChecklistItemAssignee,
+  ChecklistItemUserCheck,
+} from '@nexvoy/types'
+import type {
+  ChecklistRepository,
+  ChecklistRepositorySnapshot,
+  ChecklistItemMutationResult,
+  ChecklistMemberSnapshot,
+  ToggleChecklistItemForUserInput,
+} from '@nexvoy/core/repositories/types'
+import type { ChecklistItemInput } from '@nexvoy/core/supabase/queries'
+import type {
+  ChecklistItemReadModel,
+  ChecklistReadModel,
+  TripDetailReadModel,
+  TripMemberReadModel,
+} from '@nexvoy/core/local-first/materialize'
+import type { TripDocumentV1 } from '@nexvoy/core/local-first/documentModel'
+import { createWebDocumentPrimaryRepositories } from './documentPrimaryRepositories'
+
+export function createWebDocumentPrimaryChecklistRepository(
+  supabase: SupabaseClient,
+): ChecklistRepository {
+  return {
+    getChecklist: async (tripId) => {
+      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const [trip, checklists] = await Promise.all([
+        repositories.trips.getTrip(tripId),
+        repositories.checklists.getChecklist(tripId),
+      ])
+      if (!trip) throw new Error('Trip document was not found.')
+      return toChecklistSnapshot(trip, checklists)
+    },
+    createItem: async (checklistId, input) => {
+      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const tripId = await resolveTripIdForChecklist(repositories, checklistId)
+      if (!tripId) throw new Error('Checklist document was not found.')
+      const role = await resolveCurrentTripRole(supabase, repositories, tripId)
+      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      const itemId = createEntityId('checklist-item')
+      const result = await writeRepositories.checklists.createItem(tripId, {
+        id: itemId,
+        checklistId,
+        name: input.item_name.trim(),
+        categoryName: input.category ?? '기타',
+        legacyIsChecked: false,
+        isPrivate: input.is_private ?? false,
+        assignmentType: input.assignment_type ?? 'anyone',
+        assignedUserId: input.assigned_user_id ?? input.assignee_ids?.[0] ?? null,
+        sourceTemplateName: input.source_template_name ?? null,
+        assigneeIds: input.assignee_ids ?? [],
+      })
+      return toMutationResult(result.document, itemId)
+    },
+    updateItem: async (itemId, input) => {
+      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const resolved = await resolveTripAndItem(repositories, itemId)
+      if (!resolved) throw new Error('Checklist item document was not found.')
+      const role = await resolveCurrentTripRole(supabase, repositories, resolved.tripId)
+      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      const result = await writeRepositories.checklists.updateItem(resolved.tripId, {
+        itemId,
+        patch: {
+          name: input.item_name.trim(),
+          categoryName: input.category ?? '기타',
+          isPrivate: input.is_private ?? false,
+          assignmentType: input.assignment_type ?? 'anyone',
+          assignedUserId: input.assigned_user_id ?? input.assignee_ids?.[0] ?? null,
+          sourceTemplateName: input.source_template_name ?? resolved.item.sourceTemplateName,
+        },
+        assigneeIds: input.assignee_ids ?? [],
+      })
+      return toMutationResult(result.document, itemId)
+    },
+    deleteItem: async (itemId) => {
+      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const resolved = await resolveTripAndItem(repositories, itemId)
+      if (!resolved) throw new Error('Checklist item document was not found.')
+      const role = await resolveCurrentTripRole(supabase, repositories, resolved.tripId)
+      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      await writeRepositories.checklists.deleteItem(resolved.tripId, itemId)
+    },
+    toggleItem: async (itemId, isChecked) => {
+      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const resolved = await resolveTripAndItem(repositories, itemId)
+      if (!resolved) throw new Error('Checklist item document was not found.')
+      const role = await resolveCurrentTripRole(supabase, repositories, resolved.tripId)
+      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      await writeRepositories.checklists.toggleItem(resolved.tripId, {
+        itemId,
+        nextChecked: isChecked,
+      })
+    },
+    toggleItemForUser: async (input) => {
+      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const resolved = await resolveTripAndItem(repositories, input.item.id)
+      if (!resolved) throw new Error('Checklist item document was not found.')
+      const role = await resolveCurrentTripRole(supabase, repositories, resolved.tripId)
+      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      const result = await writeRepositories.checklists.toggleItem(resolved.tripId, {
+        itemId: input.item.id,
+        nextChecked: input.nextChecked,
+        currentUserId: input.currentUserId,
+        participantIds: input.participantIds,
+      })
+      const checklists = await repositories.checklists.getChecklist(result.document.trip.id)
+      return checklists.flatMap((checklist) => checklist.items)
+        .find((item) => item.id === input.item.id)?.userChecks
+        .map(toUserCheckRow) ?? []
+    },
+  }
+}
+
+function toChecklistSnapshot(
+  trip: TripDetailReadModel,
+  checklists: ChecklistReadModel[],
+): ChecklistRepositorySnapshot {
+  const items = checklists.flatMap((checklist) => checklist.items.map(toChecklistItemRow))
+  return {
+    checklistId: checklists[0]?.id ?? null,
+    checklists: checklists.map((checklist) => ({
+      id: checklist.id,
+      trip_id: trip.id,
+      title: checklist.title,
+      created_at: checklist.createdAt,
+    })),
+    trip: {
+      id: trip.id,
+      user_id: trip.ownerId,
+      destination: trip.destination,
+      start_date: trip.startDate,
+      end_date: trip.endDate,
+      adults_count: trip.adultsCount,
+      children_count: trip.childrenCount,
+      created_at: trip.updatedAt,
+      updated_at: trip.updatedAt,
+    },
+    items,
+    members: trip.members
+      .filter((member) => member.status !== 'revoked')
+      .map(toChecklistMemberRow),
+    userChecks: checklists.flatMap((checklist) =>
+      checklist.items.flatMap((item) => item.userChecks.map(toUserCheckRow)),
+    ),
+    itemAssignees: checklists.flatMap((checklist) =>
+      checklist.items.flatMap((item) => item.assignees.map(toAssigneeRow)),
+    ),
+  }
+}
+
+function toChecklistItemRow(item: ChecklistItemReadModel): ChecklistItem {
+  return {
+    id: item.id,
+    checklist_id: item.checklistId,
+    item_name: item.name,
+    category: item.categoryName,
+    is_checked: item.status.isChecked,
+    is_private: item.isPrivate,
+    assignment_type: item.assignmentType,
+    assigned_user_id: item.assignedUserId,
+    source_template_name: item.sourceTemplateName,
+    created_at: item.createdAt,
+    updated_at: item.updatedAt,
+  }
+}
+
+function toChecklistMemberRow(member: TripMemberReadModel): ChecklistMemberSnapshot {
+  return {
+    id: member.id,
+    trip_id: '',
+    user_id: member.userId,
+    invited_email: member.invitedEmail ?? '',
+    role: member.role,
+    status: member.status === 'pending' ? 'pending' : 'accepted',
+    created_at: '',
+    email: member.email,
+    profiles: {
+      nickname: member.nickname,
+      email: member.email,
+    },
+  }
+}
+
+function toUserCheckRow(check: ChecklistItemReadModel['userChecks'][number]): ChecklistItemUserCheck {
+  return {
+    id: check.id,
+    item_id: check.itemId,
+    user_id: check.userId,
+    created_at: check.createdAt,
+  }
+}
+
+function toAssigneeRow(assignee: ChecklistItemReadModel['assignees'][number]): ChecklistItemAssignee {
+  return {
+    id: assignee.id,
+    item_id: assignee.itemId,
+    user_id: assignee.userId,
+    created_at: assignee.createdAt,
+  }
+}
+
+async function resolveTripIdForChecklist(
+  repositories: Awaited<ReturnType<typeof createWebDocumentPrimaryRepositories>>,
+  checklistId: string,
+): Promise<string | null> {
+  const trips = await repositories.trips.listTrips('')
+  for (const trip of trips) {
+    const document = await repositories.trips.getTripDocument(trip.id)
+    if (document?.checklists[checklistId]) return trip.id
+  }
+  return null
+}
+
+async function resolveTripAndItem(
+  repositories: Awaited<ReturnType<typeof createWebDocumentPrimaryRepositories>>,
+  itemId: string,
+): Promise<{ tripId: string; item: ChecklistItemReadModel } | null> {
+  const trips = await repositories.trips.listTrips('')
+  for (const trip of trips) {
+    const checklists = await repositories.checklists.getChecklist(trip.id)
+    for (const item of checklists.flatMap((checklist) => checklist.items)) {
+      if (item.id === itemId) return { tripId: trip.id, item }
+    }
+  }
+  return null
+}
+
+async function resolveCurrentTripRole(
+  supabase: SupabaseClient,
+  repositories: Awaited<ReturnType<typeof createWebDocumentPrimaryRepositories>>,
+  tripId: string,
+): Promise<'owner' | 'editor' | 'viewer' | null> {
+  const { data } = await supabase.auth.getUser()
+  const userId = data.user?.id
+  if (!userId) return null
+  const document = await repositories.trips.getTripDocument(tripId)
+  if (!document) return null
+  if (document.trip.ownerId === userId) return 'owner'
+  return Object.values(document.members)
+    .find((member) => member.userId === userId && member.status === 'accepted')
+    ?.role ?? null
+}
+
+function toMutationResult(
+  document: TripDocumentV1,
+  itemId: string,
+): ChecklistItemMutationResult {
+  const item = Object.values(document.checklistItems).find((candidate) => candidate.id === itemId)
+  if (!item) throw new Error('Checklist item mutation result was not found.')
+  return {
+    item: {
+      id: item.id,
+      checklist_id: item.checklistId,
+      item_name: item.name,
+      category: item.categoryName,
+      is_checked: item.legacyIsChecked,
+      is_private: item.isPrivate,
+      assignment_type: item.assignmentType,
+      assigned_user_id: item.assignedUserId,
+      source_template_name: item.sourceTemplateName,
+      created_at: item.createdAt,
+      updated_at: item.updatedAt,
+    },
+    assignees: Object.values(document.checklistItemAssignees)
+      .filter((assignee) => assignee.itemId === itemId)
+      .map(toAssigneeRow),
+  }
+}
+
+function createEntityId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -1,0 +1,204 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  convertLegacyTripRowsToDocument,
+  createDocumentPrimaryRepositoryBundle,
+  createEmptyTemplateDocumentV1,
+  getLegacyTripRowBundle,
+  type DocumentMutationResult,
+  type TemplateDocumentV1,
+  type TripDocumentV1,
+} from '@nexvoy/core'
+import type { EntityId } from '@nexvoy/core/local-first/documentModel'
+import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
+import { publishLocalTripDocumentUpdate } from './p2pUpdateBridge'
+import { resolveWebOwnerContext } from './ownerNamespace'
+import {
+  createWebTemplateDocumentStore,
+  createWebTripDocumentStore,
+} from './webDocumentStores'
+
+export async function createWebDocumentPrimaryRepositories(
+  supabase: SupabaseClient,
+  options: {
+    actorRole?: 'owner' | 'editor' | 'viewer' | null
+  } = {},
+): Promise<DocumentPrimaryRepositoryBundle> {
+  const ownerContext = await resolveWebOwnerContext(supabase)
+  const actor = {
+    userId: ownerContext.ownerId,
+    role: options.actorRole ?? 'viewer',
+    status: 'accepted' as const,
+  }
+
+  const tripStore = createWebTripDocumentStore(ownerContext, {
+    hydrateDocument: async (tripId) => {
+      const bundle = await getLegacyTripRowBundle(supabase, tripId, ownerContext.authUserId)
+      return bundle ? convertLegacyTripRowsToDocument(bundle).document : null
+    },
+  })
+  const templateStore = createWebTemplateDocumentStore(ownerContext, {
+    hydrateDocument: (templateId) => hydrateTemplateDocument(supabase, templateId),
+    listLegacyDocumentIds: () => listLegacyTemplateIds(supabase, ownerContext.authUserId),
+  })
+
+  return createDocumentPrimaryRepositoryBundle({
+    tripStore,
+    templateStore,
+    runtime: {
+      actor,
+      publisher: {
+        publishMutation: (result) => {
+          if (result.documentType === 'trip') {
+            publishLocalTripDocumentUpdate({
+              documentId: result.documentId,
+              update: result.update,
+            })
+          }
+        },
+      },
+    },
+  })
+}
+
+export async function createWebTemplateDocument(input: {
+  supabase: SupabaseClient
+  title: string
+  items: Array<{
+    item_name: string
+    category: string
+    is_private?: boolean
+  }>
+}): Promise<string> {
+  const ownerContext = await resolveWebOwnerContext(input.supabase)
+  const templateStore = createWebTemplateDocumentStore(ownerContext)
+  const now = new Date().toISOString()
+  const templateId = createEntityId('template')
+  const document = createEmptyTemplateDocumentV1({
+    id: templateId,
+    ownerId: ownerContext.authUserId,
+    title: input.title,
+    visibility: 'private',
+    createdAt: now,
+  })
+
+  input.items.forEach((item, index) => {
+    const itemId = createEntityId('template-item')
+    document.items[itemId] = {
+      id: itemId,
+      templateId,
+      name: item.item_name,
+      categoryName: item.category,
+      isPrivate: item.is_private ?? false,
+      sortOrder: index,
+      createdAt: now,
+      updatedAt: now,
+    }
+  })
+
+  await templateStore.putDocument(templateId, document)
+  return templateId
+}
+
+async function listLegacyTemplateIds(
+  supabase: SupabaseClient,
+  currentUserId: string | null,
+): Promise<EntityId[]> {
+  if (!currentUserId) return []
+  const owned = supabase
+    .from('checklist_templates')
+    .select('id')
+    .eq('user_id', currentUserId)
+  const publicTemplates = supabase
+    .from('checklist_templates')
+    .select('id')
+    .is('user_id', null)
+  const shared = supabase
+    .from('checklist_template_shares')
+    .select('template_id')
+    .eq('shared_with_user_id', currentUserId)
+
+  const [ownedResult, publicResult, sharedResult] = await Promise.all([owned, publicTemplates, shared])
+  if (ownedResult.error) throw ownedResult.error
+  if (publicResult.error) throw publicResult.error
+  if (sharedResult.error) throw sharedResult.error
+
+  return Array.from(new Set([
+    ...(ownedResult.data ?? []).map((row) => row.id),
+    ...(publicResult.data ?? []).map((row) => row.id),
+    ...(sharedResult.data ?? []).map((row) => row.template_id),
+  ]))
+}
+
+async function hydrateTemplateDocument(
+  supabase: SupabaseClient,
+  templateId: EntityId,
+): Promise<TemplateDocumentV1 | null> {
+  const { data: template, error: templateError } = await supabase
+    .from('checklist_templates')
+    .select('id, user_id, title, created_at')
+    .eq('id', templateId)
+    .maybeSingle()
+  if (templateError) throw templateError
+  if (!template) return null
+
+  const [itemsResult, sharesResult] = await Promise.all([
+    supabase
+      .from('checklist_template_items')
+      .select('id, template_id, item_name, category, is_private, created_at')
+      .eq('template_id', templateId),
+    supabase
+      .from('checklist_template_shares')
+      .select('id, template_id, shared_with_user_id, role, created_by, created_at')
+      .eq('template_id', templateId),
+  ])
+  if (itemsResult.error) throw itemsResult.error
+  if (sharesResult.error) throw sharesResult.error
+
+  const createdAt = template.created_at ?? new Date().toISOString()
+  const document = createEmptyTemplateDocumentV1({
+    id: template.id,
+    ownerId: template.user_id,
+    title: template.title,
+    visibility: (sharesResult.data?.length ?? 0) > 0 ? 'shared' : 'private',
+    createdAt,
+    updatedAt: createdAt,
+    createdFromLegacyAt: new Date().toISOString(),
+  })
+
+  ;(itemsResult.data ?? []).forEach((item, index) => {
+    const itemCreatedAt = item.created_at ?? createdAt
+    document.items[item.id] = {
+      id: item.id,
+      templateId,
+      name: item.item_name,
+      categoryName: item.category ?? '기타',
+      isPrivate: item.is_private ?? false,
+      sortOrder: index,
+      createdAt: itemCreatedAt,
+      updatedAt: itemCreatedAt,
+    }
+  })
+
+  ;(sharesResult.data ?? []).forEach((share) => {
+    const shareCreatedAt = share.created_at ?? createdAt
+    document.shares[share.id] = {
+      id: share.id,
+      templateId,
+      sharedWithUserId: share.shared_with_user_id,
+      role: share.role === 'editor' ? 'editor' : 'viewer',
+      createdBy: share.created_by,
+      createdAt: shareCreatedAt,
+      updatedAt: null,
+    }
+  })
+
+  return document
+}
+
+export type WebDocumentPrimaryMutationResult =
+  DocumentMutationResult<TripDocumentV1 | TemplateDocumentV1>
+
+function createEntityId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}

--- a/apps/web/lib/local-first/repositoryFactory.ts
+++ b/apps/web/lib/local-first/repositoryFactory.ts
@@ -6,9 +6,11 @@ import {
 import type { ChecklistRepository, TripRepository } from '@nexvoy/core/repositories/types'
 import { createWebDualWriteChecklistRepository } from './dualWriteChecklistRepository'
 import { createWebLocalFirstChecklistRepository } from './localFirstChecklistRepository'
+import { createWebDocumentPrimaryChecklistRepository } from './documentPrimaryChecklistRepository'
 
 export type WebRepositoryMode =
   | 'legacy-supabase'
+  | 'document-primary'
   | 'local-first-checklist-spike'
   | 'local-first-checklist-dual-write'
 
@@ -37,6 +39,12 @@ export function createWebRepositories(
         mode,
         checklists: createWebLocalFirstChecklistRepository(supabase),
       }
+    case 'document-primary':
+      return {
+        ...legacyRepositories,
+        mode,
+        checklists: createWebDocumentPrimaryChecklistRepository(supabase),
+      }
     case 'legacy-supabase':
       return {
         ...legacyRepositories,
@@ -53,6 +61,9 @@ export function createWebRepositories(
 export function resolveWebRepositoryMode(): WebRepositoryMode {
   if (process.env.NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_DUAL_WRITE === '1') {
     return 'local-first-checklist-dual-write'
+  }
+  if (process.env.NEXT_PUBLIC_WEB_DOCUMENT_PRIMARY === '1') {
+    return 'document-primary'
   }
   if (process.env.NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_SPIKE === '1') {
     return 'local-first-checklist-spike'
@@ -72,6 +83,14 @@ export function resolveWebRepositoryMode(): WebRepositoryMode {
     window.localStorage.setItem('onvoy.localFirstChecklistSpike', '1')
     return 'local-first-checklist-spike'
   }
+  if (params.get('documentPrimary') === '1') {
+    window.localStorage.setItem('onvoy.webDocumentPrimary', '1')
+    return 'document-primary'
+  }
+  if (params.get('documentPrimary') === '0') {
+    window.localStorage.removeItem('onvoy.webDocumentPrimary')
+    return 'legacy-supabase'
+  }
   if (params.get('localFirstChecklist') === '0') {
     window.localStorage.removeItem('onvoy.localFirstChecklistSpike')
     return 'legacy-supabase'
@@ -79,6 +98,9 @@ export function resolveWebRepositoryMode(): WebRepositoryMode {
 
   if (window.localStorage.getItem('onvoy.localFirstChecklistDualWrite') === '1') {
     return 'local-first-checklist-dual-write'
+  }
+  if (window.localStorage.getItem('onvoy.webDocumentPrimary') === '1') {
+    return 'document-primary'
   }
 
   return window.localStorage.getItem('onvoy.localFirstChecklistSpike') === '1'

--- a/apps/web/lib/local-first/webDocumentStores.ts
+++ b/apps/web/lib/local-first/webDocumentStores.ts
@@ -1,0 +1,134 @@
+import type {
+  LocalDocumentStore,
+} from '@nexvoy/core/repositories/documentPrimaryRepository'
+import type {
+  EntityId,
+  TripDocumentV1,
+} from '@nexvoy/core/local-first/documentModel'
+import type {
+  TemplateDocumentV1,
+} from '@nexvoy/core/local-first/templateDocument'
+import {
+  applyTripDocumentUpdate,
+  createYjsTripDocument,
+  encodeTripDocumentUpdate,
+  readTripDocumentFromYjs,
+} from '@nexvoy/core/local-first/yjsTripDocument'
+import {
+  applyTemplateDocumentUpdate,
+  createYjsTemplateDocument,
+  encodeTemplateDocumentUpdate,
+  readTemplateDocumentFromYjs,
+} from '@nexvoy/core/local-first/templateDocument'
+import {
+  loadAllTripDocumentUpdates,
+  loadTripDocumentUpdate,
+  saveTripDocumentUpdate,
+} from './indexedDbStore'
+import type { WebOwnerContext } from './ownerNamespace'
+
+const TEMPLATE_NAMESPACE_SUFFIX = ':templates'
+
+export function createWebTripDocumentStore(
+  ownerContext: WebOwnerContext,
+  options: {
+    hydrateDocument?: (documentId: EntityId) => Promise<TripDocumentV1 | null>
+    listLegacyDocumentIds?: () => Promise<EntityId[]>
+  } = {},
+): LocalDocumentStore<TripDocumentV1> {
+  return {
+    listDocumentIds: async () => {
+      const rows = await loadAllTripDocumentUpdates(ownerContext.namespace)
+      const localIds = rows
+        .map((row) => row.documentId)
+        .filter((documentId): documentId is string => Boolean(documentId))
+      const legacyIds = await options.listLegacyDocumentIds?.() ?? []
+      return Array.from(new Set([...localIds, ...legacyIds]))
+    },
+    getDocument: async (documentId) => {
+      const update = await loadTripDocumentUpdate({
+        namespace: ownerContext.namespace,
+        documentId,
+      })
+      if (!update) {
+        const hydrated = await options.hydrateDocument?.(documentId)
+        if (!hydrated) return null
+        await putTripDocument(ownerContext.namespace, documentId, hydrated)
+        return hydrated
+      }
+
+      const doc = createYjsTripDocument()
+      applyTripDocumentUpdate(doc, update)
+      return readTripDocumentFromYjs(doc)
+    },
+    putDocument: async (documentId, document, update) => {
+      if (update) {
+        await saveTripDocumentUpdate({ namespace: ownerContext.namespace, documentId }, update)
+        return
+      }
+      await putTripDocument(ownerContext.namespace, documentId, document)
+    },
+  }
+}
+
+export function createWebTemplateDocumentStore(
+  ownerContext: WebOwnerContext,
+  options: {
+    hydrateDocument?: (documentId: EntityId) => Promise<TemplateDocumentV1 | null>
+    listLegacyDocumentIds?: () => Promise<EntityId[]>
+  } = {},
+): LocalDocumentStore<TemplateDocumentV1> {
+  const namespace = getTemplateNamespace(ownerContext)
+  return {
+    listDocumentIds: async () => {
+      const rows = await loadAllTripDocumentUpdates(namespace)
+      const localIds = rows
+        .map((row) => row.documentId)
+        .filter((documentId): documentId is string => Boolean(documentId))
+      const legacyIds = await options.listLegacyDocumentIds?.() ?? []
+      return Array.from(new Set([...localIds, ...legacyIds]))
+    },
+    getDocument: async (documentId) => {
+      const update = await loadTripDocumentUpdate({ namespace, documentId })
+      if (!update) {
+        const hydrated = await options.hydrateDocument?.(documentId)
+        if (!hydrated) return null
+        await putTemplateDocument(namespace, documentId, hydrated)
+        return hydrated
+      }
+
+      const doc = createYjsTemplateDocument()
+      applyTemplateDocumentUpdate(doc, update)
+      return readTemplateDocumentFromYjs(doc)
+    },
+    putDocument: async (documentId, document, update) => {
+      if (update) {
+        await saveTripDocumentUpdate({ namespace, documentId }, update)
+        return
+      }
+      await putTemplateDocument(namespace, documentId, document)
+    },
+  }
+}
+
+async function putTripDocument(
+  namespace: string,
+  documentId: EntityId,
+  document: TripDocumentV1,
+): Promise<void> {
+  const doc = createYjsTripDocument(document)
+  await saveTripDocumentUpdate({ namespace, documentId }, encodeTripDocumentUpdate(doc))
+}
+
+async function putTemplateDocument(
+  namespace: string,
+  documentId: EntityId,
+  document: TemplateDocumentV1,
+): Promise<void> {
+  const doc = createYjsTemplateDocument(document)
+  await saveTripDocumentUpdate({ namespace, documentId }, encodeTemplateDocumentUpdate(doc))
+}
+
+function getTemplateNamespace(ownerContext: WebOwnerContext): string {
+  return `${ownerContext.namespace}${TEMPLATE_NAMESPACE_SUFFIX}`
+}

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,47 @@
+# Walkthrough: TASK-031 Web Full Document-primary Transition
+
+## Summary
+
+TASK-031은 Web의 일정, 준비물, 템플릿, 동행자/권한 UI를 document-primary repository 경로로 전환했다.
+legacy Supabase row는 최초 hydrate/read-only fallback과 registry authority 작업에만 남겼다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-031-web-full-document-primary-transition.md`
+- `apps/web/lib/local-first/webDocumentStores.ts`
+- `apps/web/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/web/lib/local-first/documentPrimaryChecklistRepository.ts`
+- `_workspace/01_planner_analysis.md`
+- `_workspace/02b_frontend_changes.md`
+- `_workspace/03_review_result.md`
+- `_workspace/04_qa_result.md`
+
+## Key Changes
+
+- Web IndexedDB Yjs update 저장소를 `LocalDocumentStore` contract로 감싸 Trip/Template document repository에 주입했다.
+- Trip legacy row bundle과 checklist template row/share/item을 최초 진입 시 document로 hydrate하는 bridge를 추가했다.
+- 일정 목록/생성/수정/삭제/방문 상태/이미지 URL 복구를 Plan repository mutation으로 연결했다.
+- 준비물 CRUD/toggle/template apply를 document-primary checklist repository 경유로 연결했다.
+- 템플릿 목록/생성/수정/삭제/적용을 Template document repository로 전환했다.
+- 동행자 registry 조회/role 변경/revoke 후 Trip document member snapshot을 upsert/revoke하도록 연결했다.
+- mutation actor role을 호출부에서 주입해 viewer write 차단 정책이 유지되도록 했다.
+
+## Verification
+
+- `pnpm --filter nexvoy-web exec tsc --noEmit` 성공
+- `pnpm --filter @nexvoy/core test` 성공
+- `pnpm typecheck` 성공
+- `pnpm build` 성공
+- `pnpm build:mobile` 성공
+
+## Notes
+
+- 신규 Supabase migration/API Route는 없다.
+- Mobile 화면 전환은 TASK-032 범위로 유지했다.
+- Template share registry write는 기존 Supabase helper를 유지한다. document share snapshot productization은 후속 정리 대상이다.
+
+---
+
 # Walkthrough: TASK-030 Document-primary Repository Layer
 
 ## Summary


### PR DESCRIPTION
## Summary
- add Web LocalDocumentStore adapters and document-primary repository wiring
- transition Web plans, checklist, templates, and member snapshots to document-primary repository paths
- keep legacy Supabase rows as hydration/read-only fallback and registry authority where required

## Verification
- pnpm --filter nexvoy-web exec tsc --noEmit
- pnpm --filter @nexvoy/core test
- pnpm typecheck
- pnpm build
- pnpm build:mobile

Resolves #320