### PR TITLE
docs(TASK-038): reset Closed Beta local-first baseline

### DIFF
--- a/docs/refactor/TECHNICAL-SPEC.md
+++ b/docs/refactor/TECHNICAL-SPEC.md
@@ -277,7 +277,7 @@ Trip document에는 template 적용 결과로 생성된 checklist item과 출처
 
 ## 9. Supabase 백업 스키마
 
-기존 row 테이블은 즉시 제거하지 않는다. 새 backup/registry 테이블을 추가한다.
+기존 row 테이블은 즉시 제거하지 않는다. 다만 ADR-014 이후 Closed Beta 제품 경로에서는 기존 row 데이터를 자동 hydrate/fallback하지 않는다. 새 backup/registry 테이블은 신규 document-primary 데이터의 primary sync/restore 경로다.
 
 ```sql
 create table public.documents (

--- a/docs/refactor/adrs/ADR-013-full-local-first-product-scope.md
+++ b/docs/refactor/adrs/ADR-013-full-local-first-product-scope.md
@@ -1,6 +1,6 @@
 # ADR-013: Full Local-first Product Scope
 
-- 상태: 채택됨
+- 상태: 채택됨, Closed Beta 데이터 기준선은 ADR-014로 수정됨
 - 결정일: 2026-07-14
 - 결정자: ysjee141
 - 관련 문서:
@@ -11,8 +11,13 @@
   - `docs/refactor/adrs/ADR-008-invitation-and-permission-registry.md`
   - `docs/refactor/adrs/ADR-011-invitation-key-provisioning-strategy.md`
   - `docs/refactor/tasks/TASK-029-full-local-first-product-scope-adr.md`
+  - `docs/refactor/adrs/ADR-014-closed-beta-baseline-reset.md`
 
 ---
+
+> 2026-07-15 업데이트: ADR-013의 "기존 row 데이터는 손실 없이 migration 된다" 완료 조건은 Closed Beta gate에서
+> 제외한다. Closed Beta는 ADR-014에 따라 신규 document-primary 데이터만 제품 경로로 사용하고, 기존 데이터 migration은
+> 별도 후속 tool 작업으로 분리한다.
 
 ## 문제 정의
 
@@ -173,6 +178,9 @@ restore read, P2P write propagation, invitation accept, role change, revoke는 S
 
 기존 Supabase row table은 document-primary 전환 이후 primary sync 경로가 아니다.
 
+ADR-014 이후 Closed Beta 기준에서는 아래 전환 정책을 **자동 제품 경로로 적용하지 않는다**. 기존 row 데이터는
+Closed Beta 화면에서 무시하며, 명시적 migration tool의 source로만 남긴다.
+
 전환 정책:
 
 1. 기존 row 데이터는 최초 진입 또는 migration job에서 document로 변환한다.
@@ -231,7 +239,8 @@ Full Local-first product 완료는 다음 조건을 모두 만족해야 한다.
 - 동시 접속 peer는 P2P로 같은 Yjs update를 주고받는다.
 - 비동시 기기는 Supabase backup pull/restore로 eventually sync 된다.
 - viewer/revoked member는 UI edit, backup upload, P2P write propagation에서 차단된다.
-- 기존 row 데이터는 손실 없이 Trip/Template document로 migration 된다.
+- 신규 Closed Beta 데이터는 처음부터 Trip/Template document로 생성된다. 기존 row 데이터의 손실 없는 migration은
+  Closed Beta gate가 아니라 후속 migration tool 완료 조건이다.
 - 통합테스트는 legacy row assertion이 아니라 document-primary/P2P/backup restore 기준으로 통과한다.
 
 ---

--- a/docs/refactor/adrs/ADR-014-closed-beta-baseline-reset.md
+++ b/docs/refactor/adrs/ADR-014-closed-beta-baseline-reset.md
@@ -1,0 +1,88 @@
+# ADR-014: Closed Beta Baseline Reset
+
+- 상태: 채택됨
+- 결정일: 2026-07-15
+- 결정자: ysjee141
+- 관련 문서:
+  - `docs/refactor/adrs/ADR-013-full-local-first-product-scope.md`
+  - `docs/refactor/TECHNICAL-SPEC.md`
+  - `docs/refactor/progress.md`
+  - `docs/refactor/tasks/TASK-038-closed-beta-baseline-reset-plan.md`
+
+---
+
+## 문제 정의
+
+ADR-013은 기존 Supabase row 데이터를 document-primary 구조로 보존/전환하는 것을 전제로 했다. 그러나 TASK-037 검증 중
+legacy row, document registry, encrypted snapshot, device key provisioning이 함께 얽히며 Closed Beta 이전 품질
+기준을 흐리는 문제가 확인되었다.
+
+기존 운영 데이터는 Closed Beta 기준에서 제품 가치가 낮고, 자동 마이그레이션을 전제로 하면 핵심 목표인 Local-first/P2P/
+backup sync 안정화보다 전환기 호환성 문제가 더 커진다.
+
+## 결정
+
+Closed Beta 기준선을 **백지 상태의 document-primary 데이터**로 재설정한다.
+
+- 기존 여행/일정/준비물/템플릿 row 데이터는 Closed Beta 제품 경로에서 무시한다.
+- 기존 데이터에 대한 별도 사용 불가 메시지는 제공하지 않는다.
+- 새로 생성되는 여행과 템플릿만 Local-first 제품 데이터로 간주한다.
+- legacy row 자동 마이그레이션은 Closed Beta 전 필수 조건에서 제외하고, 별도 후속 도구 작업으로 분리한다.
+- 모든 기능 범위는 여행, 일정, 준비물, 템플릿, 동행자/권한을 포함한다.
+
+## 신규 데이터 기준선
+
+새 여행 생성은 다음을 원자적 제품 기준으로 삼는다.
+
+1. `TripDocumentV1` local document 생성
+2. Web IndexedDB 또는 Mobile local storage에 즉시 저장
+3. Supabase `documents` encrypted initial snapshot 생성
+4. owner `document_members` accepted row 생성
+5. current device용 `document_keys` row 생성
+
+새 템플릿 생성도 동일하게 `TemplateDocumentV1` local document와 encrypted snapshot/key bootstrap을 기준으로 한다.
+
+## Sync 원칙
+
+- Local storage가 always-first source다. 사용자의 write는 네트워크와 무관하게 local document에 먼저 기록된다.
+- 동시 접속 peer가 있으면 WebRTC P2P가 빠른 전파 경로다.
+- peer가 없거나 실패하면 Supabase encrypted backup snapshot/update가 비동시 sync/restore 경로다.
+- 다른 사용자가 나중에 같은 여행에 진입하면 Supabase backup을 기준으로 최신 document를 복구해야 한다.
+- local document와 Supabase backup이 모두 존재하고 diverge하면 `updatedAt`/document clock 기반 freshness 비교 후 최신 쪽을 선택하거나 병합한다.
+
+## 통신량/비용 원칙
+
+- 기본 polling을 피하고 trigger/event 기반 freshness 확인을 우선한다.
+- Supabase Realtime은 document metadata/freshness notification과 P2P signaling에 한정한다.
+- document 본문은 Realtime payload로 보내지 않고 encrypted backup pull로만 가져온다.
+- snapshot은 초기 생성 및 compaction 시점에만 쓰고, 일반 변경은 encrypted update queue로 batch upload한다.
+- 앱 foreground, network reconnect, visibility change, explicit document enter 이벤트에서만 backup freshness를 확인한다.
+
+## 기존 데이터 처리
+
+Closed Beta 제품 경로에서는 legacy row read-through/hydrate를 제거한다. 기존 row 데이터는 숨겨진 migration source로만 남긴다.
+
+후속 migration tool은 다음을 별도 task로 다룬다.
+
+- 사용자가 명시적으로 선택한 legacy trip/template을 document-primary로 변환
+- snapshot/key/member bootstrap
+- 변환 결과 검증과 rollback/export
+
+## 영향
+
+이 결정은 ADR-013의 "기존 row 데이터는 손실 없이 migration 된다" 완료 조건을 Closed Beta gate에서 제거한다.
+대신 Closed Beta gate는 신규 document-primary 데이터의 local write, P2P, encrypted backup, restore 품질을 기준으로 한다.
+
+## 결과
+
+장점:
+
+- 전환기 compatibility 코드와 edge case를 줄인다.
+- Closed Beta 검증 기준이 신규 document-primary flow로 선명해진다.
+- Supabase 사용량을 backup/registry/freshness로 제한하기 쉽다.
+
+단점:
+
+- 기존 데이터는 Closed Beta 제품 경로에서 보이지 않는다.
+- legacy migration은 별도 작업 전까지 제공되지 않는다.
+- 데이터 기준선 reset을 문서와 운영 안내에 명확히 반영해야 한다.

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -2,11 +2,19 @@
 
 작성일: 2026-07-14  
 기준 브랜치: `refactoring/local-first-architecture`  
-목표 해석: **웹/앱의 모든 핵심 기능을 Local-first document-primary 구조로 완성한 뒤 통합테스트와 Closed Beta를 진행한다.**  
+목표 해석: **웹/앱의 모든 핵심 기능을 신규 Local-first document-primary 데이터 기준으로 완성한 뒤 통합테스트와 Closed Beta를 진행한다.**  
 
 ## 0. 목표 정정
 
-이번 refactor의 최종 목표는 "준비물 Web-to-Web P2P 검증"이 아니다. 목표는 기존 OnVoy 제품의 핵심 기능 전체를 Web/Mobile 양쪽에서 Local-first 기반으로 전환하는 것이다.
+이번 refactor의 최종 목표는 "준비물 Web-to-Web P2P 검증"이 아니다. 목표는 OnVoy 핵심 기능 전체를 Web/Mobile 양쪽에서 Local-first 기반으로 전환하는 것이다.
+
+2026-07-15 전략 변경:
+
+- 기존 Supabase row 데이터는 Closed Beta 제품 경로에서 무시한다.
+- 신규 여행/템플릿만 document-primary 데이터로 간주한다.
+- 기존 데이터에 대한 사용 불가 메시지는 제공하지 않는다.
+- 기존 데이터 변환은 Closed Beta 필수 조건이 아니라 별도 migration tool 작업으로 분리한다.
+- 기준 ADR: `docs/refactor/adrs/ADR-014-closed-beta-baseline-reset.md`
 
 대상 기능:
 
@@ -15,7 +23,7 @@
 - 템플릿
 - 동행자 초대 / 수락 / 거부
 - 권한/멤버 역할 변경
-- Web/Mobile cross-device restore/sync
+- Web/Mobile cross-device restore/sync for new document-primary data
 - 동시 접속 중 WebRTC P2P fast path
 - 동시 접속하지 않은 기기간 Supabase encrypted backup 기반 sync/restore
 
@@ -23,12 +31,12 @@
 
 ## 1. 현재 상태 요약
 
-현재까지 TASK-001~028을 통해 Local-first 기반 부품은 많이 구현되었다. 하지만 전체 제품 관점에서는 아직 "완료"가 아니라 **준비물 중심의 부분 구현 단계**다.
+현재까지 TASK-001~037을 통해 Local-first 기반 부품과 full document-primary 전환 시도가 구현되었다. 하지만 기존 데이터 보존 전제 때문에 전환기 edge case가 커졌고, Closed Beta 기준선은 ADR-014에 따라 신규 document-primary 데이터로 재설정한다.
 
 | 영역 | 현재 상태 | 판정 |
 |------|----------|------|
 | TripDocumentV1 모델 | trips/plans/checklists/members/assets/tombstones 기반 있음. templates는 ADR-013에 따라 별도 `TemplateDocumentV1` boundary | 기반 완료, templates 후속 |
-| legacy row -> document 변환 | trip/plans/checklists/members 변환 기반 있음 | 기반 완료 |
+| legacy row -> document 변환 | trip/plans/checklists/members 변환 기반 있음 | Closed Beta 필수 경로에서 제외, TASK-042로 이관 |
 | Web 준비물 | local-first/dual-write/P2P 화면 연결됨 | 부분 완료 |
 | Mobile 준비물 | Yjs runtime/apply adapter는 있으나 화면 write path는 legacy 중심 | 미완료 |
 | Web 일정 | document model에는 포함되나 화면 CRUD는 legacy Supabase 중심 | 미완료 |
@@ -38,22 +46,22 @@
 | WebRTC P2P | Web 준비물 Web-to-Web 제품 경로까지 연결. Mobile은 adapter 수준 | 부분 완료 |
 | Backup/restore | schema/crypto/key provisioning/restore helper 있음. 모든 기능의 sync 경로로 통합되지 않음 | 부분 완료 |
 | 통합테스트 | legacy Web E2E와 core tests 중심. full Local-first E2E 없음 | 미완료 |
-| Closed Beta | 완성 제품 기준으로는 아직 불가 | 미완료 |
+| Closed Beta | 신규 document-primary 기준선 안정화 전까지 불가 | 미완료 |
 
 정확한 현재 판정:
 
-> Local-first 전체 제품 완성도는 "foundation + Web checklist pilot" 단계다. 전체 기능 완료 후 Closed Beta라는 목표 기준에서는 아직 Phase 2에 가깝다.
+> Local-first 전체 제품 완성도는 "foundation + document-primary cutover 재정렬" 단계다. 이제 핵심 과제는 legacy 호환이 아니라 신규 데이터 기준의 생성/동기화/복구 안정화다.
 
 ## 2. 아키텍처 방향 결정
 
-속도를 우선한다면 기존 Supabase row 통신 방식을 계속 dual-write로 오래 유지하는 것보다, **document-primary 전환 + legacy row 마이그레이션/호환 최소화**가 더 단순할 수 있다.
+속도를 우선한다면 기존 Supabase row 통신 방식과 자동 migration/hydrate를 계속 유지하는 것보다, **신규 document-primary 기준선 + legacy migration tool 후속 분리**가 더 단순하다.
 
 권장 방향:
 
 1. `TripDocumentV1`을 제품 기능의 primary data source로 승격한다.
-2. 기존 row 데이터는 최초 진입 또는 migration job에서 document로 변환한다.
+2. 신규 여행/템플릿은 생성 즉시 local document + encrypted snapshot + owner key를 bootstrap한다.
 3. 화면 CRUD는 Web/Mobile 모두 document repository를 사용한다.
-4. Supabase row 테이블은 필요한 기간 동안 read-only migration source 또는 rollback fallback으로 축소한다.
+4. Supabase row 테이블은 Closed Beta 제품 경로에서 제외하고 후속 migration source로만 유지한다.
 5. 동기화는 두 계층으로 분리한다.
    - 동시 접속: WebRTC P2P로 Yjs update 전파
    - 비동시 접속: Supabase encrypted backup snapshot/update로 restore/sync
@@ -68,9 +76,9 @@
 
 위험:
 
-- legacy Supabase row 기반 기능을 한 번에 document repository로 옮기는 작업량이 크다.
+- legacy Supabase row 기반 기능을 제품 경로에서 제거하며 신규 document bootstrap을 엄격히 보장해야 한다.
 - 기존 화면이 row shape에 깊게 의존한다.
-- migration/restore 실패 시 고객 데이터 접근에 직접 영향이 생긴다.
+- 기존 데이터는 migration tool 전까지 제품 경로에서 보이지 않는다.
 
 따라서 빠르게 가되, 기능 단위로 document-primary 전환 PR을 쪼개는 방식이 필요하다.
 

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -7,6 +7,7 @@
 - `docs/refactor/TECHNICAL-SPEC.md`
 - `docs/refactor/progress.md`
 - `docs/refactor/adrs/ADR-001-local-first-data-engine.md`
+- `docs/refactor/adrs/ADR-014-closed-beta-baseline-reset.md`
 - `docs/plans/PLAN-008-local-first-architecture-review.md`
 
 ## 문서 네이밍
@@ -53,7 +54,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 - 각 task는 가능한 한 하나의 PR로 끝낼 수 있는 크기를 유지한다.
 - UI는 Supabase, Yjs, WebRTC를 직접 호출하지 않고 Repository 또는 platform adapter를 통해 접근한다.
 - `packages/core`에는 IndexedDB, SQLite, WebRTC, Next.js, Expo/RN API를 넣지 않는다.
-- 기존 Supabase row table은 document-primary 전환 전까지 fallback으로 유지한다.
+- Closed Beta 제품 경로는 신규 document-primary 데이터만 대상으로 한다. 기존 Supabase row 데이터는 자동 hydrate/fallback하지 않고 후속 migration tool의 source로만 유지한다.
 - WebRTC/P2P는 optional fast path이며, 기본 sync/restore는 Supabase backup pull/push다.
 - Cloudflare STUN/TURN은 managed provider 기준선으로 사용한다.
 
@@ -98,9 +99,14 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-034-p2p-all-domain-wiring.md` | 완료 | Trip document-level P2P lifecycle 승격, Web/Mobile reconnect/status 하드닝, Issue #326, PR #327 |
 | `TASK-035-full-integration-test-suite.md` | 완료 | Web document-primary 권한/reload E2E, observability safety E2E, Mobile/P2P/backup smoke runbook, Issue #328, PR #329 |
 | `TASK-036-closed-beta-readiness.md` | 완료 | Closed Beta go/no-go gate, secret inventory, deployment rollback, tester 운영 runbook, Issue #330, PR #331 |
