### PR TITLE
docs: prepare TASK-036 closed beta readiness

### DIFF
--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,230 +1,90 @@
-# 프로덕션 런치 준비 체크리스트
+# Closed Beta Production Readiness
 
-OnVoy를 프로덕션 환경에 배포하기 위해 해야 할 것과 챙겨야 할 것을 정리한 문서.
+## 결론
 
----
+온여정(OnVoy) Closed Beta는 **Web production, Expo/EAS internal distribution, Supabase Local-first backend, monitoring, legal, rollback**이 모두 준비된 뒤 시작한다. 이 문서는 실제 배포 실행서가 아니라 go/no-go 판단 기준이다. 값이 들어간 secret은 문서에 기록하지 않고 `docs/runbooks/secret-inventory.md`의 위치/소유자 기준으로만 관리한다.
 
-## 현재 상태 요약
+## Go/No-Go Gate
 
-| 영역 | 상태 | 비고 |
-|------|------|------|
-| 인프라 (Supabase, Vercel) | ✅ 완비 | 운영 인스턴스 존재 |
-| CI/CD 파이프라인 | ✅ 완비 | E2E 자동화, OTA 배포 |
-| 데이터 보안 (RLS) | ✅ 완비 | 전 테이블 적용 |
-| 모니터링 (Sentry, GA) | ✅ 완비 | 운영 환경 조건부 활성화 |
-| 모바일 앱 (Capacitor) | ⚠️ 서명 미완료 | 스토어 배포 불가 |
-| API 보안 | ⚠️ Rate limiting 미구현 | |
-| 테스트 커버리지 | ⚠️ E2E 부분, 단위 0% | |
-| 배포/운영 문서 | ⚠️ 부재 | |
+| Gate | Go 기준 | Evidence |
+| --- | --- | --- |
+| Product path | document-primary Web/Mobile smoke PASS | `docs/qa/local-first-integration-runbook.md` 결과 표 |
+| Web | Vercel Preview와 Production env가 일치하고 `pnpm build` PASS | PR/배포 로그 |
+| Mobile | Android Internal Testing 또는 iOS TestFlight 설치 smoke PASS | EAS build URL, 기기/OS 기록 |
+| Supabase | migration list 확인, RLS/RPC smoke PASS, 배포 전 backup snapshot 생성 | Supabase dashboard/export 기록 |
+| Monitoring | Sentry/GA/Firebase/Discord/Supabase/Vercel alert test PASS | alert test 로그 |
+| Legal | 약관/개인정보 처리방침 URL, store privacy label 초안 준비 | URL, store console draft |
+| Rollback | Web/Mobile/Supabase/Local-first rollback owner와 절차 확인 | `docs/runbooks/deployment-rollback.md` |
 
----
+## Required Verification
 
-## 1. 보안 — 배포 전 필수
+| 명령/절차 | 목적 |
+| --- | --- |
+| `pnpm --filter @nexvoy/core test` | Local-first, sync, permission 순수 로직 |
+| `pnpm typecheck` | shared packages + mobile 타입 정합성 |
+| `pnpm build` | Vercel production build |
+| `pnpm build:mobile` | Expo export/Metro bundle 정합성 |
+| `pnpm --filter nexvoy-web test:e2e -- observability-safety.spec.ts` | 관측 payload 안전성 |
+| `pnpm --filter nexvoy-web test:e2e -- local-first-product.spec.ts` | 로컬 Supabase 기반 Web 권한/reload E2E |
+| `docs/qa/local-first-integration-runbook.md` | Web/Web, Web/Mobile, Mobile/Mobile, backup restore, offline reconnect |
 
-### 1-1. 환경변수 관리
+## Web/Vercel Checklist
 
-- [ ] **`.env.local`이 `.gitignore`에 포함되어 있는지 확인** — 실제 API 키가 포함되어 있음
-- [ ] **`.env.example` 또는 `.env.local.example` 파일 생성** — 필요한 변수 목록 문서화, 값은 더미로
-- [ ] **CI/CD 시크릿 검토** — 현재 GitHub Actions에서 사용 중인 시크릿:
-  - `E2E_SUPABASE_SERVICE_ROLE_KEY` — E2E 테스트용
-  - `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` — OTA 배포용
-  - 운영 배포 워크플로우 추가 시 `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`, `KAKAO_CLIENT_SECRET`, `RESEND_API_KEY`, `DISCORD_WEBHOOK_URL`, `NEXT_PUBLIC_SENTRY_DSN` 시크릿 등록 필요
-- [ ] **Google Maps API 키 제한 설정** — Google Cloud Console에서 허용 도메인/앱 제한 적용
-- [ ] **Kakao OAuth 리다이렉트 URI 검토** — 운영 도메인만 허용하는지 확인
+| 항목 | 기준 |
+| --- | --- |
+| Build | `vercel.json`의 `pnpm --filter nexvoy-web build`, output `apps/web/.next` 유지 |
+| Env | `NEXT_PUBLIC_APP_URL`, Supabase, Kakao, Google Maps, GA/Sentry, Resend, Discord 설정 |
+| Domain | production domain SSL, Kakao OAuth redirect, Supabase Auth redirect URL 일치 |
+| Preview | PR preview에서 login, trip create, invite, document-primary smoke 확인 |
+| API hardening | `/api/invite`, `/api/feedback`, `/api/places/photo/store` rate limiting은 Closed Beta risk item으로 추적 |
 
-### 1-2. API Routes 보안
+## Mobile/EAS Checklist
 
