### PR TITLE
fix: allow document key lookup for legacy trips

### DIFF
--- a/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
@@ -4,10 +4,12 @@ import {
   createDocumentPrimaryRepositoryBundle,
   createEmptyTemplateDocumentV1,
   getLegacyTripRowBundle,
+  shouldBootstrapDocumentRegistry,
   type DocumentMutationResult,
   type TemplateDocumentV1,
   type TripDocumentV1,
 } from '@nexvoy/core'
+import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
 import type { EntityId } from '@nexvoy/core/local-first/documentModel'
 import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
 import { publishLocalMobileTripDocumentUpdate } from './p2pUpdateBridge'
@@ -24,7 +26,8 @@ export async function createMobileDocumentPrimaryRepositories(
   } = {},
 ): Promise<DocumentPrimaryRepositoryBundle> {
   const { data } = await supabase.auth.getUser()
-  const userId = data.user?.id ?? 'anonymous-mobile-user'
+  const authUserId = data.user?.id ?? null
+  const userId = authUserId ?? 'anonymous-mobile-user'
   const actor = {
     userId,
     role: options.actorRole ?? 'viewer',
@@ -55,17 +58,49 @@ export async function createMobileDocumentPrimaryRepositories(
               update: result.update,
             })
             if (actor.role === 'owner' || actor.role === 'editor') {
-              void enqueueMobileBackupUpdate({
-                supabase,
-                documentId: result.documentId,
-                update: result.update,
-              }).catch(() => undefined)
+              void (async () => {
+                await ensureMobileDocumentRegistryBootstrapped(supabase, authUserId, result.document as TripDocumentV1)
+                await enqueueMobileBackupUpdate({
+                  supabase,
+                  documentId: result.documentId,
+                  update: result.update,
+                })
+              })().catch(() => undefined)
             }
           }
         },
       },
     },
   })