-| `TASK-037-web-document-primary-key-bootstrap-and-photo-storage.md` | 진행 중 | Web document-primary key bootstrap과 place photo storage 호환성 보완, Issue #334 |
+| `TASK-037-web-document-primary-key-bootstrap-and-photo-storage.md` | 완료 | Web document-primary key bootstrap, backup restore/status, place photo storage 호환성 보완, Issue #334, PR #335 |
+| `TASK-038-closed-beta-baseline-reset-plan.md` | 완료 | 기존 데이터 자동 보존 전제를 제거하고 Closed Beta 기준선을 신규 document-primary 데이터로 재정의 |
+| `TASK-039-new-document-bootstrap.md` | 예정 | 신규 여행/템플릿 생성 시 local document + encrypted snapshot + owner key bootstrap |
+| `TASK-040-document-primary-product-path-cutover.md` | 예정 | 여행/일정/준비물/템플릿 제품 경로에서 legacy hydrate/fallback 제거 |
+| `TASK-041-backup-freshness-and-cost-control.md` | 예정 | local-first freshness, trigger 기반 backup pull/upload, Supabase 비용 최소화 |
+| `TASK-042-legacy-migration-tool.md` | 예정 | 기존 row 데이터를 명시적으로 document-primary로 전환하는 후속 도구 |
 