-- [ ] **Rate Limiting 적용** — 다음 API에 우선 적용:
-  - `/api/invite` — 초대 링크 생성 (어뷰징 가능)
-  - `/api/feedback` — 피드백 제출
-  - `/api/places/photo/store` — 사진 저장
-  - Vercel의 `@upstash/ratelimit` 또는 Supabase Edge Function 활용 권장
-- [ ] **모든 API Route에 세션 검증 확인** — 인증 없이 접근 가능한 엔드포인트가 없는지 확인
-- [ ] **요청 입력 검증 강화** — request body, query parameter에 대해 zod 등으로 스키마 검증 추가
+| 항목 | 기준 |
+| --- | --- |
+| App identity | `apps/mobile/app.json` name `온여정`, scheme `onvoy`, id `xyz.nexvoy.app` |
+| Build profiles | `apps/mobile/eas.json`의 `development`, `preview`, `production` 사용 |
+| Android | Play Console Internal Testing draft, package `xyz.nexvoy.app`, permission disclosure 작성 |
+| iOS | TestFlight draft, bundle id `xyz.nexvoy.app`, background processing/privacy disclosure 작성 |
+| Firebase | `google-services.json`/`GoogleService-Info.plist`는 local secret 파일로만 관리 |
+| Maps | `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY`가 app config에 주입되는지 EAS build log에서 확인 |
 
-### 1-3. Supabase 보안
+## Supabase Checklist
 
-- [ ] **RLS 정책 운영 환경에서 재검증** — 로컬과 동일한 마이그레이션이 적용되어 있는지 확인
-- [ ] **`anon` role 권한 최소화** — anon key로 접근 가능한 데이터 범위 검토
-- [ ] **Service Role Key 노출 확인** — 서버사이드 코드 이외에서 사용되지 않는지 grep 확인
-  ```bash
-  rg "SUPABASE_SERVICE_ROLE_KEY" apps packages supabase
-  ```
-- [ ] **Supabase Auth 설정 확인** — 운영 환경 OAuth 리다이렉트 URL 등록
+| 항목 | 기준 |
+| --- | --- |
+| Migration inventory | `supabase/migrations/` 적용 목록과 운영 DB 목록 비교 |
+| Legacy patch SQL | migration 밖 `supabase/fix_*.sql`, `consolidated_patch.sql` 적용 여부 별도 기록 |
+| Backup | 운영 migration 전 Supabase backup snapshot 생성 |
+| RLS/RPC smoke | document registry, members, keys, backup updates, signaling topic RPC 검증 |
+| Edge Functions | `handle-kakao-oauth`, `ice-servers`, push/notification functions secret 설정 |
 
----
+## Monitoring & Incident Readiness
 
-## 2. 인프라 및 배포
+| 채널 | 확인 |
+| --- | --- |
+| Sentry | Web/Mobile DSN, release/environment tag, critical alert route |
+| GA4/Firebase | beta funnel, app open, auth, trip create, invite/share, local-first events |
+| Discord | `/api/feedback` webhook delivery test |
+| Supabase | DB CPU, connection count, auth error, storage usage 확인 |
+| Vercel/EAS | deploy/build failure notification 수신자 지정 |
 
-### 2-1. 웹 배포 (Vercel)
+## Legal & Store Readiness
 
