### PR TITLE
TASK-032 Mobile full document-primary transition

### DIFF
--- a/apps/mobile/app/(tabs)/templates.tsx
+++ b/apps/mobile/app/(tabs)/templates.tsx
@@ -23,11 +23,12 @@ import {
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter, useFocusEffect } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
-import { getTemplatesWithPreview, deleteTemplate } from '@nexvoy/core'
 import type { TemplateWithPreview } from '@nexvoy/types'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/lib/auth-context'
 import { ConfirmSheet, EmptyState } from '@/components/ui'
+import { createMobileDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import { toTemplatePreviewRow } from '@/lib/local-first/documentPrimaryAdapters'
 import { colors, fontSizes, fontWeights, radii, spacing, shadows } from '@/theme'
 
 /**
@@ -44,6 +45,7 @@ function formatRegisteredDate(createdAt: string): string {
 
 export default function TemplatesScreen() {
   const { session } = useAuth()
+  const currentUserId = session?.user.id
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const [templates, setTemplates] = useState<TemplateWithPreview[]>([])
@@ -52,17 +54,20 @@ export default function TemplatesScreen() {
   const isMounted = useRef(true)
 
   const loadTemplates = useCallback(async () => {
-    if (!session?.user) return
+    if (!currentUserId) return
     setLoading(true)
     try {
-      const data = await getTemplatesWithPreview(supabase, session.user.id)
-      if (isMounted.current) setTemplates(data)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase)
+      const data = await repositories.templates.listTemplates(currentUserId)
+      if (isMounted.current) {
+        setTemplates(data.map((template) => toTemplatePreviewRow(template, currentUserId)))
+      }
     } catch {
       // 조회 실패 시 직전 목록 유지 (useFocusEffect 재진입 시 깜박임 방지)
     } finally {
       if (isMounted.current) setLoading(false)
     }
-  }, [session?.user])
+  }, [currentUserId])
 
   useFocusEffect(
     useCallback(() => {
@@ -86,7 +91,8 @@ export default function TemplatesScreen() {
   const confirmDelete = useCallback(async () => {
     if (!pendingDelete) return
     try {
-      await deleteTemplate(supabase, pendingDelete.id)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+      await repositories.templates.deleteTemplate(pendingDelete.id)
       setPendingDelete(null)
       await loadTemplates()
     } catch {

--- a/apps/mobile/app/join.tsx
+++ b/apps/mobile/app/join.tsx
@@ -101,7 +101,6 @@ export default function JoinScreen() {
     } else {
       setMessage('초대 코드를 입력해 주세요.')
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token, code])
 
   const handleCodeSubmit = () => {

--- a/apps/mobile/app/templates/[id].tsx
+++ b/apps/mobile/app/templates/[id].tsx
@@ -26,19 +26,17 @@ import { Ionicons } from '@expo/vector-icons'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import {
   getChecklistCategories,
-  getTemplateWithItems,
-  getTemplateShares,
   getProfileByEmail,
-  shareTemplate,
-  updateTemplateShareRole,
-  removeTemplateShare,
-  updateTemplate,
-  replaceTemplateItems,
-  deleteTemplate,
 } from '@nexvoy/core'
 import type { ChecklistCategory, ChecklistTemplateShareRole, ChecklistTemplateShareWithProfile } from '@nexvoy/types'
 import { supabase } from '@/lib/supabase'
 import { BottomSheet } from '@/components/ui'
+import { createMobileDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import {
+  toTemplateItemRows,
+  toTemplateShareRows,
+  toTemplateWithAccessRow,
+} from '@/lib/local-first/documentPrimaryAdapters'
 import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
 
 const TITLE_MAX = 50
@@ -79,8 +77,9 @@ export default function EditTemplateScreen() {
     if (!id) return
     setSharesLoading(true)
     try {
-      const data = await getTemplateShares(supabase, id)
-      if (isMounted.current) setShares(data)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase)
+      const template = await repositories.templates.getTemplate(id)
+      if (isMounted.current) setShares(template ? toTemplateShareRows(template) : [])
     } catch {
       if (isMounted.current) setShares([])
     } finally {
@@ -92,21 +91,23 @@ export default function EditTemplateScreen() {
     if (!id) return
     setInitialLoading(true)
     try {
-      const result = await getTemplateWithItems(supabase, id)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase)
+      const result = await repositories.templates.getTemplate(id)
       if (!isMounted.current) return
       if (!result) {
         setNotFound(true)
         return
       }
-      setTitle(result.template.title)
-      setTemplateOwnerId(result.template.user_id)
-      setItems(result.items.map((it) => ({
+      const { data: { user } } = await supabase.auth.getUser()
+      const template = toTemplateWithAccessRow(result, user?.id ?? null)
+      setTitle(template.title)
+      setTemplateOwnerId(template.user_id)
+      setItems(toTemplateItemRows(result).map((it) => ({
         id: it.id,
         item_name: it.item_name,
         category: it.category || '기타',
         is_private: it.is_private,
       })))
-      const { data: { user } } = await supabase.auth.getUser()
       setCurrentUserId(user?.id ?? null)
       if (user) setCategories(await getChecklistCategories(supabase, user.id))
     } catch {
@@ -182,16 +183,17 @@ export default function EditTemplateScreen() {
     setSaving(true)
     setError(null)
     try {
-      await updateTemplate(supabase, id, { title: title.trim() })
-      await replaceTemplateItems(
-        supabase,
-        id,
-        items.map((item) => ({
-          item_name: item.item_name,
-          category: item.category,
-          is_private: item.is_private,
-        }))
-      )
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: canManageShares ? 'owner' : 'editor' })
+      await repositories.templates.updateTemplate(id, { title: title.trim() })
+      await repositories.templates.replaceItems(id, {
+        items: items.map((item, index) => ({
+          id: item.id.startsWith('template-item-') ? item.id : createEntityId('template-item'),
+          name: item.item_name,
+          categoryName: item.category,
+          isPrivate: item.is_private,
+          sortOrder: index,
+        })),
+      })
       router.back()
     } catch (e) {
       if (isMounted.current) {
@@ -220,7 +222,8 @@ export default function EditTemplateScreen() {
             setDeleting(true)
             setError(null)
             try {
-              await deleteTemplate(supabase, id)
+              const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+              await repositories.templates.deleteTemplate(id)
               router.back()
             } catch (e) {
               if (isMounted.current) {
@@ -248,22 +251,45 @@ export default function EditTemplateScreen() {
     const profile = await getProfileByEmail(supabase, email)
     if (!profile) throw new Error('해당 이메일의 사용자를 찾을 수 없어요.')
     if (profile.id === currentUserId) throw new Error('내 계정에는 공유할 수 없어요.')
-    await shareTemplate(supabase, {
-      template_id: id,
-      shared_with_user_id: profile.id,
-      role,
-      created_by: currentUserId,
+    const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+    await repositories.templates.upsertShare(id, {
+      share: {
+        id: createEntityId('template-share'),
+        templateId: id,
+        sharedWithUserId: profile.id,
+        role,
+        createdBy: currentUserId,
+        createdAt: new Date().toISOString(),
+        updatedAt: null,
+      },
     })
     await loadShares()
   }
 
   const handleUpdateShareRole = async (shareId: string, role: ChecklistTemplateShareRole) => {
-    await updateTemplateShareRole(supabase, shareId, role)
+    if (!id) return
+    const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+    const template = await repositories.templates.getTemplate(id)
+    const share = template?.shares.find((candidate) => candidate.id === shareId)
+    if (!share) return
+    await repositories.templates.upsertShare(id, {
+      share: {
+        id: shareId,
+        templateId: id,
+        sharedWithUserId: share.sharedWithUserId,
+        role,
+        createdBy: share.createdBy,
+        createdAt: share.createdAt,
+        updatedAt: new Date().toISOString(),
+      },
+    })
     await loadShares()
   }
 
   const handleRemoveShare = async (shareId: string) => {
-    await removeTemplateShare(supabase, shareId)
+    if (!id) return
+    const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+    await repositories.templates.removeShare(id, shareId)
     await loadShares()
   }
 
@@ -595,6 +621,11 @@ export default function EditTemplateScreen() {
       />
     </SafeAreaView>
   )
+}
+
+function createEntityId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
 function getShareProfileLabel(share: ChecklistTemplateShareWithProfile): string {

--- a/apps/mobile/app/templates/new.tsx
+++ b/apps/mobile/app/templates/new.tsx
@@ -22,10 +22,11 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter } from 'expo-router'
-import { createTemplate, getChecklistCategories, replaceTemplateItems } from '@nexvoy/core'
+import { getChecklistCategories } from '@nexvoy/core'
 import type { ChecklistCategory } from '@nexvoy/types'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/lib/auth-context'
+import { createMobileTemplateDocument } from '@/lib/local-first/documentPrimaryRepositories'
 import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
 
 const TITLE_MAX = 50
@@ -124,19 +125,15 @@ export default function NewTemplateScreen() {
     setLoading(true)
     setError(null)
     try {
-      const template = await createTemplate(supabase, {
-        title: title.trim(),
-        user_id: session.user.id,
-      })
-      await replaceTemplateItems(
+      await createMobileTemplateDocument({
         supabase,
-        template.id,
-        items.map((item) => ({
+        title: title.trim(),
+        items: items.map((item) => ({
           item_name: item.item_name,
           category: item.category,
           is_private: item.is_private,
-        }))
-      )
+        })),
+      })
       router.back()
     } catch (e) {
       if (isMounted.current) {

--- a/apps/mobile/app/trip/[id].tsx
+++ b/apps/mobile/app/trip/[id].tsx
@@ -42,33 +42,12 @@ import * as Clipboard from 'expo-clipboard'
 import * as WebBrowser from 'expo-web-browser'
 import { NativeMapView, NativeMarker } from '@/components/map/NativeMap'
 import {
-  getPlansWithUrls,
-  getTripsByUser,
-  getTripById,
-  getChecklistByTrip,
   getChecklistCategories,
-  getChecklistItemAssignees,
   getChecklistItemStatus,
-  getChecklistItemUserChecks,
   getTemplatesWithPreview,
-  getUserTripRole,
-  getTripMembers,
   inviteTripMember,
-  updateTripMemberRole,
-  removeTripMember,
   getOrCreateTripShareLink,
-  updateTrip,
-  createPlan,
-  updatePlan,
-  deletePlan,
-  ensureChecklist,
   createChecklistCategory,
-  createChecklistItem,
-  updateChecklistItem,
-  deleteChecklistItem,
-  applyTemplateToChecklist,
-  toggleChecklistItemForUser,
-  togglePlanVisited,
   formatDate,
   formatCurrency,
   getCurrencyFromTimezone,
@@ -101,6 +80,19 @@ import {
 } from '@/components/ui'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/lib/auth-context'
+import { createMobileDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import {
+  toChecklistSnapshotRows,
+  toPlanRow,
+  toPlanRows,
+  toTripMemberRows,
+  toTripRow,
+} from '@/lib/local-first/documentPrimaryAdapters'
+import { bindMobileP2PLifecycle } from '@/lib/local-first/p2pLifecycle.native'
+import {
+  connectMobileP2PPeer,
+  type MobileP2PConnection,
+} from '@/lib/local-first/webP2PConnection'
 import { runMobileForegroundKeyProvisioning } from '@/lib/local-first/keyProvisioningService'
 import type { MobileRestoreOutcome } from '@/lib/local-first/mobileSnapshotRestoreService'
 import {
@@ -123,6 +115,7 @@ type PlanSheetStep = 'place' | 'details'
 type TimeDisplayMode = 'local' | 'kst' | 'both'
 type ShareType = DocumentShareType
 type PlanLocalAlarmUiStatus = LocalNotificationScheduleStatus | 'unknown'
+type MobileP2PStatus = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'unavailable'
 
 type GeneratedInvite = Pick<CreatedDocumentInvitation, 'id' | 'role' | 'inviteCode' | 'expiresAt'> & {
   inviteUrl: string
@@ -166,7 +159,7 @@ type GooglePlaceDetail = {
     lat?: number
     lng?: number
   }
-  photos?: Array<{ photo_reference?: string }>
+  photos?: { photo_reference?: string }[]
 }
 
 type GoogleAutocompleteResponse = {
@@ -688,6 +681,48 @@ const MOBILE_RESTORE_TEXT_COLOR: Record<RestoreStatusTone, string> = {
   error: colors.brand.error,
 }
 
+function createEntityId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function normalizeDocumentRole(role: string | null): 'owner' | 'editor' | 'viewer' | null {
+  return role === 'owner' || role === 'editor' || role === 'viewer' ? role : null
+}
+
+function getMobileP2PStatusLabel(status: MobileP2PStatus): string {
+  if (status === 'connected') return '실시간 연결됨'
+  if (status === 'connecting') return '실시간 연결 중'
+  if (status === 'reconnecting') return '실시간 재연결 중'
+  if (status === 'unavailable') return '로컬 저장 중'
+  return '로컬 저장'
+}
+
+async function syncPlanUrls(
+  repositories: Awaited<ReturnType<typeof createMobileDocumentPrimaryRepositories>>,
+  tripId: string,
+  planId: string,
+  previousUrls: PlanUrl[],
+  nextUrls: string[],
+): Promise<void> {
+  const normalizedNextUrls = nextUrls.map((url) => url.trim()).filter(Boolean)
+  const previousByUrl = new Map(previousUrls.map((entry) => [entry.url, entry]))
+  const nextUrlSet = new Set(normalizedNextUrls)
+
+  await Promise.all(previousUrls
+    .filter((entry) => !nextUrlSet.has(entry.url))
+    .map((entry) => repositories.plans.deletePlanUrl(tripId, entry.id)))
+
+  await Promise.all(normalizedNextUrls.map((url) => {
+    const existing = previousByUrl.get(url)
+    return repositories.plans.upsertPlanUrl(tripId, {
+      id: existing?.id ?? createEntityId('plan-url'),
+      planId,
+      url,
+    })
+  }))
+}
+
 // ─── 화면 ─────────────────────────────────────────────────────────────────────
 
 export default function TripDetailScreen() {
@@ -698,6 +733,7 @@ export default function TripDetailScreen() {
   const isMounted = useRef(true)
   const keyProvisioningInFlight = useRef(false)
   const mobileRestoreStatusRef = useRef<RestoreStatusDisplay | null>(null)
+  const p2pConnectionRef = useRef<MobileP2PConnection | null>(null)
   const scrollRef = useRef<ScrollView>(null)
   const detailTopHeightRef = useRef(0)
   const scrollOffsetRef = useRef(0)
@@ -754,6 +790,7 @@ export default function TripDetailScreen() {
   // *다른 멤버*의 키 요청을 처리한 결과")와 의미가 다르므로 절대 병합하지 않는다
   // (01b_ux_design.md §2.1/§5 근거 — 슬롯을 공유하면 마지막 쓰기가 이전 정보를 덮어씀).
   const [mobileRestoreStatus, setMobileRestoreStatus] = useState<RestoreStatusDisplay | null>(null)
+  const [p2pStatus, setP2PStatus] = useState<MobileP2PStatus>('idle')
 
   useEffect(() => {
     isMounted.current = true
@@ -773,8 +810,9 @@ export default function TripDetailScreen() {
   const loadTripList = useCallback(async () => {
     if (!session?.user.id) return
     try {
-      const data = await getTripsByUser(supabase, session.user.id)
-      if (isMounted.current) setAllTrips(data)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase)
+      const data = await repositories.trips.listTrips(session.user.id)
+      if (isMounted.current) setAllTrips(data.map(toTripRow))
     } catch {
       // 여행 스위처는 보조 기능이므로 상세 화면 로딩을 막지 않는다.
     }
@@ -784,8 +822,9 @@ export default function TripDetailScreen() {
     if (!id) return
     setMembersLoading(true)
     try {
-      const data = await getTripMembers(supabase, id)
-      if (isMounted.current) setMembers(data)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase)
+      const data = await repositories.members.listMembers(id)
+      if (isMounted.current) setMembers(toTripMemberRows(data, id))
     } catch {
       if (isMounted.current) setMembers([])
     } finally {
@@ -802,32 +841,28 @@ export default function TripDetailScreen() {
     setLoading(true)
     setError(false)
     try {
-      const [tripData, plansData] = await Promise.all([
-        getTripById(supabase, id),
-        getPlansWithUrls(supabase, id),
-      ])
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase)
+      const tripData = await repositories.trips.getTrip(id)
       if (!isMounted.current) return
       if (!tripData) {
         setError(true)
         return
       }
-      setTrip(tripData)
-      setPlans(plansData)
-      void loadMembers()
-      getUserTripRole(supabase, id)
-        .then((role) => {
-          if (isMounted.current) setUserRole(role)
-        })
-        .catch(() => {
-          if (isMounted.current) setUserRole(null)
-        })
+      setTrip(toTripRow(tripData))
+      setPlans(toPlanRows(tripData.plans, tripData.id))
+      setMembers(toTripMemberRows(tripData.members, tripData.id))
+      const currentUserId = session?.user.id ?? null
+      const role = tripData.ownerId === currentUserId
+        ? 'owner'
+        : tripData.members.find((member) => member.userId === currentUserId && member.status === 'accepted')?.role ?? null
+      setUserRole(role)
     } catch {
       // 상세는 특정 trip 이 필수 → 에러를 명시(빈 목록 흡수 X)
       if (isMounted.current) setError(true)
     } finally {
       if (isMounted.current) setLoading(false)
     }
-  }, [id, loadMembers])
+  }, [id, session?.user.id])
 
   useEffect(() => {
     loadTrip()
@@ -905,6 +940,61 @@ export default function TripDetailScreen() {
     return () => subscription.remove()
   }, [canEditContent, id, runTripKeyProvisioning])
 
+  const reconnectP2P = useCallback(async (status: MobileP2PStatus = 'connecting') => {
+    if (!id || !session?.user.id || !canEditContent) return
+    await p2pConnectionRef.current?.close().catch(() => undefined)
+    p2pConnectionRef.current = null
+    setP2PStatus(status)
+    try {
+      const connection = await connectMobileP2PPeer({
+        documentId: id,
+        userId: session.user.id,
+        membership: {
+          role: normalizeDocumentRole(userRole),
+          status: 'accepted',
+        },
+        isInitiator: userRole === 'owner',
+        onHandshakeComplete: () => {
+          if (isMounted.current) setP2PStatus('connected')
+        },
+        onUpdateApplied: () => {
+          if (isMounted.current) {
+            void loadTrip()
+            setChecklistLoaded(false)
+          }
+        },
+      })
+      p2pConnectionRef.current = connection
+    } catch {
+      if (isMounted.current) setP2PStatus('unavailable')
+    }
+  }, [canEditContent, id, loadTrip, session?.user.id, userRole])
+
+  useEffect(() => {
+    if (!id || !session?.user.id || !canEditContent) {
+      setP2PStatus('idle')
+      return undefined
+    }
+
+    void reconnectP2P('connecting')
+    const unbindLifecycle = bindMobileP2PLifecycle({
+      closeActiveConnection: async () => {
+        await p2pConnectionRef.current?.close().catch(() => undefined)
+        p2pConnectionRef.current = null
+        if (isMounted.current) setP2PStatus('idle')
+      },
+      reconnectActiveConnection: () => {
+        void reconnectP2P('reconnecting')
+      },
+    })
+
+    return () => {
+      unbindLifecycle()
+      void p2pConnectionRef.current?.close().catch(() => undefined)
+      p2pConnectionRef.current = null
+    }
+  }, [canEditContent, id, reconnectP2P, session?.user.id])
+
   useEffect(() => {
     setChecklist(null)
     setItems([])
@@ -920,26 +1010,16 @@ export default function TripDetailScreen() {
     if (!id) return
     setChecklistLoading(true)
     try {
-      const result = await getChecklistByTrip(supabase, id)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase)
+      const result = await repositories.checklists.getChecklist(id)
       if (!isMounted.current) return
-      if (result) {
-        const itemIds = result.items.map((item) => item.id)
-        const [assigneesData, checksData, categoryData] = await Promise.all([
-          getChecklistItemAssignees(supabase, itemIds),
-          getChecklistItemUserChecks(supabase, itemIds),
-          session?.user.id ? getChecklistCategories(supabase, session.user.id) : Promise.resolve([]),
-        ])
-        setChecklist(result.checklist)
-        setItems(result.items)
-        setItemAssignees(assigneesData)
-        setUserChecks(checksData)
-        setChecklistCategories(categoryData)
-      } else {
-        setChecklist(null)
-        setItems([])
-        setItemAssignees([])
-        setUserChecks([])
-      }
+      const snapshot = toChecklistSnapshotRows(result, id)
+      const categoryData = session?.user.id ? await getChecklistCategories(supabase, session.user.id) : []
+      setChecklist(snapshot.checklist)
+      setItems(snapshot.items)
+      setItemAssignees(snapshot.itemAssignees)
+      setUserChecks(snapshot.userChecks)
+      setChecklistCategories(categoryData)
     } catch {
       // 빈 상태 유지
     } finally {
@@ -953,10 +1033,18 @@ export default function TripDetailScreen() {
   const ensureCurrentTripChecklist = useCallback(async () => {
     if (!id) return null
     if (checklist?.trip_id === id) return checklist
-    const currentChecklist = await ensureChecklist(supabase, id)
-    setChecklist(currentChecklist)
-    return currentChecklist
-  }, [checklist, id])
+    const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+      actorRole: normalizeDocumentRole(userRole),
+    })
+    const checklistId = createEntityId('checklist')
+    const result = await repositories.checklists.createChecklist(id, {
+      id: checklistId,
+      title: '준비물',
+    })
+    const snapshot = toChecklistSnapshotRows(await repositories.checklists.getChecklist(result.document.trip.id), id)
+    setChecklist(snapshot.checklist)
+    return snapshot.checklist
+  }, [checklist, id, userRole])
 
   // 준비물 탭 최초 진입 시 1회 lazy load
   useEffect(() => {
@@ -972,7 +1060,13 @@ export default function TripDetailScreen() {
       prev.map((p) => (p.id === plan.id ? { ...p, is_visited: next } : p))
     )
     try {
-      await togglePlanVisited(supabase, plan.id, next)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+        actorRole: normalizeDocumentRole(userRole),
+      })
+      await repositories.plans.updatePlan(id, {
+        planId: plan.id,
+        patch: { isVisited: next },
+      })
     } catch {
       if (isMounted.current) {
         setPlans((prev) =>
@@ -983,7 +1077,7 @@ export default function TripDetailScreen() {
       }
       Alert.alert('오류', '저장에 실패했어요. 다시 시도해 주세요.')
     }
-  }, [])
+  }, [id, userRole])
 
   // 체크리스트 항목 토글 (낙관적 업데이트 + 롤백)
   const participantIds = useMemo(
@@ -1041,7 +1135,15 @@ export default function TripDetailScreen() {
       )
     }
     try {
-      await toggleChecklistItemForUser(supabase, item, session.user.id, next)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+        actorRole: normalizeDocumentRole(userRole),
+      })
+      await repositories.checklists.toggleItem(id, {
+        itemId: item.id,
+        nextChecked: next,
+        currentUserId: session.user.id,
+        participantIds,
+      })
     } catch {
       if (isMounted.current) {
         setItems(previousItems)
@@ -1049,7 +1151,7 @@ export default function TripDetailScreen() {
       }
       Alert.alert('오류', '저장에 실패했어요. 다시 시도해 주세요.')
     }
-  }, [itemAssignees, items, participantIds, session?.user.id, userChecks])
+  }, [id, itemAssignees, items, participantIds, session?.user.id, userChecks, userRole])
 
   const handleSaveTrip = useCallback(
     async (input: {
@@ -1060,11 +1162,21 @@ export default function TripDetailScreen() {
       children_count: number
     }) => {
       if (!trip) return
-      const saved = await updateTrip(supabase, trip.id, input)
-      setTrip(saved)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+        actorRole: normalizeDocumentRole(userRole),
+      })
+      await repositories.trips.updateTrip(trip.id, {
+        destination: input.destination,
+        startDate: input.start_date,
+        endDate: input.end_date,
+        adultsCount: input.adults_count,
+        childrenCount: input.children_count,
+      })
+      const updated = await repositories.trips.getTrip(trip.id)
+      if (updated) setTrip(toTripRow(updated))
       setIsTripSheetOpen(false)
     },
-    [trip]
+    [trip, userRole]
   )
 
   const handleOfflineSave = useCallback(() => {
@@ -1076,13 +1188,8 @@ export default function TripDetailScreen() {
     setDeletingTrip(true)
     try {
       await cancelDocumentAlarms(id).catch(() => ({ status: 'failed' as const }))
-      const { error: deleteError } = await supabase
-        .from('trips')
-        .delete()
-        .eq('id', id)
-        .eq('user_id', session.user.id)
-
-      if (deleteError) throw deleteError
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+      await repositories.trips.deleteTrip(id)
       setIsTripDeleteOpen(false)
       router.replace('/(tabs)')
     } catch {
@@ -1096,19 +1203,45 @@ export default function TripDetailScreen() {
     async (input: PlanSaveInput) => {
       if (!id) return
       let savedPlan: PlanWithUrls | null = null
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+        actorRole: normalizeDocumentRole(userRole),
+      })
+      const planId = editingPlan?.id ?? createEntityId('plan')
+      const planInput = {
+        title: input.title,
+        location: input.location,
+        address: input.address ?? null,
+        coordinates: input.location_lat != null && input.location_lng != null
+          ? { lat: input.location_lat, lng: input.location_lng }
+          : null,
+        googlePlaceId: input.google_place_id ?? null,
+        imageUrl: input.image_url ?? editingPlan?.image_url ?? null,
+        photoReference: input.photo_reference ?? null,
+        startDateTimeLocal: input.start_datetime_local,
+        endDateTimeLocal: input.end_datetime_local,
+        timezone: input.timezone_string || editingPlan?.timezone_string || 'Asia/Seoul',
+        alarmMinutesBefore: input.alarm_minutes_before ?? null,
+        alarmSentAt: editingPlan?.alarm_sent_at ?? null,
+        cost: input.cost,
+        memo: input.memo,
+        isCompleted: editingPlan?.is_completed ?? false,
+        isVisited: editingPlan?.is_visited ?? false,
+      }
       if (editingPlan) {
-        savedPlan = await updatePlan(supabase, editingPlan.id, {
-          ...input,
-          trip_id: id,
-          timezone_string: input.timezone_string || editingPlan.timezone_string || 'Asia/Seoul',
+        await repositories.plans.updatePlan(id, {
+          planId: editingPlan.id,
+          patch: planInput,
         })
       } else {
-        savedPlan = await createPlan(supabase, {
-          ...input,
-          trip_id: id,
-          timezone_string: input.timezone_string || 'Asia/Seoul',
+        await repositories.plans.createPlan(id, {
+          id: planId,
+          ...planInput,
         })
       }
+      await syncPlanUrls(repositories, id, planId, editingPlan?.plan_urls ?? [], input.urls)
+      const nextPlans = await repositories.plans.listPlans(id)
+      const savedPlanReadModel = nextPlans.find((plan) => plan.id === planId)
+      savedPlan = savedPlanReadModel ? toPlanRow(savedPlanReadModel, id) : null
       if (savedPlan) {
         const alarmMinutesBefore = savedPlan.alarm_minutes_before ?? 0
         let requestPermission = false
@@ -1185,12 +1318,15 @@ export default function TripDetailScreen() {
           })
       }
     },
-    [editingPlan, id, loadTrip, session?.user.id]
+    [editingPlan, id, loadTrip, session?.user.id, userRole]
   )
 
   const handleDeletePlan = useCallback(
     async (plan: PlanWithUrls) => {
-      await deletePlan(supabase, plan.id)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+        actorRole: normalizeDocumentRole(userRole),
+      })
+      await repositories.plans.deletePlan(id, plan.id)
       const alarmResult = await cancelPlanAlarm(plan.id).catch(() => ({ status: 'failed' as const }))
       setLocalAlarmStatusByPlanId((prev) => ({
         ...prev,
@@ -1200,7 +1336,7 @@ export default function TripDetailScreen() {
       setIsPlanSheetOpen(false)
       await loadTrip()
     },
-    [loadTrip]
+    [id, loadTrip, userRole]
   )
 
   const handleSaveChecklistItem = useCallback(
@@ -1234,40 +1370,57 @@ export default function TripDetailScreen() {
           : []
 
       if (editingItem) {
-        await updateChecklistItem(supabase, editingItem.id, {
-          item_name: input.item_name,
-          category: normalizedCategory,
-          is_private: input.is_private,
-          assignment_type: input.is_private ? 'specific' : input.assignment_type,
-          assigned_user_id: finalAssigneeIds[0] ?? null,
-          assignee_ids: finalAssigneeIds,
-          source_template_name: editingItem.source_template_name,
+        const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+          actorRole: normalizeDocumentRole(userRole),
+        })
+        await repositories.checklists.updateItem(id, {
+          itemId: editingItem.id,
+          patch: {
+            name: input.item_name,
+            categoryName: normalizedCategory,
+            isPrivate: input.is_private,
+            assignmentType: input.is_private ? 'specific' : input.assignment_type,
+            assignedUserId: finalAssigneeIds[0] ?? null,
+            sourceTemplateName: editingItem.source_template_name,
+          },
+          assigneeIds: finalAssigneeIds,
         })
       } else {
-        await createChecklistItem(supabase, currentChecklist.id, {
-          item_name: input.item_name,
-          category: normalizedCategory,
-          is_private: input.is_private,
-          assignment_type: input.is_private ? 'specific' : input.assignment_type,
-          assigned_user_id: finalAssigneeIds[0] ?? null,
-          assignee_ids: finalAssigneeIds,
+        const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+          actorRole: normalizeDocumentRole(userRole),
+        })
+        await repositories.checklists.createItem(id, {
+          id: createEntityId('checklist-item'),
+          checklistId: currentChecklist.id,
+          name: input.item_name,
+          categoryName: normalizedCategory,
+          legacyIsChecked: false,
+          isPrivate: input.is_private,
+          assignmentType: input.is_private ? 'specific' : input.assignment_type,
+          assignedUserId: finalAssigneeIds[0] ?? null,
+          sourceTemplateName: null,
+          assigneeIds: finalAssigneeIds,
         })
       }
       setEditingItem(null)
       setIsItemSheetOpen(false)
       await loadChecklist()
     },
-    [checklistCategories, editingItem, ensureCurrentTripChecklist, id, loadChecklist, session?.user.id]
+    [checklistCategories, editingItem, ensureCurrentTripChecklist, id, loadChecklist, session?.user.id, userRole]
   )
 
   const handleDeleteChecklistItem = useCallback(
     async (item: ChecklistItem) => {
-      await deleteChecklistItem(supabase, item.id)
+      if (!id) return
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+        actorRole: normalizeDocumentRole(userRole),
+      })
+      await repositories.checklists.deleteItem(id, item.id)
       setEditingItem(null)
       setIsItemSheetOpen(false)
       await loadChecklist()
     },
-    [loadChecklist]
+    [id, loadChecklist, userRole]
   )
 
   const handleApplyTemplate = useCallback(
@@ -1275,11 +1428,21 @@ export default function TripDetailScreen() {
       if (!id) return
       const currentChecklist = await ensureCurrentTripChecklist()
       if (!currentChecklist) return
-      await applyTemplateToChecklist(supabase, currentChecklist.id, templateId, session?.user.id)
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, {
+        actorRole: normalizeDocumentRole(userRole),
+      })
+      const template = await repositories.templates.getTemplate(templateId)
+      if (!template) throw new Error('Template document was not found.')
+      await repositories.checklists.applyTemplate(
+        id,
+        currentChecklist.id,
+        templateId,
+        template.items.map(() => createEntityId('checklist-item')),
+      )
       setIsTemplateSheetOpen(false)
       await loadChecklist()
     },
-    [ensureCurrentTripChecklist, id, loadChecklist, session?.user.id]
+    [ensureCurrentTripChecklist, id, loadChecklist, userRole]
   )
 
   const totalPlanCost = useMemo(
@@ -1494,7 +1657,23 @@ export default function TripDetailScreen() {
 
   const handleUpdateMemberRole = async (memberId: string, role: 'editor' | 'viewer') => {
     try {
-      await updateTripMemberRole(supabase, memberId, role)
+      if (!id) return
+      const member = members.find((candidate) => candidate.id === memberId)
+      if (!member) return
+      const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+      await repositories.members.upsertMember(id, {
+        member: {
+          id: member.id,
+          userId: member.user_id,
+          invitedEmail: member.invited_email || null,
+          role,
+          status: member.status,
+          nickname: member.profiles?.nickname ?? null,
+          email: member.profiles?.email ?? member.invited_email ?? null,
+          createdAt: member.created_at || new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      })
       await loadMembers()
     } catch {
       Alert.alert('오류', '권한 변경에 실패했어요.')
@@ -1512,7 +1691,9 @@ export default function TripDetailScreen() {
           style: 'destructive',
           onPress: async () => {
             try {
-              await removeTripMember(supabase, member.id)
+              if (!id) return
+              const repositories = await createMobileDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+              await repositories.members.revokeMember(id, member.id)
               await loadMembers()
             } catch {
               Alert.alert('오류', '동행자 삭제에 실패했어요.')
@@ -1653,6 +1834,18 @@ export default function TripDetailScreen() {
                       <Ionicons name="wallet-outline" size={14} color={colors.brand.ink} />
                       <Text style={styles.tripMetaText} numberOfLines={1}>
                         약 {totalPlanCost.toLocaleString()}원
+                      </Text>
+                    </View>
+                  ) : null}
+                  {canEditContent ? (
+                    <View style={styles.tripMetaItem}>
+                      <Ionicons
+                        name={p2pStatus === 'connected' ? 'radio-outline' : 'cloud-outline'}
+                        size={14}
+                        color={p2pStatus === 'connected' ? colors.brand.success : colors.brand.muted}
+                      />
+                      <Text style={styles.tripMetaText} numberOfLines={1}>
+                        {getMobileP2PStatusLabel(p2pStatus)}
                       </Text>
                     </View>
                   ) : null}
@@ -1914,7 +2107,7 @@ export default function TripDetailScreen() {
   )
 }
 
-const TIME_MODE_OPTIONS: Array<{ value: TimeDisplayMode; label: string }> = [
+const TIME_MODE_OPTIONS: { value: TimeDisplayMode; label: string }[] = [
   { value: 'local', label: '현지 시간' },
   { value: 'kst', label: '한국 시간' },
   { value: 'both', label: '동시 표기' },
@@ -3445,7 +3638,7 @@ function AssigneeFilterSheet({
 }: {
   visible: boolean
   filter: 'all' | 'me' | 'companions'
-  companions: Array<{ user_id: string; label: string }>
+  companions: { user_id: string; label: string }[]
   selectedIds: string[]
   onSelectAll: () => void
   onSelectMe: () => void
@@ -3546,11 +3739,11 @@ function ChecklistDropdownSheet({
   visible: boolean
   title: string
   value: string
-  options: Array<{
+  options: {
     value: string
     label: string
     icon: React.ComponentProps<typeof Ionicons>['name']
-  }>
+  }[]
   onSelect: (value: string) => void
   onClose: () => void
 }) {
@@ -4765,7 +4958,7 @@ function SelectTriggerField<T extends string | number>({
 }: {
   label: string
   icon: React.ComponentProps<typeof Ionicons>['name']
-  options: Array<{ value: T; label: string }>
+  options: { value: T; label: string }[]
   value: T
   onPress: () => void
 }) {
@@ -4800,7 +4993,7 @@ function OptionPickerModal<T extends string | number>({
   onChange,
 }: {
   visible: boolean
-  options: Array<{ value: T; label: string }>
+  options: { value: T; label: string }[]
   value: T
   onClose: () => void
   onChange: (value: T) => void

--- a/apps/mobile/lib/local-first/documentPrimaryAdapters.ts
+++ b/apps/mobile/lib/local-first/documentPrimaryAdapters.ts
@@ -1,0 +1,227 @@
+import type {
+  Checklist,
+  ChecklistItem,
+  ChecklistItemAssignee,
+  ChecklistItemUserCheck,
+  ChecklistTemplateItem,
+  ChecklistTemplateShareWithProfile,
+  ChecklistTemplateWithAccess,
+  Plan,
+  PlanUrl,
+  TemplateWithPreview,
+  Trip,
+  TripMember,
+} from '@nexvoy/types'
+import type {
+  ChecklistItemReadModel,
+  ChecklistReadModel,
+  PlanTimelineItemReadModel,
+  TemplateDetailReadModel,
+  TemplateSummaryReadModel,
+  TripDetailReadModel,
+  TripMemberReadModel,
+  TripSummaryReadModel,
+} from '@nexvoy/core'
+
+export type MobilePlanWithUrls = Plan & { plan_urls: PlanUrl[] }
+
+export function toTripRow(readModel: TripDetailReadModel | TripSummaryReadModel): Trip {
+  return {
+    id: readModel.id,
+    user_id: readModel.ownerId,
+    destination: readModel.destination,
+    start_date: readModel.startDate,
+    end_date: readModel.endDate,
+    adults_count: readModel.adultsCount,
+    children_count: readModel.childrenCount,
+    created_at: readModel.updatedAt,
+    updated_at: readModel.updatedAt,
+  }
+}
+
+export function toPlanRows(readModels: PlanTimelineItemReadModel[], tripId: string): MobilePlanWithUrls[] {
+  return readModels.map((plan) => toPlanRow(plan, tripId))
+}
+
+export function toPlanRow(plan: PlanTimelineItemReadModel, tripId: string): MobilePlanWithUrls {
+  return {
+    id: plan.id,
+    trip_id: tripId,
+    title: plan.title,
+    location: plan.location,
+    address: plan.address,
+    lat: plan.coordinates?.lat ?? null,
+    lng: plan.coordinates?.lng ?? null,
+    location_lat: plan.coordinates?.lat ?? null,
+    location_lng: plan.coordinates?.lng ?? null,
+    visit_date: plan.startDateTimeLocal.slice(0, 10),
+    visit_time: parseTimePart(plan.startDateTimeLocal),
+    start_datetime_local: plan.startDateTimeLocal,
+    end_datetime_local: plan.endDateTimeLocal,
+    timezone_string: plan.timezone,
+    alarm_minutes_before: plan.alarmMinutesBefore,
+    alarm_sent_at: plan.alarmSentAt,
+    cost: plan.cost,
+    memo: plan.memo,
+    image_url: plan.imageUrl,
+    photo_reference: plan.photoReference,
+    google_place_id: plan.googlePlaceId,
+    is_completed: plan.isCompleted,
+    is_visited: plan.isVisited,
+    created_at: plan.startDateTimeLocal,
+    updated_at: plan.startDateTimeLocal,
+    plan_urls: plan.urls.map((url) => ({
+      id: url.id,
+      plan_id: url.planId,
+      url: url.url,
+      created_at: url.createdAt,
+    })),
+  }
+}
+
+export function toChecklistSnapshotRows(
+  checklists: ChecklistReadModel[],
+  tripId: string,
+): {
+  checklist: Checklist | null
+  items: ChecklistItem[]
+  itemAssignees: ChecklistItemAssignee[]
+  userChecks: ChecklistItemUserCheck[]
+} {
+  const firstChecklist = checklists[0] ?? null
+  return {
+    checklist: firstChecklist
+      ? {
+        id: firstChecklist.id,
+        trip_id: tripId,
+        title: firstChecklist.title,
+        created_at: firstChecklist.createdAt,
+      }
+      : null,
+    items: checklists.flatMap((checklist) => checklist.items.map(toChecklistItemRow)),
+    itemAssignees: checklists.flatMap((checklist) =>
+      checklist.items.flatMap((item) => item.assignees.map(toAssigneeRow)),
+    ),
+    userChecks: checklists.flatMap((checklist) =>
+      checklist.items.flatMap((item) => item.userChecks.map(toUserCheckRow)),
+    ),
+  }
+}
+
+export function toTripMemberRows(members: TripMemberReadModel[], tripId: string): TripMember[] {
+  return members
+    .filter((member) => member.status !== 'revoked')
+    .map((member) => ({
+      id: member.id,
+      trip_id: tripId,
+      user_id: member.userId,
+      invited_email: member.invitedEmail ?? member.email ?? '',
+      role: member.role,
+      status: member.status === 'pending' ? 'pending' : 'accepted',
+      created_at: '',
+      profiles: {
+        nickname: member.nickname,
+        email: member.email,
+      },
+    }))
+}
+
+export function toTemplatePreviewRow(
+  template: TemplateSummaryReadModel,
+  currentUserId: string | null | undefined,
+): TemplateWithPreview {
+  return {
+    id: template.id,
+    title: template.title,
+    user_id: template.ownerId,
+    item_count: template.itemCount,
+    preview_items: template.previewItems,
+    created_at: template.updatedAt,
+    access: template.ownerId === currentUserId
+      ? 'owner'
+      : template.ownerId === null || template.visibility === 'public'
+        ? 'default'
+        : 'viewer',
+  }
+}
+
+export function toTemplateWithAccessRow(
+  template: TemplateDetailReadModel,
+  currentUserId: string | null | undefined,
+): ChecklistTemplateWithAccess {
+  const access = template.ownerId === currentUserId
+    ? 'owner'
+    : template.ownerId === null || template.visibility === 'public'
+      ? 'default'
+      : 'viewer'
+
+  return {
+    id: template.id,
+    title: template.title,
+    user_id: template.ownerId,
+    created_at: template.updatedAt,
+    access,
+    share_role: access === 'viewer' ? 'viewer' : null,
+  }
+}
+
+export function toTemplateItemRows(template: TemplateDetailReadModel): ChecklistTemplateItem[] {
+  return template.items.map((item) => ({
+    id: item.id,
+    template_id: item.templateId,
+    item_name: item.name,
+    category: item.categoryName,
+    is_private: item.isPrivate,
+    created_at: item.createdAt,
+  }))
+}
+
+export function toTemplateShareRows(template: TemplateDetailReadModel): ChecklistTemplateShareWithProfile[] {
+  return template.shares.map((share) => ({
+    id: share.id,
+    template_id: share.templateId,
+    shared_with_user_id: share.sharedWithUserId,
+    role: share.role,
+    created_by: share.createdBy,
+    created_at: share.createdAt,
+    profiles: null,
+  }))
+}
+
+function toChecklistItemRow(item: ChecklistItemReadModel): ChecklistItem {
+  return {
+    id: item.id,
+    checklist_id: item.checklistId,
+    item_name: item.name,
+    category: item.categoryName,
+    is_checked: item.status.isChecked,
+    is_private: item.isPrivate,
+    assignment_type: item.assignmentType,
+    assigned_user_id: item.assignedUserId,
+    source_template_name: item.sourceTemplateName,
+    created_at: item.createdAt,
+    updated_at: item.updatedAt,
+  }
+}
+
+function toAssigneeRow(assignee: ChecklistItemReadModel['assignees'][number]): ChecklistItemAssignee {
+  return {
+    id: assignee.id,
+    item_id: assignee.itemId,
+    user_id: assignee.userId,
+    created_at: assignee.createdAt,
+  }
+}
+
+function toUserCheckRow(check: ChecklistItemReadModel['userChecks'][number]): ChecklistItemUserCheck {
+  return {
+    id: check.id,
+    item_id: check.itemId,
+    user_id: check.userId,
+    created_at: check.createdAt,
+  }
+}
+
+function parseTimePart(dateTime: string): string | null {
+  return dateTime.match(/[T\s](\d{1,2}:\d{2})/)?.[1] ?? null
+}

--- a/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
@@ -1,0 +1,204 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  convertLegacyTripRowsToDocument,
+  createDocumentPrimaryRepositoryBundle,
+  createEmptyTemplateDocumentV1,
+  getLegacyTripRowBundle,
+  type DocumentMutationResult,
+  type TemplateDocumentV1,
+  type TripDocumentV1,
+} from '@nexvoy/core'
+import type { EntityId } from '@nexvoy/core/local-first/documentModel'
+import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
+import { publishLocalMobileTripDocumentUpdate } from './p2pUpdateBridge'
+import {
+  createMobileTemplateDocumentStore,
+  createMobileTripDocumentStore,
+} from './mobileDocumentStores'
+
+export async function createMobileDocumentPrimaryRepositories(
+  supabase: SupabaseClient,
+  options: {
+    actorRole?: 'owner' | 'editor' | 'viewer' | null
+  } = {},
+): Promise<DocumentPrimaryRepositoryBundle> {
+  const { data } = await supabase.auth.getUser()
+  const userId = data.user?.id ?? 'anonymous-mobile-user'
+  const actor = {
+    userId,
+    role: options.actorRole ?? 'viewer',
+    status: 'accepted' as const,
+  }
+
+  const tripStore = createMobileTripDocumentStore({
+    hydrateDocument: async (tripId) => {
+      const bundle = await getLegacyTripRowBundle(supabase, tripId, data.user?.id ?? null)
+      return bundle ? convertLegacyTripRowsToDocument(bundle).document : null
+    },
+  })
+  const templateStore = createMobileTemplateDocumentStore({
+    hydrateDocument: (templateId) => hydrateTemplateDocument(supabase, templateId),
+    listLegacyDocumentIds: () => listLegacyTemplateIds(supabase, data.user?.id ?? null),
+  })
+
+  return createDocumentPrimaryRepositoryBundle({
+    tripStore,
+    templateStore,
+    runtime: {
+      actor,
+      publisher: {
+        publishMutation: (result) => {
+          if (result.documentType === 'trip') {
+            publishLocalMobileTripDocumentUpdate({
+              documentId: result.documentId,
+              update: result.update,
+            })
+          }
+        },
+      },
+    },
+  })
+}
+
+export async function createMobileTemplateDocument(input: {
+  supabase: SupabaseClient
+  title: string
+  items: Array<{
+    item_name: string
+    category: string
+    is_private?: boolean
+  }>
+}): Promise<string> {
+  const { data } = await input.supabase.auth.getUser()
+  const templateStore = createMobileTemplateDocumentStore()
+  const now = new Date().toISOString()
+  const templateId = createEntityId('template')
+  const document = createEmptyTemplateDocumentV1({
+    id: templateId,
+    ownerId: data.user?.id ?? null,
+    title: input.title,
+    visibility: 'private',
+    createdAt: now,
+  })
+
+  input.items.forEach((item, index) => {
+    const itemId = createEntityId('template-item')
+    document.items[itemId] = {
+      id: itemId,
+      templateId,
+      name: item.item_name,
+      categoryName: item.category,
+      isPrivate: item.is_private ?? false,
+      sortOrder: index,
+      createdAt: now,
+      updatedAt: now,
+    }
+  })
+
+  await templateStore.putDocument(templateId, document)
+  return templateId
+}
+
+async function listLegacyTemplateIds(
+  supabase: SupabaseClient,
+  currentUserId: string | null,
+): Promise<EntityId[]> {
+  if (!currentUserId) return []
+  const owned = supabase
+    .from('checklist_templates')
+    .select('id')
+    .eq('user_id', currentUserId)
+  const publicTemplates = supabase
+    .from('checklist_templates')
+    .select('id')
+    .is('user_id', null)
+  const shared = supabase
+    .from('checklist_template_shares')
+    .select('template_id')
+    .eq('shared_with_user_id', currentUserId)
+
+  const [ownedResult, publicResult, sharedResult] = await Promise.all([owned, publicTemplates, shared])
+  if (ownedResult.error) throw ownedResult.error
+  if (publicResult.error) throw publicResult.error
+  if (sharedResult.error) throw sharedResult.error
+
+  return Array.from(new Set([
+    ...(ownedResult.data ?? []).map((row) => row.id),
+    ...(publicResult.data ?? []).map((row) => row.id),
+    ...(sharedResult.data ?? []).map((row) => row.template_id),
+  ]))
+}
+
+async function hydrateTemplateDocument(
+  supabase: SupabaseClient,
+  templateId: EntityId,
+): Promise<TemplateDocumentV1 | null> {
+  const { data: template, error: templateError } = await supabase
+    .from('checklist_templates')
+    .select('id, user_id, title, created_at')
+    .eq('id', templateId)
+    .maybeSingle()
+  if (templateError) throw templateError
+  if (!template) return null
+
+  const [itemsResult, sharesResult] = await Promise.all([
+    supabase
+      .from('checklist_template_items')
+      .select('id, template_id, item_name, category, is_private, created_at')
+      .eq('template_id', templateId),
+    supabase
+      .from('checklist_template_shares')
+      .select('id, template_id, shared_with_user_id, role, created_by, created_at')
+      .eq('template_id', templateId),
+  ])
+  if (itemsResult.error) throw itemsResult.error
+  if (sharesResult.error) throw sharesResult.error
+
+  const createdAt = template.created_at ?? new Date().toISOString()
+  const document = createEmptyTemplateDocumentV1({
+    id: template.id,
+    ownerId: template.user_id,
+    title: template.title,
+    visibility: (sharesResult.data?.length ?? 0) > 0 ? 'shared' : 'private',
+    createdAt,
+    updatedAt: createdAt,
+    createdFromLegacyAt: new Date().toISOString(),
+  })
+
+  ;(itemsResult.data ?? []).forEach((item, index) => {
+    const itemCreatedAt = item.created_at ?? createdAt
+    document.items[item.id] = {
+      id: item.id,
+      templateId,
+      name: item.item_name,
+      categoryName: item.category ?? '기타',
+      isPrivate: item.is_private ?? false,
+      sortOrder: index,
+      createdAt: itemCreatedAt,
+      updatedAt: itemCreatedAt,
+    }
+  })
+
+  ;(sharesResult.data ?? []).forEach((share) => {
+    const shareCreatedAt = share.created_at ?? createdAt
+    document.shares[share.id] = {
+      id: share.id,
+      templateId,
+      sharedWithUserId: share.shared_with_user_id,
+      role: share.role === 'editor' ? 'editor' : 'viewer',
+      createdBy: share.created_by,
+      createdAt: shareCreatedAt,
+      updatedAt: null,
+    }
+  })
+
+  return document
+}
+
+export type MobileDocumentPrimaryMutationResult =
+  DocumentMutationResult<TripDocumentV1 | TemplateDocumentV1>
+
+function createEntityId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}

--- a/apps/mobile/lib/local-first/mobileDocumentStores.ts
+++ b/apps/mobile/lib/local-first/mobileDocumentStores.ts
@@ -1,0 +1,173 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import type {
+  LocalDocumentStore,
+} from '@nexvoy/core/repositories/documentPrimaryRepository'
+import type {
+  EntityId,
+  TripDocumentV1,
+} from '@nexvoy/core/local-first/documentModel'
+import type {
+  TemplateDocumentV1,
+} from '@nexvoy/core/local-first/templateDocument'
+import {
+  applyTripDocumentUpdate,
+  createYjsTripDocument,
+  encodeTripDocumentUpdate,
+  readTripDocumentFromYjs,
+} from '@nexvoy/core/local-first/yjsTripDocument'
+import {
+  applyTemplateDocumentUpdate,
+  createYjsTemplateDocument,
+  encodeTemplateDocumentUpdate,
+  readTemplateDocumentFromYjs,
+} from '@nexvoy/core/local-first/templateDocument'
+
+const TRIP_UPDATE_PREFIX = 'onvoy:local-first:yjs-update:'
+const TEMPLATE_UPDATE_PREFIX = 'onvoy:local-first:template-yjs-update:'
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+export function createMobileTripDocumentStore(options: {
+  hydrateDocument?: (documentId: EntityId) => Promise<TripDocumentV1 | null>
+} = {}): LocalDocumentStore<TripDocumentV1> {
+  return {
+    listDocumentIds: async () => listDocumentIds(TRIP_UPDATE_PREFIX),
+    getDocument: async (documentId) => {
+      const update = await loadDocumentUpdate(TRIP_UPDATE_PREFIX, documentId)
+      if (!update) {
+        const hydrated = await options.hydrateDocument?.(documentId)
+        if (!hydrated) return null
+        await putTripDocument(documentId, hydrated)
+        return hydrated
+      }
+
+      const doc = createYjsTripDocument()
+      applyTripDocumentUpdate(doc, update)
+      return readTripDocumentFromYjs(doc)
+    },
+    putDocument: async (documentId, document, update) => {
+      if (update) {
+        await saveDocumentUpdate(TRIP_UPDATE_PREFIX, documentId, update)
+        return
+      }
+      await putTripDocument(documentId, document)
+    },
+  }
+}
+
+export function createMobileTemplateDocumentStore(options: {
+  hydrateDocument?: (documentId: EntityId) => Promise<TemplateDocumentV1 | null>
+  listLegacyDocumentIds?: () => Promise<EntityId[]>
+} = {}): LocalDocumentStore<TemplateDocumentV1> {
+  return {
+    listDocumentIds: async () => {
+      const localIds = await listDocumentIds(TEMPLATE_UPDATE_PREFIX)
+      const legacyIds = await options.listLegacyDocumentIds?.() ?? []
+      return Array.from(new Set([...localIds, ...legacyIds]))
+    },
+    getDocument: async (documentId) => {
+      const update = await loadDocumentUpdate(TEMPLATE_UPDATE_PREFIX, documentId)
+      if (!update) {
+        const hydrated = await options.hydrateDocument?.(documentId)
+        if (!hydrated) return null
+        await putTemplateDocument(documentId, hydrated)
+        return hydrated
+      }
+
+      const doc = createYjsTemplateDocument()
+      applyTemplateDocumentUpdate(doc, update)
+      return readTemplateDocumentFromYjs(doc)
+    },
+    putDocument: async (documentId, document, update) => {
+      if (update) {
+        await saveDocumentUpdate(TEMPLATE_UPDATE_PREFIX, documentId, update)
+        return
+      }
+      await putTemplateDocument(documentId, document)
+    },
+  }
+}
+
+async function putTripDocument(
+  documentId: EntityId,
+  document: TripDocumentV1,
+): Promise<void> {
+  const doc = createYjsTripDocument(document)
+  await saveDocumentUpdate(TRIP_UPDATE_PREFIX, documentId, encodeTripDocumentUpdate(doc))
+}
+
+async function putTemplateDocument(
+  documentId: EntityId,
+  document: TemplateDocumentV1,
+): Promise<void> {
+  const doc = createYjsTemplateDocument(document)
+  await saveDocumentUpdate(TEMPLATE_UPDATE_PREFIX, documentId, encodeTemplateDocumentUpdate(doc))
+}
+
+async function listDocumentIds(prefix: string): Promise<EntityId[]> {
+  const keys = await AsyncStorage.getAllKeys()
+  return keys
+    .filter((key) => key.startsWith(prefix))
+    .map((key) => key.slice(prefix.length))
+    .filter(Boolean)
+}
+
+async function loadDocumentUpdate(prefix: string, documentId: EntityId): Promise<Uint8Array | null> {
+  const encoded = await AsyncStorage.getItem(`${prefix}${documentId}`)
+  return encoded ? base64ToBytes(encoded) : null
+}
+
+async function saveDocumentUpdate(
+  prefix: string,
+  documentId: EntityId,
+  update: Uint8Array,
+): Promise<void> {
+  await AsyncStorage.setItem(`${prefix}${documentId}`, bytesToBase64(update))
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let output = ''
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index]
+    const second = bytes[index + 1]
+    const third = bytes[index + 2]
+    const combined = (first << 16) | ((second ?? 0) << 8) | (third ?? 0)
+
+    output += BASE64_ALPHABET[(combined >> 18) & 63]
+    output += BASE64_ALPHABET[(combined >> 12) & 63]
+    output += index + 1 < bytes.length ? BASE64_ALPHABET[(combined >> 6) & 63] : '='
+    output += index + 2 < bytes.length ? BASE64_ALPHABET[combined & 63] : '='
+  }
+  return output
+}
+
+function base64ToBytes(base64: string): Uint8Array | null {
+  const normalized = base64.replace(/\s/g, '')
+  if (normalized.length % 4 !== 0) return null
+
+  const padding = normalized.endsWith('==') ? 2 : normalized.endsWith('=') ? 1 : 0
+  const bytes = new Uint8Array((normalized.length / 4) * 3 - padding)
+  let byteIndex = 0
+
+  for (let index = 0; index < normalized.length; index += 4) {
+    const first = decodeBase64Char(normalized[index])
+    const second = decodeBase64Char(normalized[index + 1])
+    const third = normalized[index + 2] === '=' ? 0 : decodeBase64Char(normalized[index + 2])
+    const fourth = normalized[index + 3] === '=' ? 0 : decodeBase64Char(normalized[index + 3])
+
+    if (first < 0 || second < 0 || third < 0 || fourth < 0) return null
+    const combined = (first << 18) | (second << 12) | (third << 6) | fourth
+
+    if (byteIndex < bytes.length) bytes[byteIndex] = (combined >> 16) & 255
+    byteIndex += 1
+    if (byteIndex < bytes.length) bytes[byteIndex] = (combined >> 8) & 255
+    byteIndex += 1
+    if (byteIndex < bytes.length) bytes[byteIndex] = combined & 255
+    byteIndex += 1
+  }
+
+  return bytes
+}
+
+function decodeBase64Char(char: string): number {
+  return BASE64_ALPHABET.indexOf(char)
+}

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -265,6 +265,10 @@
 - Web 템플릿 적용 전환
 - Web 동행자 UI read/write 정리
 
+상태:
+
+- 완료. PR #321에서 Web의 일정/준비물/템플릿/동행자 경로를 document-primary repository로 전환했다.
+
 ### TASK-032: Mobile Full Document-primary 전환
 
 범위:
@@ -274,6 +278,11 @@
 - Mobile 템플릿 적용 전환
 - Mobile collaborator/key provisioning UX 정리
 - Mobile P2P 화면 생명주기 연결
+
+상태:
+
+- 완료. Issue #322에서 Mobile AsyncStorage 기반 Trip/Template document store, Mobile repository factory, trip detail/template 화면 document-primary 전환, Mobile P2P screen lifecycle/status 연결을 구현했다.
+- 검증: `pnpm --filter nexvoy-app typecheck`, `pnpm --filter nexvoy-app lint`, `pnpm build:mobile` 통과.
 
 ### TASK-033: Backup Sync Productization
 

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -90,8 +90,8 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-028-rotating-room-secret-hardening.md` | 완료 | server-issued signaling topic, active topic RLS, Web/Mobile adapter 전환 구현, Issue [#312](https://github.com/ysjee141/nexvoy-frontend/issues/312) |
 | `TASK-029-full-local-first-product-scope-adr.md` | 완료 | ADR-013으로 전체 제품 Local-first 범위, `TemplateDocumentV1` boundary, migration/rollback 정책 채택, Issue [#316](https://github.com/ysjee141/nexvoy-frontend/issues/316) |
 | `TASK-030-document-primary-repository-layer.md` | 완료 | Trip/Plan/Checklist/Template/Member document-primary repository contract, mutation writer, TemplateDocumentV1 구현, Issue [#318](https://github.com/ysjee141/nexvoy-frontend/issues/318) |
-| `TASK-031-web-full-document-primary-transition.md` | 계획됨 | Web checklist/plans/templates/collaborators document-primary 전환 |
-| `TASK-032-mobile-full-document-primary-transition.md` | 계획됨 | Mobile checklist/plans/templates/collaborators document-primary 전환 |
+| `TASK-031-web-full-document-primary-transition.md` | 완료 | Web checklist/plans/templates/collaborators document-primary 전환, PR #321 |
+| `TASK-032-mobile-full-document-primary-transition.md` | 완료 | Mobile checklist/plans/templates/collaborators document-primary 전환, Issue #322 |
 | `TASK-033-backup-sync-productization.md` | 계획됨 | 모든 도메인 mutation의 encrypted backup/update sync 제품화 |
 | `TASK-034-p2p-all-domain-wiring.md` | 계획됨 | 모든 도메인 P2P update 전파와 late join/peer discovery 하드닝 |
 | `TASK-035-full-integration-test-suite.md` | 계획됨 | Web/App 전체 기능 통합 테스트 및 실기기 smoke 검증 |
@@ -166,8 +166,8 @@ rotating room secret 보안 하드닝을 완료했다.
 
 - [x] `TASK-029-full-local-first-product-scope-adr.md`: 전체 제품 Local-first 범위와 migration/rollback 정책 확정
 - [x] `TASK-030-document-primary-repository-layer.md`: 모든 핵심 도메인의 공통 document-primary repository 계약 도입
-- [ ] `TASK-031-web-full-document-primary-transition.md`: Web 핵심 기능을 document-primary read/write로 전환
-- [ ] `TASK-032-mobile-full-document-primary-transition.md`: Mobile 핵심 기능을 document-primary read/write로 전환
+- [x] `TASK-031-web-full-document-primary-transition.md`: Web 핵심 기능을 document-primary read/write로 전환
+- [x] `TASK-032-mobile-full-document-primary-transition.md`: Mobile 핵심 기능을 document-primary read/write로 전환
 - [ ] `TASK-033-backup-sync-productization.md`: encrypted backup/update sync를 모든 도메인 mutation에 연결
 - [ ] `TASK-034-p2p-all-domain-wiring.md`: P2P update 전파를 모든 도메인으로 확장하고 late join을 하드닝
 - [ ] `TASK-035-full-integration-test-suite.md`: 전체 제품 통합 테스트와 실기기 smoke 검증

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,43 @@
+# Walkthrough: TASK-032 Mobile Full Document-primary Transition
+
+## Summary
+
+TASK-032는 Mobile의 trip detail, 준비물, 일정, 템플릿, collaborator member snapshot을 document-primary repository 경로로 전환했다. Mobile AsyncStorage 기반 Trip/Template document store를 추가했고, owner/editor 화면에서는 `connectMobileP2PPeer()`를 screen lifecycle과 AppState foreground/background에 연결했다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-032-mobile-full-document-primary-transition.md`
+- GitHub Issue [#322](https://github.com/ysjee141/nexvoy-frontend/issues/322)
+- 브랜치: `feature/task-032-mobile-full-document-primary-transition-322`
+- `apps/mobile/lib/local-first/mobileDocumentStores.ts`
+- `apps/mobile/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/mobile/lib/local-first/documentPrimaryAdapters.ts`
+- `_workspace/01_planner_analysis.md`
+- `_workspace/implementation_plan.md`
+
+## Key Changes
+
+- Mobile AsyncStorage Yjs update 저장소를 `LocalDocumentStore` contract로 감싸 Trip/Template document repository에 주입했다.
+- Trip legacy row bundle과 checklist template rows를 최초 진입 시 document로 hydrate하는 Mobile bridge를 추가했다.
+- Mobile trip detail의 trip/plans/checklist/member read path와 일정/준비물 mutations를 document-primary repository로 전환했다.
+- Mobile template list/create/edit/delete/share management를 Template document repository 경유로 전환했다.
+- collaborator role 변경/revoke 후 Trip document member snapshot을 upsert/revoke하도록 연결했다.
+- trip screen에서 Mobile P2P connection을 자동 시도하고, background cleanup/foreground reconnect 및 상태 표시를 추가했다.
+
+## Verification
+
+- `pnpm --filter nexvoy-app typecheck` 성공
+- `pnpm --filter nexvoy-app lint` 성공
+- `pnpm build:mobile` 성공
+
+## Notes
+
+- 신규 Supabase migration/API Route는 없다.
+- `pnpm build:mobile` 중 `react-native-webrtc`의 `event-target-shim` exports fallback 경고가 출력됐지만 export는 성공했다.
+- Android preview APK 설치/Logcat smoke는 이번 세션에서 실행하지 못했다. TASK-035 full integration/mobile smoke에서 이어서 검증한다.
+
+---
+
 # Walkthrough: TASK-031 Web Full Document-primary Transition
 
 ## Summary


### PR DESCRIPTION
## Summary
- add Mobile AsyncStorage-backed Trip/Template document stores and document-primary repository factory
- switch Mobile trip detail plans/checklists/members and template screens to document-primary repositories
- connect Mobile P2P peer lifecycle/status to the trip screen for owner/editor sessions
- update refactor progress docs and walkthrough

## Verification
- pnpm --filter nexvoy-app typecheck
- pnpm --filter nexvoy-app lint
- pnpm build:mobile

## Notes
- No Supabase migration/API route changes.
- Android preview APK install/Logcat smoke was not run in this session; it remains for TASK-035/full mobile smoke.
- `pnpm build:mobile` emitted the existing react-native-webrtc/event-target-shim exports fallback warning, but export succeeded.

Resolves #322