-현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `Phase 3`의 모바일 WebRTC native feasibility와 Cloudflare ICE config 발급 경로는 provider boundary, Edge Function, 검증 보고서로 정리했다. `Phase 4`의 dual-write 및 mismatch detector와 guest auth promotion은 Web-first 범위로 구현했다. `TASK-013`에서 초대/권한 registry, invite/share RPC, Web/Mobile join fallback을 구현했고, `TASK-014`에서 notification metadata, local notification scheduler, observability event boundary를 구현했다. `TASK-015`에서 owner/editor Web foreground document key provisioning과 pending/status UX를 구현했다. `TASK-016`은 Mobile Native Key Provisioning MVP를 구현하고 accepted scope 기준 검증했다. `TASK-017`은 Mobile background task 기반 provisioning retry path를 구현하고 Android-first 검증 범위에서 PASS를 받았다. `TASK-018`은 Android Keystore/iOS Keychain 기반 non-exportable key storage hardening을 구현하고 native preview build와 SQL smoke까지 검증했다. `TASK-019`는 Mobile-first owner bootstrap 후속 문서다. `TASK-020`은 `restore.ts`의 Yjs 비의존 부분(snapshot 복호화·hash 검증)을 `backupPayloadCodec.ts`/`mobileRestore.ts`로 분리해 Mobile 전용 encrypted snapshot restore 경로(`restoreMobileEncryptedSnapshot`)를 구현하고, `TASK-019`의 owner bootstrap 성공/provisioning completion 트리거에 재시도를 연결했다. updates replay(Web/Yjs 기반 최신 콘텐츠 반영)는 이번 범위에서 제외했다. `TASK-021`은 `ADR-004`가 유보했던 시그널링 전송 계층을 `ADR-012`(Supabase Realtime Broadcast)로 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 배선해 P2P fast path의 최초 연결을 증명했다. `TASK-022`는 일반 Web 로그인 trip이 `documents`/`document_members`에 등록되지 않던 선결 문제를 lazy bootstrap으로 해소했다. `TASK-023`은 같은 signaling 프로토콜과 room topic 파생 규칙을 Mobile까지 확장하고 native data-channel handshake/조립 지점을 추가했다. `TASK-024`는 Web-to-Web 범위에서 data channel로 Yjs update를 청킹/전송/재조립하고 IndexedDB 문서에 적용하는 fast path를 구현했다. `TASK-027`은 Mobile Yjs runtime adapter와 `react-native-quick-crypto` 기반 Metro shim을 추가해 Mobile도 같은 Yjs update format을 apply할 수 있게 했다. `TASK-029`부터는 checklist pilot을 넘어 Web/App 전체 제품 기능을 document-primary로 전환하고, 그 이후 통합 테스트와 Closed Beta 준비를 진행한다.
+현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `TASK-038`부터는 ADR-014에 따라 Closed Beta 기준선을 기존 row 자동 migration에서 신규 document-primary 데이터로 재설정한다. 기존 row 데이터는 제품 경로에서 자동 hydrate하지 않고, `TASK-042`의 명시적 migration tool source로만 남긴다.
 
 `TASK-021`은 `ADR-004`가 유보했던 시그널링 전송 계층을 `ADR-012`(Supabase Realtime Broadcast)로
 결정하고, Web에서 시그널링 채널과 데이터 채널을 실제로 연결해 P2P fast path의 최초 연결을 증명했다