-- [ ] **도메인 설정** — 운영 도메인 연결 및 SSL 인증서 확인
-- [ ] **환경변수 설정** — Vercel Dashboard에 모든 운영 환경변수 등록
-  - `NEXT_PUBLIC_APP_ENV=production`
-  - `NEXT_PUBLIC_APP_URL=https://app.nexvoy.xyz`
-  - `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-  - `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`
-  - `NEXT_PUBLIC_KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`
-  - `NEXT_PUBLIC_SENTRY_DSN`
-  - `RESEND_API_KEY`
-  - `DISCORD_WEBHOOK_URL`
-- [ ] **`pnpm build` 성공 확인** — 로컬에서 프로덕션 빌드 에러 없음 검증
-- [ ] **Vercel Preview 배포로 최종 확인** — PR 단계 preview URL에서 주요 기능 테스트
+| 항목 | 기준 |
+| --- | --- |
+| Terms/Privacy | `ONVOY_TERMS_DOCUMENT`이 Web/Mobile signup/profile에서 접근 가능 |
+| Public URL | store console에 넣을 약관/개인정보 URL 준비 |
+| Data safety | Auth email, nickname, trip content, analytics, crash logs, push token, photos 수집 여부 정리 |
+| Age rating | 만 14세 미만 이용 제한 정책 결정 |
+| Third parties | Supabase, Vercel, Google, Firebase, Sentry, Resend, Discord 위탁/제3자 항목 확인 |
 
-### 2-2. 데이터베이스 마이그레이션
+## Release Decision
 
-- [ ] **운영 Supabase에 마이그레이션 적용 확인**
-  ```bash
-  supabase db push --linked  # 또는 supabase migration list로 현황 확인
-  ```
-- [ ] **`supabase/` 하위의 패치 SQL 파일 적용 여부 추적** — `fix_*.sql`, `consolidated_patch.sql` 등이 운영 DB에 적용되었는지 별도 기록 관리 필요 (현재 마이그레이션 파일로 관리되지 않고 있음)
-- [ ] **마이그레이션 전/후 DB 스냅샷** — 첫 운영 배포 전 백업 스냅샷 생성
-- [ ] **`place_photos` 버킷 생성 확인** — `20260527000002_place_photos_bucket.sql` 적용 여부
+Closed Beta를 시작하려면 다음을 모두 만족해야 한다.
 
-### 2-3. Supabase Storage
-
-- [ ] **`place-photos` 버킷 접근 정책 확인** — 인증된 사용자만 업로드, 공개 읽기 여부 결정
-- [ ] **Storage 용량 플랜 확인** — 무료 플랜 한도(1GB) 대비 예상 사용량 검토
-
----
-
-## 3. 모바일 앱 배포
-
-### 3-1. 공통
-
-- [ ] **앱 버전 확정** — `apps/mobile/package.json` 및 `apps/mobile/app.json`의 `version` 확인
-- [ ] **번들 ID 확정** — 현재: `xyz.nexvoy.app` — 스토어 등록 후 변경 불가
-- [ ] **Expo/RN 검증 성공 확인** — `pnpm --filter nexvoy-app lint`, `pnpm --filter nexvoy-app typecheck`, `pnpm --filter nexvoy-app build`
-- [ ] **Expo 설정 최종 확인** (`apps/mobile/app.json`)
-  - `ios.bundleIdentifier`, `android.package` 확인
-  - EAS build profile 및 앱 스토어 제출 전략 확인
-
-### 3-2. Android
-
-- [ ] **코드 서명 키스토어 생성** — `keytool`로 release keystore 생성 및 안전한 곳에 보관
-- [ ] **`build.gradle` release 서명 설정** — keystore 경로 및 비밀번호 설정 (환경변수로 주입)
-- [ ] **`minSdkVersion`/`targetSdkVersion` 확인** — 현재 Play Store 정책 충족 여부 (targetSdk ≥ 35)
-- [ ] **릴리즈 APK/AAB 빌드 및 테스트** — `./gradlew bundleRelease`
-- [ ] **Google Play Console 앱 등록** — 메타데이터, 스크린샷, 개인정보처리방침 URL 준비
-- [ ] **내부 테스트 트랙 배포** — 팀원 계정으로 최종 기능 검증
-
-### 3-3. iOS
-
-- [ ] **Apple Developer 계정 등록** — 연 $99, 법인/개인 결정
-- [ ] **Bundle ID 등록** (App Store Connect)
-- [ ] **코드 서명 프로비저닝 프로파일 생성** — Distribution certificate + App Store provision
-- [ ] **Xcode Build Settings 설정** — Team ID, Code Signing Identity
-- [ ] **TestFlight 배포** — 내부 테스터 최종 검증
-- [ ] **App Store Connect 메타데이터** — 앱 설명, 스크린샷, 카테고리, 연령 등급
-
----
-
-## 4. 품질 및 테스트
-
-### 4-1. E2E 테스트 커버리지 보완
-
-현재 테스트가 없는 핵심 시나리오:
-
-- [ ] **체크리스트 CRUD** — 항목 추가/수정/삭제, 완료 토글
-- [ ] **여행 공유 플로우** — 초대 링크 생성 → 수락 → 공유 멤버 접근
-- [ ] **오프라인 모드** — 네트워크 차단 후 캐시된 데이터 표시 확인
-- [ ] **OTA 업데이트 흐름** — 업데이트 감지 및 적용 (모바일 시뮬레이터)
-- [ ] **OAuth 로그인** — 실제 카카오/구글 OAuth 흐름 (현재 mock 처리)
-
-### 4-2. 수동 검증 체크리스트
-
-배포 전 실제 기기/브라우저에서 확인:
-
-- [ ] 카카오 OAuth 로그인/로그아웃
-- [ ] 구글 OAuth 로그인/로그아웃
-- [ ] 여행 생성 → 플랜 추가 → 체크리스트 추가 전체 플로우
-- [ ] 여행 공유 (초대 링크 전송 → 다른 계정으로 수락)
-- [ ] 이미지 업로드 (장소 사진)
-- [ ] 오프라인 상태에서 기존 데이터 열람
-- [ ] 네트워크 복구 후 자동 동기화
-- [ ] Android 기기에서 앱 설치 및 실행
-- [ ] iOS 기기에서 앱 설치 및 실행 (TestFlight)
-- [ ] 푸시 알림 수신 (테스트 알림 발송)
-
-### 4-3. 성능
-
-- [ ] **웹 Lighthouse 점수** — Performance 90+, Accessibility 90+ 목표
-- [ ] **번들 크기 확인** — `pnpm build` 후 빌드 아웃풋 분석 (`@next/bundle-analyzer` 활용)
-- [ ] **초기 로드 시간** — 3G 환경 기준 FCP 3초 이하 목표
-- [ ] **Supabase 쿼리 성능** — N+1 문제 없는지 Supabase Dashboard에서 Slow Queries 확인
-
----
-
-## 5. 모니터링 및 운영
-
-### 5-1. 모니터링 설정 확인
-
-- [ ] **Sentry 프로젝트 설정** — 운영 환경용 DSN, 알림 임계값 설정
-  - 에러 발생 시 담당자 알림 설정
-  - 샘플 레이트 10% → 초기 운영 시 25%로 올렸다가 안정화 후 조정
-- [ ] **Google Analytics** — 주요 이벤트 추적 설정 (여행 생성, 공유, 체크리스트 완료 등)
-- [ ] **Discord Webhook** — 피드백 채널 연결 확인
-
-### 5-2. 알림 및 대응 계획
-
-- [ ] **Sentry 에러 알림 채널 지정** — Slack 또는 이메일로 critical 에러 즉시 수신
-- [ ] **Supabase 모니터링** — Database CPU, 연결 수, Storage 사용량 알림 설정
-- [ ] **Vercel 배포 알림** — 배포 실패 시 알림 설정
-
-### 5-3. 운영 문서 작성
-
-- [ ] **배포 절차서** — 웹 배포, 모바일 OTA 배포, 네이티브 앱 스토어 배포 각각 절차 문서화
-- [ ] **롤백 가이드** — 배포 후 문제 발생 시 롤백 방법 (Vercel 이전 배포로 되돌리기, OTA 이전 버전 지정)
-- [ ] **트러블슈팅 가이드** — 자주 발생하는 이슈와 해결책 (Supabase 연결 실패, OAuth 에러 등)
-- [ ] **DB 마이그레이션 관리 정책** — `supabase/` 패치 파일들의 관리 방식 명확화 (현재 산발적으로 존재)
-
----
-
-## 6. 법적 요건
-
-- [ ] **개인정보처리방침 페이지** — 수집 항목, 목적, 보유 기간, 제3자 제공 명시
-  - 카카오/구글 OAuth 사용 시 OAuth 제공자 약관 준수 필요
-  - Sentry에 PII 수집 사실 명시
-- [ ] **서비스 이용약관** — 스토어 등록 시 필수
-- [ ] **앱 스토어 개인정보 관련 항목 작성**
-  - Google Play: 데이터 수집 설문
-  - App Store: 개인정보 처리 레이블 (Privacy Nutrition Label)
-- [ ] **만 14세 미만 이용 제한 여부 결정** — 정보통신망법 준수
-
----
-
-## 7. 우선순위 로드맵
-
-### 즉시 (지금)
-
-1. `.env.local` `.gitignore` 포함 여부 재확인, `.env.local.example` 작성
-2. API Rate Limiting 추가 (`/api/invite`, `/api/feedback`)
-3. 운영 Supabase DB 마이그레이션 현황 추적 문서 작성
-
-### 1주 이내
-
-4. Vercel 운영 환경변수 전체 등록 및 `pnpm build` 성공 확인
-5. E2E 테스트 체크리스트/공유 시나리오 추가
-6. 수동 검증 체크리스트 전항목 통과
-7. Sentry 알림 채널 설정
-
-### 2-3주 이내
-
-8. Google Maps, Kakao API 키 도메인 제한 설정
-9. 개인정보처리방침 / 이용약관 페이지 작성
-10. Android 서명 키스토어 생성 및 내부 테스트 APK 배포
-11. iOS TestFlight 배포
-
-### 스토어 출시 전
-
-12. Google Play Console / App Store Connect 앱 등록
-13. 스토어 검수 → 출시 승인
-
----
-
-## 참고
-
-- Supabase 운영 보안 가이드: https://supabase.com/docs/guides/platform/going-into-prod
-- Next.js 배포 체크리스트: https://nextjs.org/docs/app/building-your-application/deploying
-- Expo EAS Build: https://docs.expo.dev/build/introduction/
-- Expo EAS Submit: https://docs.expo.dev/submit/introduction/
+1. 이 문서의 Go/No-Go Gate가 모두 Go다.
+2. `docs/runbooks/closed-beta-runbook.md`의 daily operation owner가 지정됐다.
+3. `docs/runbooks/deployment-rollback.md`의 rollback owner와 연락 경로가 지정됐다.
+4. unresolved Critical/Major bug가 없다.
+5. unresolved legal/store blocker가 없다.

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -330,12 +330,12 @@
 
 범위:
 
-- 운영 migration
-- production readiness 문서 갱신
-- EAS/TestFlight/Play Internal Testing
-- monitoring/alerting
-- privacy/terms
-- beta runbook
+- `docs/production-readiness.md` Closed Beta go/no-go gate 갱신
+- `docs/runbooks/secret-inventory.md` 추가
+- `docs/runbooks/deployment-rollback.md` 추가
+- `docs/runbooks/closed-beta-runbook.md` 추가
+- Expo/EAS, Vercel, Supabase, monitoring, legal/store, Local-first rollback 기준 정리
+- Issue #330
 
 ## 5. 통합테스트 전략
 

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -97,7 +97,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-033-backup-sync-productization.md` | 완료 | Web/Mobile document-primary mutation encrypted backup update queue/upload 제품화, Issue #324, PR #325 |
 | `TASK-034-p2p-all-domain-wiring.md` | 완료 | Trip document-level P2P lifecycle 승격, Web/Mobile reconnect/status 하드닝, Issue #326, PR #327 |
 | `TASK-035-full-integration-test-suite.md` | 완료 | Web document-primary 권한/reload E2E, observability safety E2E, Mobile/P2P/backup smoke runbook, Issue #328, PR #329 |