+}
+
+const mobileDocumentRegistryBootstrapAttempted = new Set<string>()
+
+async function ensureMobileDocumentRegistryBootstrapped(
+  supabase: SupabaseClient,
+  authUserId: string | null,
+  document: TripDocumentV1,
+): Promise<void> {
+  if (!authUserId) return
+  if (!shouldBootstrapDocumentRegistry({
+    authUserId,
+    tripOwnerId: document.trip.ownerId,
+  })) {
+    return
+  }
+
+  const key = `${authUserId}:${document.trip.id}`
+  if (mobileDocumentRegistryBootstrapAttempted.has(key)) return
+  mobileDocumentRegistryBootstrapAttempted.add(key)
+
+  try {
+    await createSupabaseBackupRepository(supabase).ensureDocumentBootstrapped({
+      documentId: document.trip.id,
+      ownerId: authUserId,
+    })
+  } catch {
+    mobileDocumentRegistryBootstrapAttempted.delete(key)
+  }
 }
 
 export async function createMobileTemplateDocument(input: {

--- a/apps/mobile/lib/local-first/mobileBackupSyncService.ts
+++ b/apps/mobile/lib/local-first/mobileBackupSyncService.ts
@@ -47,6 +47,7 @@ export async function flushMobileBackupQueue(input: {
   const clientId = await getOrCreateMobileDeviceId()
   const queue = await loadMobileQueue(input.documentId, clientId)
   if (queue.pending.length === 0) return
+  if (!(await hasActiveSession(input.supabase))) return
 
   const documentKey = await getCurrentMobileDocumentKey({
     supabase: input.supabase,
@@ -83,6 +84,15 @@ export async function flushMobileBackupQueue(input: {
     const failed = markBackupUploadFailed(uploading, reason)
     await saveMobileQueue(failed)
     await emitBackupFailure(reason, failed.pending.length)
+  }
+}
+
+async function hasActiveSession(supabase: SupabaseClient): Promise<boolean> {
+  try {
+    const { data } = await supabase.auth.getSession()
+    return Boolean(data.session?.access_token)
+  } catch {
+    return false
   }
 }
 

--- a/apps/web/lib/local-first/backupSyncService.ts
+++ b/apps/web/lib/local-first/backupSyncService.ts
@@ -43,6 +43,7 @@ export async function flushWebBackupQueue(input: {
   const clientId = getOrCreateWebDeviceId()
   const queue = await loadWebQueue(input.documentId, clientId)
   if (queue.pending.length === 0) return
+  if (!(await hasActiveSession(input.supabase))) return
 
   const documentKey = await getCurrentWebDocumentKey({
     supabase: input.supabase,
@@ -79,6 +80,15 @@ export async function flushWebBackupQueue(input: {
     const failed = markBackupUploadFailed(uploading, reason)
     await saveWebQueue(failed)
     emitBackupFailure(reason, failed.pending.length)
+  }
+}
+
+async function hasActiveSession(supabase: SupabaseClient): Promise<boolean> {
+  try {
+    const { data } = await supabase.auth.getSession()
+    return Boolean(data.session?.access_token)
+  } catch {
+    return false
   }
 }
 

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -4,10 +4,12 @@ import {
   createDocumentPrimaryRepositoryBundle,
   createEmptyTemplateDocumentV1,
   getLegacyTripRowBundle,
+  shouldBootstrapDocumentRegistry,
   type DocumentMutationResult,
   type TemplateDocumentV1,
   type TripDocumentV1,
 } from '@nexvoy/core'
+import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
 import type { EntityId } from '@nexvoy/core/local-first/documentModel'
 import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
 import { publishLocalTripDocumentUpdate } from './p2pUpdateBridge'
@@ -55,17 +57,49 @@ export async function createWebDocumentPrimaryRepositories(
               update: result.update,
             })
             if (actor.role === 'owner' || actor.role === 'editor') {
-              void enqueueWebBackupUpdate({
-                supabase,
-                documentId: result.documentId,
-                update: result.update,
-              }).catch(() => undefined)
+              void (async () => {
+                await ensureWebDocumentRegistryBootstrapped(supabase, ownerContext, result.document as TripDocumentV1)
+                await enqueueWebBackupUpdate({
+                  supabase,
+                  documentId: result.documentId,
+                  update: result.update,
+                })
+              })().catch(() => undefined)
             }
           }
         },
       },
     },
   })
+}
+
+const webDocumentRegistryBootstrapAttempted = new Set<string>()
+
+async function ensureWebDocumentRegistryBootstrapped(
+  supabase: SupabaseClient,
+  ownerContext: Awaited<ReturnType<typeof resolveWebOwnerContext>>,
+  document: TripDocumentV1,
+): Promise<void> {
+  if (!ownerContext.authUserId) return
+  if (!shouldBootstrapDocumentRegistry({
+    authUserId: ownerContext.authUserId,
+    tripOwnerId: document.trip.ownerId,
+  })) {
+    return
+  }
+
+  const key = `${ownerContext.authUserId}:${document.trip.id}`
+  if (webDocumentRegistryBootstrapAttempted.has(key)) return
+  webDocumentRegistryBootstrapAttempted.add(key)
+
+  try {
+    await createSupabaseBackupRepository(supabase).ensureDocumentBootstrapped({
+      documentId: document.trip.id,
+      ownerId: ownerContext.authUserId,
+    })
+  } catch {
+    webDocumentRegistryBootstrapAttempted.delete(key)
+  }
 }
 
 export async function createWebTemplateDocument(input: {

--- a/supabase/migrations/20260714000002_document_permission_legacy_trip_compat.sql
+++ b/supabase/migrations/20260714000002_document_permission_legacy_trip_compat.sql
@@ -1,0 +1,88 @@
+-- TASK-037 hotfix: document permission helpers must tolerate legacy trips that
+-- have not yet been materialized into document_members.
+--
+-- During the document-primary transition, TripDocumentV1 uses the legacy
+-- trips.id as document_id. Existing trips can therefore be valid editable
+-- documents before their document_members registry row is bootstrapped. RPCs
+-- such as get_my_active_document_key rely on check_is_document_member(), so
+-- they need the same legacy compatibility that signaling received in TASK-025.
+
+CREATE OR REPLACE FUNCTION public.check_is_document_owner(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.documents
+    WHERE id = _document_id
+      AND owner_id = _user_id
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+      AND role = 'owner'
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.trips
+    WHERE id = _document_id
+      AND user_id = _user_id
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_is_document_member(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT public.check_is_document_owner(_document_id, _user_id)
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.trip_members
+    WHERE trip_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_is_document_editor(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT public.check_is_document_owner(_document_id, _user_id)
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+      AND role IN ('owner', 'editor')
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.trip_members
+    WHERE trip_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+      AND role = 'editor'
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.check_is_document_owner(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_is_document_member(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_is_document_editor(uuid, uuid) TO anon, authenticated;

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,37 @@
+# Walkthrough: Fix Document Key RPC Legacy Permission
+
+## Summary
+
+일정 생성 후 document-primary backup flush가 `get_my_active_document_key` RPC를 호출할 때 legacy trip이 아직 `document_members`에 bootstrap되지 않아 `권한이 없습니다.`가 발생하던 문제를 보강했다. 전환기 동안 legacy `trips`/`trip_members` 권한을 document permission helper가 인정하도록 migration을 추가하고, Web/Mobile document-primary mutation 경로에서 owner registry bootstrap을 backup enqueue 전에 시도한다.
+
+## Artifacts
+
+- GitHub Issue [#332](https://github.com/ysjee141/nexvoy-frontend/issues/332)
+- PR [#333](https://github.com/ysjee141/nexvoy-frontend/pull/333)
+- 브랜치: `fix/document-key-rpc-legacy-member-permission`
+- `supabase/migrations/20260714000002_document_permission_legacy_trip_compat.sql`
+- `apps/web/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/web/lib/local-first/backupSyncService.ts`
+- `apps/mobile/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/mobile/lib/local-first/mobileBackupSyncService.ts`
+
+## Key Changes
+
+- `check_is_document_owner/member/editor`가 legacy `trips`/`trip_members`를 fallback으로 인정하도록 migration을 추가했다.
+- Web/Mobile document-primary publisher가 owner mutation 후 backup enqueue 전에 `documents`/`document_members` bootstrap을 시도한다.
+- Web/Mobile backup flush가 active auth session이 없으면 RPC를 호출하지 않고 pending queue를 유지하도록 guard를 추가했다.
+
+## Verification
+
+| 명령 | 결과 |
+| --- | --- |
+| `pnpm --filter nexvoy-web exec tsc --noEmit` | PASS |
+| `pnpm --filter nexvoy-app typecheck` | PASS |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm typecheck` | PASS |
+| `pnpm build` | PASS |
+| `pnpm build:mobile` | PASS |
+
 # Walkthrough: TASK-035 Full Integration Test Suite
 
 ## Summary


### PR DESCRIPTION
## Summary
- add legacy trips/trip_members compatibility to document permission helper functions
- bootstrap document registry before Web/Mobile document-primary backup enqueue for owner mutations
- skip backup RPC flush when the client has no active auth session

## Verification
- pnpm --filter nexvoy-web exec tsc --noEmit
- pnpm --filter nexvoy-app typecheck
- pnpm --filter @nexvoy/core test
- pnpm typecheck
- pnpm build
- pnpm build:mobile

Closes #332