--- a/docs/refactor/tasks/TASK-038-closed-beta-baseline-reset-plan.md
+++ b/docs/refactor/tasks/TASK-038-closed-beta-baseline-reset-plan.md
@@ -1,0 +1,65 @@
+# TASK-038: Closed Beta Baseline Reset Plan
+
+## 목적
+
+Closed Beta 기준선을 기존 데이터 보존/자동 마이그레이션에서 신규 document-primary 데이터 기준으로 재설정한다.
+기존 데이터는 제품 경로에서 무시하고, 신규 여행/일정/준비물/템플릿이 local storage, P2P, encrypted backup으로
+일관되게 동작하도록 후속 task를 분리한다.
+
+## 범위
+
+- ADR-014 작성 및 채택
+- refactor 진행 문서와 task index 갱신
+- 기존 데이터 자동 마이그레이션 전제 제거
+- 후속 구현 task 분리
+- Closed Beta gate를 신규 document-primary flow 기준으로 재정의
+
+제외:
+
+- 실제 legacy row 삭제
+- 실제 기능 코드 변경
+- migration tool 구현
+
+## 선행 조건
+
+- `TASK-037-web-document-primary-key-bootstrap-and-photo-storage.md`
+- PR #335 merge
+
+## 변경 대상
+
+- `docs/refactor/adrs/ADR-014-closed-beta-baseline-reset.md`
+- `docs/refactor/tasks/README.md`
+- `docs/refactor/progress.md`
+- `docs/refactor/tasks/TASK-039-new-document-bootstrap.md`
+- `docs/refactor/tasks/TASK-040-document-primary-product-path-cutover.md`
+- `docs/refactor/tasks/TASK-041-backup-freshness-and-cost-control.md`
+- `docs/refactor/tasks/TASK-042-legacy-migration-tool.md`
+
+## 구현 단계
+
+1. ADR-014로 전략 변경을 기록한다.
+2. TASK-039~042를 작은 구현 단위로 분리한다.
+3. task index와 progress 문서의 완료 기준을 신규 baseline 기준으로 수정한다.
+4. Closed Beta 전 필수 작업과 후속 migration 작업을 분리한다.
+
+## 데이터 호환성 고려사항
+
+- 기존 row 데이터는 삭제하지 않는다.
+- 기존 row 데이터는 제품 화면에서 자동 hydrate하지 않는다.
+- 기존 데이터 복구/전환은 TASK-042에서 명시적 migration tool로 다룬다.
+
+## 검증 방법
+
+- 문서상 Closed Beta gate가 신규 document-primary 데이터 기준인지 확인한다.
+- 기존 데이터 자동 마이그레이션이 필수 조건에서 제거되었는지 확인한다.
+- 후속 task가 여행/일정/준비물/템플릿 전체를 포함하는지 확인한다.
+
+## 롤백 방법
+
+- ADR-014를 폐기하고 ADR-013의 migration-first 전략으로 되돌린다.
+- TASK-039~042를 보류하고 legacy hydrate/fallback 작업을 재개한다.
+
+## 완료 조건
+
+- 전략 변경이 ADR/task/progress 문서에 일관되게 반영된다.
+- 후속 구현 task가 작업 가능한 크기로 분리된다.