-| `TASK-036-closed-beta-readiness.md` | 계획됨 | 완성 제품 기준 Closed Beta 출시 준비 |
+| `TASK-036-closed-beta-readiness.md` | 완료 | Closed Beta go/no-go gate, secret inventory, deployment rollback, tester 운영 runbook, Issue #330, PR #331 |
 
 현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `Phase 3`의 모바일 WebRTC native feasibility와 Cloudflare ICE config 발급 경로는 provider boundary, Edge Function, 검증 보고서로 정리했다. `Phase 4`의 dual-write 및 mismatch detector와 guest auth promotion은 Web-first 범위로 구현했다. `TASK-013`에서 초대/권한 registry, invite/share RPC, Web/Mobile join fallback을 구현했고, `TASK-014`에서 notification metadata, local notification scheduler, observability event boundary를 구현했다. `TASK-015`에서 owner/editor Web foreground document key provisioning과 pending/status UX를 구현했다. `TASK-016`은 Mobile Native Key Provisioning MVP를 구현하고 accepted scope 기준 검증했다. `TASK-017`은 Mobile background task 기반 provisioning retry path를 구현하고 Android-first 검증 범위에서 PASS를 받았다. `TASK-018`은 Android Keystore/iOS Keychain 기반 non-exportable key storage hardening을 구현하고 native preview build와 SQL smoke까지 검증했다. `TASK-019`는 Mobile-first owner bootstrap 후속 문서다. `TASK-020`은 `restore.ts`의 Yjs 비의존 부분(snapshot 복호화·hash 검증)을 `backupPayloadCodec.ts`/`mobileRestore.ts`로 분리해 Mobile 전용 encrypted snapshot restore 경로(`restoreMobileEncryptedSnapshot`)를 구현하고, `TASK-019`의 owner bootstrap 성공/provisioning completion 트리거에 재시도를 연결했다. updates replay(Web/Yjs 기반 최신 콘텐츠 반영)는 이번 범위에서 제외했다. `TASK-021`은 `ADR-004`가 유보했던 시그널링 전송 계층을 `ADR-012`(Supabase Realtime Broadcast)로 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 배선해 P2P fast path의 최초 연결을 증명했다. `TASK-022`는 일반 Web 로그인 trip이 `documents`/`document_members`에 등록되지 않던 선결 문제를 lazy bootstrap으로 해소했다. `TASK-023`은 같은 signaling 프로토콜과 room topic 파생 규칙을 Mobile까지 확장하고 native data-channel handshake/조립 지점을 추가했다. `TASK-024`는 Web-to-Web 범위에서 data channel로 Yjs update를 청킹/전송/재조립하고 IndexedDB 문서에 적용하는 fast path를 구현했다. `TASK-027`은 Mobile Yjs runtime adapter와 `react-native-quick-crypto` 기반 Metro shim을 추가해 Mobile도 같은 Yjs update format을 apply할 수 있게 했다. `TASK-029`부터는 checklist pilot을 넘어 Web/App 전체 제품 기능을 document-primary로 전환하고, 그 이후 통합 테스트와 Closed Beta 준비를 진행한다.
 