--- a/docs/refactor/tasks/TASK-039-new-document-bootstrap.md
+++ b/docs/refactor/tasks/TASK-039-new-document-bootstrap.md
@@ -1,0 +1,66 @@
+# TASK-039: New Document Bootstrap
+
+## 목적
+
+신규 여행과 템플릿을 처음부터 document-primary 기준으로 생성한다. 생성 시점에 local document, encrypted initial
+snapshot, owner membership, current device document key를 함께 준비해 `key_unavailable` 전환기 상태를 만들지 않는다.
+
+## 범위
+
+- Web 신규 여행 생성 document-primary 전환
+- Mobile 신규 여행 생성 document-primary 전환
+- Web/Mobile 신규 템플릿 생성 document-primary 전환
+- initial encrypted snapshot upload
+- owner `document_members` bootstrap
+- current device `document_keys` bootstrap
+
+제외:
+
+- 기존 row 데이터 migration
+- P2P lifecycle 변경
+- snapshot compaction 정책 변경
+
+## 선행 조건
+
+- `TASK-038-closed-beta-baseline-reset-plan.md`
+
+## 변경 대상
+
+- `apps/web/app/trips/new`
+- `apps/mobile/app` 신규 여행 생성 화면/서비스
+- Web/Mobile template creation flow
+- `packages/core/src/local-first`
+- `apps/web/lib/local-first/*`
+- `apps/mobile/lib/local-first/*`
+- 필요 시 Supabase RPC/migration
+
+## 구현 단계
+
+1. 신규 `TripDocumentV1` 생성 helper를 owner/device bootstrap과 묶는다.
+2. Web 신규 여행 생성이 legacy `trips` write를 primary로 사용하지 않도록 전환한다.
+3. Mobile 신규 여행 생성도 같은 bootstrap contract를 사용한다.
+4. 신규 `TemplateDocumentV1` 생성 경로를 동일한 기준으로 전환한다.
+5. 생성 직후 local read, backup restore, 다른 기기 restore smoke를 검증한다.
+
+## 데이터 호환성 고려사항
+
+- 신규 document id는 기존 row id 호환을 고려하지 않아도 된다.
+- legacy row는 생성하지 않거나, 필요하면 검색/index용 비권위 read model로만 생성한다.
+- owner device key 생성 실패 시 여행/템플릿 생성 완료로 보지 않는다.
+
+## 검증 방법
+
+- 신규 여행 생성 후 local storage에 `TripDocumentV1`이 존재한다.
+- Supabase `documents.snapshot`과 `document_keys`가 즉시 존재한다.
+- 같은 계정의 새 Web session이 backup restore로 여행을 볼 수 있다.
+- Web/Mobile 신규 템플릿 생성도 같은 기준을 만족한다.
+
+## 롤백 방법
+
+- 신규 생성 feature flag를 legacy create flow로 되돌린다.
+- 생성 중 실패한 partial document/registry/key row를 cleanup script로 정리한다.
+
+## 완료 조건
+
+- 신규 여행/템플릿은 legacy migration 없이 document-primary로 시작한다.
+- 생성 직후 backup restore가 가능한 상태다.

--- a/docs/refactor/tasks/TASK-040-document-primary-product-path-cutover.md
+++ b/docs/refactor/tasks/TASK-040-document-primary-product-path-cutover.md
@@ -1,0 +1,61 @@
+# TASK-040: Document-Primary Product Path Cutover
+
+## 목적
+
+여행, 일정, 준비물, 템플릿 화면이 기존 row hydrate/fallback에 의존하지 않고 document-primary repository를
+제품 경로로 사용하도록 정리한다.
+
+## 범위
+
+- Web 여행 목록/상세/일정/준비물 document-primary read path 정리
+- Mobile 여행 목록/상세/일정/준비물 document-primary read path 정리
+- Web/Mobile 템플릿 list/detail/apply document-primary 정리
+- legacy row 자동 hydrate 제거
+- 기존 데이터 미노출 처리
+
+제외:
+
+- 기존 데이터 마이그레이션 UI
+- 검색/index 전용 read model 최적화
+- Realtime freshness policy
+
+## 선행 조건
+
+- `TASK-039-new-document-bootstrap.md`
+
+## 변경 대상
+
+- `apps/web/app/trips/*`
+- `apps/web/app/templates/*`
+- `apps/mobile/app/*`
+- `apps/web/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/mobile/lib/local-first/documentPrimaryRepositories.ts`
+- repository factory / feature flag
+
+## 구현 단계
+
+1. 목록은 document registry/backup metadata 또는 local document list 기준으로 재정의한다.
+2. 상세/일정/준비물은 local document 없을 때 backup restore만 시도한다.
+3. legacy row hydrate fallback을 제품 경로에서 제거한다.
+4. 템플릿도 `TemplateDocumentV1` 기준으로 전환한다.
+5. 기존 row 데이터가 화면에 나타나지 않는지 확인한다.
+
+## 데이터 호환성 고려사항
+
+- 기존 row 데이터는 삭제하지 않지만 화면에서 자동 노출하지 않는다.
+- 기존 데이터 migration은 TASK-042에서 사용자가 명시적으로 실행하는 도구로 분리한다.
+- read model/index table이 필요하면 document에서 파생된 비권위 데이터로 제한한다.
+
+## 검증 방법
+
+- 신규 여행/일정/준비물/템플릿이 Web/Mobile 양쪽에서 document repository로 보인다.
+- 기존 row-only 여행/템플릿은 제품 목록에 나타나지 않는다.
+- legacy row hydrate 호출이 제품 진입 경로에서 제거된다.
+
+## 롤백 방법
+
+- document-primary feature flag를 끄고 legacy 화면으로 복귀한다.
+
+## 완료 조건
+
+- Closed Beta 제품 화면은 신규 document-primary 데이터만 대상으로 한다.