@@ -173,7 +173,7 @@ rotating room secret 보안 하드닝을 완료했다.
 - [x] `TASK-033-backup-sync-productization.md`: encrypted backup/update sync를 모든 도메인 mutation에 연결
 - [x] `TASK-034-p2p-all-domain-wiring.md`: P2P update 전파를 모든 도메인으로 확장하고 late join을 하드닝
 - [x] `TASK-035-full-integration-test-suite.md`: 전체 제품 통합 테스트와 실기기 smoke 검증
-- [ ] `TASK-036-closed-beta-readiness.md`: 완성 제품 기준 Closed Beta 출시 준비
+- [x] `TASK-036-closed-beta-readiness.md`: 완성 제품 기준 Closed Beta 출시 준비
 
 ## 권장 시작 순서
 

--- a/docs/refactor/tasks/TASK-036-closed-beta-readiness.md
+++ b/docs/refactor/tasks/TASK-036-closed-beta-readiness.md
@@ -38,14 +38,24 @@
 
 ## 구현 단계
 
-1. production readiness 문서를 Expo RN/EAS 기준으로 갱신한다.
-2. 운영 Supabase migration list와 RLS smoke 결과를 기록한다.
-3. Vercel env/preview/production 배포 checklist를 확정한다.
-4. Android internal testing build와 iOS TestFlight checklist를 작성한다.
-5. Sentry/GA/Discord/Supabase/Vercel alerting을 점검한다.
-6. 개인정보처리방침/이용약관/스토어 privacy label을 준비한다.
-7. Closed Beta tester 초대/피드백/incident 대응 runbook을 작성한다.
-8. P2P/backup/document-primary kill switch와 rollback 절차를 검증한다.
+1. production readiness 문서를 Expo RN/EAS 기준으로 갱신한다. ✅
+2. 운영 Supabase migration list와 RLS smoke 결과 기록 위치를 확정한다. ✅
+3. Vercel env/preview/production 배포 checklist를 확정한다. ✅
+4. Android internal testing build와 iOS TestFlight checklist를 작성한다. ✅
+5. Sentry/GA/Discord/Supabase/Vercel alerting 점검표를 작성한다. ✅
+6. 개인정보처리방침/이용약관/스토어 privacy label 준비 항목을 정리한다. ✅
+7. Closed Beta tester 초대/피드백/incident 대응 runbook을 작성한다. ✅
+8. P2P/backup/document-primary kill switch와 rollback 절차를 문서화한다. ✅
+
+## 구현 결과
+
+| 항목 | 결과 |
+| --- | --- |
+| Production readiness | `docs/production-readiness.md`를 Closed Beta go/no-go gate 기준으로 갱신 |
+| Secret inventory | `docs/runbooks/secret-inventory.md`에 Web/Mobile/Supabase secret 위치와 rotation trigger 정리 |
+| Rollback | `docs/runbooks/deployment-rollback.md`에 Vercel/EAS/Supabase/Local-first rollback matrix 작성 |
+| Beta 운영 | `docs/runbooks/closed-beta-runbook.md`에 tester onboarding, daily smoke, feedback triage, incident/data request 절차 작성 |
+| Issue | [#330](https://github.com/ysjee141/nexvoy-frontend/issues/330) |
 
 ## 데이터 호환성 고려사항
 
@@ -55,11 +65,11 @@
 
 ## 검증 방법
 
-- full integration suite PASS.
-- Android internal test install/pass.
-- iOS TestFlight smoke pass.
-- production Supabase RLS/RPC smoke pass.
-- monitoring alert test pass.
+- full integration suite PASS 또는 미실행 사유 기록.
+- Android internal test install/pass 결과 기록.
+- iOS TestFlight smoke pass 결과 기록.
+- production Supabase RLS/RPC smoke 결과 기록.
+- monitoring alert test 결과 기록.
 - privacy/terms URL 공개 확인.
 
 ## 롤백 방법

--- a/docs/runbooks/closed-beta-runbook.md
+++ b/docs/runbooks/closed-beta-runbook.md
@@ -1,0 +1,77 @@
+# Closed Beta Runbook
+
+## 결론
+
+Closed Beta는 제한된 테스터에게 Local-first document-primary 제품을 노출하고, 동기화/복구/권한/알림 안정성을 매일 확인하는 운영 단계다. 기능 미완성 검증이 아니라 출시 전 운영 리허설로 취급한다.
+
+## Roles
+
+| 역할 | 책임 |
+| --- | --- |
+| Release owner | go/no-go 판단, deploy 승인, rollback 승인 |
+| QA owner | daily smoke, device matrix, regression 기록 |
+| Support owner | tester 초대, 피드백 triage, 삭제 요청 응답 |
+| Incident owner | SEV 판단, timeline 기록, 후속 task 생성 |
+
+## Tester Onboarding
+
+| 단계 | 조치 |
+| --- | --- |
+| 1 | 테스터 이메일/기기/OS/플랫폼(Web/Android/iOS)을 기록 |
+| 2 | 개인정보/피드백 수집 범위와 beta 제한 사항 안내 |
+| 3 | Web URL 또는 Play Internal Testing/TestFlight 초대 발송 |
+| 4 | 첫 로그인, trip 생성, invite accept, backup restore smoke 요청 |
+| 5 | 피드백 채널과 incident contact 공유 |
+
+## Daily Smoke
+
+| 시나리오 | 기준 |
+| --- | --- |
+| Auth | email/social login, logout, account switch |
+| Trip | create, open, edit destination/date, delete/withdraw if available |
+| Plans | add/edit/delete/toggle visited, location/photo fallback |
+| Checklist | add/edit/delete/check, assignment/template apply |
+| Collaboration | owner invites editor/viewer, accept, permission boundary |
+| Local-first | offline edit, reconnect, reload, cross-device restore |
+| P2P | Web/Web and Web/Mobile fast path or backup fallback |
+| Notifications | local reminder/push metadata path smoke |
+| Feedback | `/api/feedback` Discord delivery |
+
+TASK-035의 상세 cross-device 절차는 `docs/qa/local-first-integration-runbook.md`를 따른다.
+
+## Feedback Triage
+
+| 등급 | 기준 | 처리 |
+| --- | --- | --- |
+| Critical | 데이터 손실, 권한 우회, 앱 실행 불가 | incident 생성, rollout 중단 판단 |
+| Major | 주요 여정/준비물/초대/동기화 실패 | 24시간 내 fix/rollback 판단 |
+| Minor | UI 불편, 문구, 비핵심 알림 | backlog |
+| Question | 사용법/기대 동작 문의 | FAQ 또는 onboarding 보강 |
+
+## Data & Privacy Requests
+
+| 요청 | 처리 기준 |
+| --- | --- |
+| 계정 삭제 | 본인 확인 후 Supabase Auth/profile/trip ownership/local backup 영향 확인 |
+| trip 삭제 | owner 요청인지 확인하고 shared member 영향 안내 |
+| feedback 삭제 | Discord 첨부/메시지 삭제 가능 여부 확인 |
+| 데이터 export | Closed Beta에서는 수동 지원 여부를 release owner가 결정 |
+
+## Communication Template
+
+| 상황 | 메시지 요지 |
+| --- | --- |
+| 초대 | beta 목적, 설치 링크, 피드백 채널, 알려진 제한 |
+| 장애 | 영향 범위, 임시 우회, 다음 업데이트 예상 시간 |
+| 복구 | 원인 요약, 사용자 조치 필요 여부, 재발 방지 |
+| 종료 | beta 기간 종료, 데이터 보존/삭제 정책, 다음 단계 |
+
+## Exit Criteria
+
+Closed Beta를 종료하고 다음 단계로 넘어가려면 다음을 만족한다.
+
+1. 7일 이상 SEV1 없음.
+2. 핵심 smoke 시나리오 3회 연속 PASS.
+3. 신규 Major issue가 triage SLA 안에서 처리됨.
+4. store privacy/legal blocker 없음.
+5. rollback runbook이 실제 incident drill 또는 tabletop review를 통과함.

--- a/docs/runbooks/deployment-rollback.md
+++ b/docs/runbooks/deployment-rollback.md
@@ -1,0 +1,73 @@
+# Deployment & Rollback Runbook
+
+## 결론
+
+Closed Beta rollback은 먼저 **사용자 데이터 손실을 막는 방향**으로 판단한다. Web/Mobile UI rollback보다 Supabase migration rollback이 더 위험하므로, DB는 forward-fix 또는 feature disable을 우선한다.
+
+## Release Order
+
+```mermaid
+flowchart TD
+  A[Run required verification] --> B[Supabase backup snapshot]
+  B --> C[Supabase migration/Edge Function deploy]
+  C --> D[Vercel Preview smoke]
+  D --> E[Vercel Production deploy]
+  E --> F[EAS preview/internal build]
+  F --> G[Closed Beta tester rollout]
+```
+
+## Web Rollback
+
+| 상황 | 조치 |
+| --- | --- |
+| Vercel deploy failure | 이전 successful deployment로 rollback |
+| auth/share callback regression | `NEXT_PUBLIC_APP_URL`, Supabase Auth redirect, Kakao redirect를 먼저 확인 |
+| document-primary Web regression | `NEXT_PUBLIC_WEB_DOCUMENT_PRIMARY=0` 또는 query/localStorage `documentPrimary=0`로 legacy fallback 검증 |
+| feedback/invite abuse | endpoint 임시 차단 또는 env secret rotation 후 rate limiting task 우선 처리 |
+
+## Mobile Rollback
+
+| 상황 | 조치 |
+| --- | --- |
+| EAS build install failure | 이전 preview/internal build로 tester 재배포 |
+| OTA-capable JS regression | EAS Update channel을 이전 runtime-compatible update로 rollback |
+| native module regression | 새 native build를 중단하고 이전 store/internal build 유지 |
+| key provisioning failure | `EXPO_PUBLIC_ONVOY_ENABLE_LEGACY_SECURESTORE_KEY_MATERIAL_FALLBACK`는 incident owner 승인 후 임시 활성화 |
+
+## Supabase Rollback
+
+| 상황 | 우선 조치 |
+| --- | --- |
+| migration apply failure | 즉시 중단, backup snapshot 보존, failed migration 로그 첨부 |
+| RLS blocks legitimate access | narrow forward-fix migration 작성 후 RLS smoke |
+| RLS allows excessive access | affected policy disable/fix migration, service role audit, incident 기록 |
+| Edge Function regression | 이전 function bundle redeploy 또는 function secret/config rollback |
+| data corruption suspicion | writes stop, backup snapshot 복구 가능성 평가, 사용자 공지 여부 결정 |
+
+## Local-first Kill Switch Matrix
+
+| 경로 | Disable 방법 | 영향 |
+| --- | --- | --- |
+| Web document-primary | `NEXT_PUBLIC_WEB_DOCUMENT_PRIMARY=0`, URL `?documentPrimary=0` | Web repository가 legacy Supabase fallback으로 전환 |
+| Web checklist spike/dual-write | `NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_SPIKE=0`, `NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_DUAL_WRITE=0` | 이전 checklist fallback 검증 |
+| P2P fast path | Cloudflare TURN secret 제거/ICE failure 허용 또는 client rollout 중단 | local write와 backup sync는 계속 유지되어야 함 |
+| Mobile legacy key fallback | `EXPO_PUBLIC_ONVOY_ENABLE_LEGACY_SECURESTORE_KEY_MATERIAL_FALLBACK=false` | native key path만 사용 |
+| Backup sync | 신규 배포 중단, backup RPC/RLS forward-fix | 데이터 복구 기준 경로이므로 disable보다 forward-fix 우선 |
+
+## Incident Severity
+
+| Severity | 예시 | 목표 |
+| --- | --- | --- |
+| SEV1 | 데이터 손실, 권한 우회, secret 노출 | 즉시 rollout 중단, 1시간 내 사용자 영향 판단 |
+| SEV2 | 로그인/동기화 주요 기능 장애 | 당일 rollback 또는 forward-fix |
+| SEV3 | 일부 UI/알림/분석 문제 | 다음 beta build 또는 patch |
+
+## Required Incident Record
+
+| 항목 | 내용 |
+| --- | --- |
+| 시간 | 감지/대응/복구 시각 |
+| 영향 | 플랫폼, 사용자 수, 데이터 범위 |
+| 원인 | deploy, migration, env, vendor, app bug |
+| 조치 | rollback, forward-fix, secret rotation, user notice |
+| 후속 | test/runbook/code 보강 task |

--- a/docs/runbooks/secret-inventory.md
+++ b/docs/runbooks/secret-inventory.md
@@ -1,0 +1,60 @@
+# Secret Inventory
+
+## 결론
+
+이 문서는 secret **값을 기록하지 않는다**. Closed Beta 운영자는 각 secret의 이름, 설정 위치, 사용처, rotation trigger만 관리한다. 실제 값은 Vercel, EAS, Supabase, Google/Firebase/Kakao/Discord/Resend console에만 둔다.
+
+## Web Runtime
+
+| 이름 | 위치 | 사용처 | Rotation trigger |
+| --- | --- | --- | --- |
+| `NEXT_PUBLIC_APP_URL` | Vercel env | Web callback/share URL | domain 변경 |
+| `NEXT_PUBLIC_SUPABASE_URL` | Vercel env | Supabase client/Edge Function URL | Supabase project 변경 |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Vercel env | Browser Supabase client | Supabase key rotation |
+| `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` | Vercel env | Places/Maps UI and API routes | Google key 노출 또는 제한 변경 |
+| `NEXT_PUBLIC_KAKAO_CLIENT_ID` | Vercel env | Kakao OAuth start | Kakao app 변경 |
+| `NEXT_PUBLIC_GA_ID` | Vercel env | GA4 tracking | GA property 변경 |
+| `NEXT_PUBLIC_SENTRY_DSN` | Vercel env | Web error reporting | Sentry project 변경 |
+
+## Web Server/API
+
+| 이름 | 위치 | 사용처 | Rotation trigger |
+| --- | --- | --- | --- |
+| `SUPABASE_SERVICE_ROLE_KEY` | Vercel env, Supabase Functions | server-only privileged operations | 노출 의심, team member offboarding |
+| `KAKAO_CLIENT_SECRET` | Vercel env/Supabase Function secret | Kakao OAuth token exchange | Kakao secret rotation |
+| `RESEND_API_KEY` | Vercel env | `/api/invite` email delivery | Resend key rotation |
+| `DISCORD_WEBHOOK_URL` | Vercel env | `/api/feedback` delivery | channel 변경 또는 URL 노출 |
+| `GOOGLE_PLACES_API_KEY` | Vercel env optional | Places photo server API | Google key 노출 또는 quota abuse |
+
+## Mobile/EAS
+
+| 이름 | 위치 | 사용처 | Rotation trigger |
+| --- | --- | --- | --- |
+| `EXPO_PUBLIC_SUPABASE_URL` | EAS env | Mobile Supabase client | Supabase project 변경 |
+| `EXPO_PUBLIC_SUPABASE_ANON_KEY` | EAS env | Mobile Supabase client | Supabase key rotation |
+| `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY` | EAS env | `app.config.js` native Maps config | Google key 노출 또는 restriction 변경 |
+| `EXPO_PUBLIC_GOOGLE_PLACES_API_KEY` | EAS env optional | Mobile place search | Google key split/rotation |
+| `EXPO_PUBLIC_APP_URL` | EAS env | Web callback/share fallback | domain 변경 |
+| `EXPO_PUBLIC_WEB_API_URL` | EAS env | Mobile share/feedback Web API base | API domain 변경 |
+| `EXPO_PUBLIC_ONVOY_ENABLE_LEGACY_SECURESTORE_KEY_MATERIAL_FALLBACK` | EAS env | Android/iOS key provisioning fallback | emergency only, disable after incident |
+| `google-services.json` | local/EAS secret file | Android Firebase | Firebase app rotation |
+| `GoogleService-Info.plist` | local/EAS secret file | iOS Firebase | Firebase app rotation |
+
+## Supabase Edge Functions
+
+| 이름 | 위치 | 사용처 |
+| --- | --- | --- |
+| `SUPABASE_URL` | Supabase function secret | Function Supabase client |
+| `SUPABASE_ANON_KEY` | Supabase function secret | User-scoped Supabase client |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase function secret | privileged server operations |
+| `KAKAO_CLIENT_ID` | Supabase function secret | Kakao OAuth |
+| `KAKAO_CLIENT_SECRET` | Supabase function secret | Kakao OAuth |
+| `CLOUDFLARE_TURN_ID` | Supabase function secret | ICE server credential issue |
+| `CLOUDFLARE_TURN_TOKEN` | Supabase function secret | ICE server credential issue |
+
+## Handling Rules
+
+- `.env.local`, Firebase config files, keystores, provisioning profiles, service role keys are never committed.
+- `.env.test.local` must point to local Supabase only for E2E.
+- Public-prefixed variables are still treated as configurable deployment data, not source constants.
+- Rotate any secret after console access changes, accidental log exposure, suspicious quota usage, or vendor incident.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,45 @@
+# Walkthrough: TASK-036 Closed Beta Readiness
+
+## Summary
+
+TASK-036은 Local-first document-primary 제품을 Closed Beta로 공개하기 위한 운영 기준선을 문서화했다. 기능 코드는 변경하지 않았고, production readiness, secret inventory, deployment/rollback, tester 운영 runbook을 Expo/EAS와 Local-first sync/P2P/backup 구조에 맞춰 정리했다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-036-closed-beta-readiness.md`
+- GitHub Issue [#330](https://github.com/ysjee141/nexvoy-frontend/issues/330)
+- PR [#331](https://github.com/ysjee141/nexvoy-frontend/pull/331)
+- 브랜치: `feature/task-036-closed-beta-readiness-330`
+- `docs/production-readiness.md`
+- `docs/runbooks/secret-inventory.md`
+- `docs/runbooks/deployment-rollback.md`
+- `docs/runbooks/closed-beta-runbook.md`
+- `_workspace/01_planner_analysis.md`
+- `_workspace/implementation_plan.md`
+
+## Key Changes
+
+- `docs/production-readiness.md`: 기존 Capacitor/구버전 readiness를 Closed Beta go/no-go gate 중심으로 갱신했다.
+- `docs/runbooks/secret-inventory.md`: Web, server/API, Mobile/EAS, Supabase Edge Function secret을 값 없이 inventory로 정리했다.
+- `docs/runbooks/deployment-rollback.md`: Vercel, EAS, Supabase, Local-first kill switch rollback matrix를 추가했다.
+- `docs/runbooks/closed-beta-runbook.md`: tester onboarding, daily smoke, feedback triage, privacy/data request, beta exit criteria를 정의했다.
+
+## Verification
+
+문서-only 변경이지만 release readiness 문서가 build/test 명령과 앱 설정을 참조하므로 아래 검증을 실행했다.
+
+| 명령 | 결과 |
+| --- | --- |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm typecheck` | PASS |
+| `pnpm build` | PASS |
+| `pnpm build:mobile` | PASS |
+
+## Follow-up
+
+- 실제 Closed Beta 시작 전 Supabase 운영 migration list, RLS/RPC smoke, Android Internal Testing, iOS TestFlight, monitoring alert test 결과를 readiness 문서의 evidence로 남긴다.
+- `/api/invite`, `/api/feedback`, `/api/places/photo/store` rate limiting은 별도 hardening task로 분리한다.
+
 # Walkthrough: TASK-035 Full Integration Test Suite
 
 ## Summary


### PR DESCRIPTION
## Summary
- refresh production readiness around Closed Beta go/no-go gates
- add secret inventory, deployment rollback, and Closed Beta operations runbooks
- update TASK-036/progress/walkthrough documentation

## Verification
- pnpm --filter @nexvoy/core test
- pnpm typecheck
- pnpm build
- pnpm build:mobile

Closes #330