--- a/docs/refactor/tasks/TASK-041-backup-freshness-and-cost-control.md
+++ b/docs/refactor/tasks/TASK-041-backup-freshness-and-cost-control.md
@@ -1,0 +1,66 @@
+# TASK-041: Backup Freshness and Cost Control
+
+## 목적
+
+로컬 storage 우선 원칙을 유지하면서, 다른 사용자가 나중에 같은 여행에 진입했을 때 최신 데이터를 볼 수 있도록
+Supabase backup freshness 확인과 pull/restore 정책을 비용 효율적으로 정리한다.
+
+## 범위
+
+- document metadata freshness model 정의
+- local document `updatedAt`/clock과 remote snapshot/update freshness 비교
+- backup update batch upload 정책
+- foreground/network reconnect/document enter 기반 pull trigger
+- Supabase Realtime 또는 lightweight metadata trigger 검토
+- sync status UX 기준 정리
+
+제외:
+
+- legacy migration
+- P2P transport 재구현
+- full conflict-free merge 알고리즘 재작성
+
+## 선행 조건
+
+- `TASK-039-new-document-bootstrap.md`
+- `TASK-040-document-primary-product-path-cutover.md`
+
+## 변경 대상
+
+- `packages/core/src/sync`
+- Web/Mobile backup sync services
+- Supabase `documents` metadata/RPC
+- sync status UI
+- QA runbook
+
+## 구현 단계
+
+1. local/remote freshness metadata를 정의한다.
+2. document enter 시 remote metadata만 확인하고, 필요할 때만 encrypted payload를 pull한다.
+3. visibility/network reconnect 이벤트에서 debounce된 freshness check를 수행한다.
+4. Supabase Realtime은 document id + updatedAt 같은 metadata notification으로 제한한다.
+5. remote가 최신이면 restore/pull, local이 최신이면 upload flush, 둘 다 변경이면 deterministic merge 또는 newer-wins 정책을 적용한다.
+6. 통신량/업로드 횟수 지표를 관측한다.
+
+## 데이터 호환성 고려사항
+
+- document 본문은 Realtime payload에 싣지 않는다.
+- snapshot은 초기 생성과 compaction에만 사용하고 일반 변경은 update log로 처리한다.
+- `updatedAt` 단독 비교가 부족한 경우 vector/client sequence metadata를 추가한다.
+
+## 검증 방법
+
+- 단일 사용자가 변경 후 앱을 닫아도 다른 사용자가 나중에 진입하면 최신 backup을 복구한다.
+- local 최신 상태에서 불필요한 snapshot/download가 발생하지 않는다.
+- remote 최신 상태에서 local stale document가 갱신된다.
+- Supabase Realtime payload에 document content가 포함되지 않는다.
+
+## 롤백 방법
+
+- freshness trigger를 끄고 foreground/document enter pull만 유지한다.
+- backup upload batching을 보수적으로 낮춘다.
+
+## 완료 조건
+
+- 비동시 사용자 sync가 backup 기반으로 안정 동작한다.
+- Supabase payload/download/upload가 최소화된 trigger 기반 정책으로 제한된다.

--- a/docs/refactor/tasks/TASK-042-legacy-migration-tool.md
+++ b/docs/refactor/tasks/TASK-042-legacy-migration-tool.md
@@ -1,0 +1,62 @@
+# TASK-042: Legacy Migration Tool
+
+## 목적
+
+Closed Beta 기준선에서는 기존 데이터를 무시하지만, 향후 필요 시 기존 row 데이터를 명시적으로 document-primary로
+전환할 수 있는 migration tool을 만든다.
+
+## 범위
+
+- legacy trip/template scan
+- 사용자가 선택한 항목만 migration
+- row bundle -> `TripDocumentV1`/`TemplateDocumentV1` 변환
+- encrypted snapshot/key/member bootstrap
+- migration 결과 검증
+- 실패 시 rollback/export
+
+제외:
+
+- Closed Beta 필수 gate
+- 자동 silent migration
+- legacy row 실시간 mirror
+
+## 선행 조건
+
+- `TASK-040-document-primary-product-path-cutover.md`
+- `TASK-041-backup-freshness-and-cost-control.md`
+
+## 변경 대상
+
+- admin/dev migration script 또는 protected route
+- `packages/core/src/local-first/migrations.ts`
+- Supabase service role script
+- migration runbook
+
+## 구현 단계
+
+1. legacy row-only 데이터 후보를 식별한다.
+2. dry-run 변환과 validation report를 만든다.
+3. 사용자가 선택한 데이터만 document-primary snapshot/key/member로 bootstrap한다.
+4. 변환 후 Web/Mobile restore smoke를 수행한다.
+5. 실패 항목은 원본 row를 유지하고 report에 남긴다.
+
+## 데이터 호환성 고려사항
+
+- 원본 legacy row는 migration 성공 후에도 즉시 삭제하지 않는다.
+- migration은 idempotent해야 한다.
+- 이미 document-primary document가 있는 항목은 overwrite하지 않는다.
+
+## 검증 방법
+
+- dry-run report가 row 수, 변환 entity 수, 누락 필드를 보여준다.
+- 성공 migration 후 fresh Web/Mobile session에서 backup restore가 가능하다.
+- 실패 migration은 원본 row를 변경하지 않는다.
+
+## 롤백 방법
+
+- 생성된 document/updates/keys/members를 migration batch id 기준으로 삭제한다.
+- legacy row 원본을 계속 유지한다.
+
+## 완료 조건
+
+- 기존 데이터를 수동 선택 방식으로 안전하게 document-primary로 전환할 수 있다.


### PR DESCRIPTION
## Summary
- Adopt ADR-014 to reset the Closed Beta baseline to new document-primary data only.
- Split follow-up work into TASK-039 through TASK-042 for bootstrap, product path cutover, backup freshness/cost control, and legacy migration tooling.
- Update refactor progress, task index, ADR-013, and technical spec to remove automatic legacy row preservation from the Closed Beta gate.

## Verification
- Docs-only change; runtime tests not run.