### PR TITLE
feat(TASK-039): bootstrap new document-primary records

### DIFF
--- a/apps/mobile/app/trip/new.tsx
+++ b/apps/mobile/app/trip/new.tsx
@@ -8,7 +8,7 @@
  * toDateString() 으로 YYYY-MM-DD 문자열을 만든다. `toISOString()` 은 UTC 변환으로
  * TZ 왜곡 위험이 있어 금지 — 로컬 연/월/일을 직접 조합한다.
  *
- * createTrip 호출로 여행을 생성하고 상세 화면으로 이동한다. 화면은 폼 UI/검증/상태만 담당.
+ * document-primary bootstrap으로 여행을 생성하고 상세 화면으로 이동한다. 화면은 폼 UI/검증/상태만 담당.
  */
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -27,9 +27,9 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter } from 'expo-router'
 import DateTimePicker from '@react-native-community/datetimepicker'
-import { createTrip } from '@nexvoy/core'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/lib/auth-context'
+import { createMobileTripDocument } from '@/lib/local-first/documentPrimaryRepositories'
 import { colors, fontSizes, fontWeights, radii, shadows, spacing } from '@/theme'
 
 const DESTINATION_MAX = 50
@@ -140,15 +140,15 @@ export default function NewTripScreen() {
     setLoading(true)
     setError(null)
     try {
-      const trip = await createTrip(supabase, {
-        user_id: session.user.id,
+      const tripId = await createMobileTripDocument({
+        supabase,
         destination: destination.trim(),
-        start_date: toDateString(startDate),
-        end_date: toDateString(endDate),
-        adults_count: adultsCount,
-        children_count: childrenCount,
+        startDate: toDateString(startDate),
+        endDate: toDateString(endDate),
+        adultsCount,
+        childrenCount,
       })
-      router.replace({ pathname: '/trip/[id]', params: { id: trip.id } })
+      router.replace({ pathname: '/trip/[id]', params: { id: tripId } })
     } catch (e) {
       if (isMounted.current) {
         setError(

--- a/apps/mobile/lib/local-first/documentBootstrapService.ts
+++ b/apps/mobile/lib/local-first/documentBootstrapService.ts
@@ -9,6 +9,7 @@ import { serializeEncryptedBackupPayload } from '@nexvoy/core/sync/backupPayload
 import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
 import { TRIP_DOCUMENT_SCHEMA_VERSION } from '@nexvoy/core/local-first/documentModel'
 import { createEmptyTripDocumentV1 } from '@nexvoy/core/local-first/tripDocument'
+import type { BackupDocumentType } from '@nexvoy/core/sync/backupTypes'
 import { bootstrapMobileDeviceDocumentKey } from './keyProvisioningService'
 import {
   createMobileYjsTripDocument,
@@ -18,6 +19,14 @@ import {
 
 // Document key version must match the value in keyProvisioningService.ts
 const DOCUMENT_KEY_VERSION = 1
+
+export interface EnsureMobileOwnerDocumentKeyForSnapshotInput {
+  supabase: SupabaseClient
+  documentId: string
+  documentType: BackupDocumentType
+  schemaVersion: number
+  snapshotPayload: Uint8Array
+}
 
 export function getMobileBackupCryptoProvider(): BackupCryptoProvider {
   return {
@@ -106,7 +115,54 @@ export async function ensureMobileOwnerDocumentKey({
     // fall through to (re)bootstrap from scratch.
   }
 
-  await bootstrapOwnerDocument({ supabase, backupRepository, documentId, userId: user.id })
+  await bootstrapOwnerDocument({
+    supabase,
+    backupRepository,
+    documentId,
+    userId: user.id,
+    documentType: 'trip',
+    schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+    snapshotPayload: createInitialMobileSnapshotPayload(documentId, user.id),
+  })
+}
+
+export async function ensureMobileOwnerDocumentKeyForSnapshot({
+  supabase,
+  documentId,
+  documentType,
+  schemaVersion,
+  snapshotPayload,
+}: EnsureMobileOwnerDocumentKeyForSnapshotInput): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) throw new Error('인증 정보가 없습니다.')
+
+  const backupRepository = createSupabaseBackupRepository(supabase)
+  const activeKey = await backupRepository.getMyActiveDocumentKey({
+    documentId,
+    keyVersion: DOCUMENT_KEY_VERSION,
+  })
+  if (activeKey?.wrappingAlg === 'RSA-OAEP-256') return
+
+  const hasSnapshot = await backupRepository.hasSnapshot(documentId)
+  if (hasSnapshot) {
+    const isOwner = await isCurrentUserDocumentOwner(supabase, documentId)
+    const anyKeyExists = isOwner && (await documentHasAnyKey(supabase, documentId))
+    if (!isOwner || anyKeyExists) {
+      throw new Error('owner_device_key_unavailable')
+    }
+  }
+
+  await bootstrapOwnerDocument({
+    supabase,
+    backupRepository,
+    documentId,
+    userId: user.id,
+    documentType,
+    schemaVersion,
+    snapshotPayload,
+  })
 }
 
 async function isCurrentUserDocumentOwner(
@@ -143,14 +199,19 @@ async function bootstrapOwnerDocument({
   backupRepository,
   documentId,
   userId,
+  documentType,
+  schemaVersion,
+  snapshotPayload,
 }: {
   supabase: SupabaseClient
   backupRepository: ReturnType<typeof createSupabaseBackupRepository>
   documentId: string
   userId: string
+  documentType: BackupDocumentType
+  schemaVersion: number
+  snapshotPayload: Uint8Array
 }): Promise<void> {
   const cryptoProvider = getMobileBackupCryptoProvider()
-  const snapshotPayload = createInitialMobileSnapshotPayload(documentId, userId)
 
   const dek = await generateDocumentEncryptionKey(cryptoProvider)
   const encryptedPayload = await encryptBackupPayload(cryptoProvider, {
@@ -169,14 +230,16 @@ async function bootstrapOwnerDocument({
   await backupRepository.upsertSnapshot({
     documentId,
     ownerId: userId,
-    type: 'trip',
-    schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+    type: documentType,
+    schemaVersion,
     snapshot: encryptedSnapshot,
     snapshotHash,
     encrypted: true,
   })
   await backupRepository.upsertOwnerMember({ documentId, userId })
-  await saveMobileTripDocumentUpdate({ documentId }, snapshotPayload)
+  if (documentType === 'trip') {
+    await saveMobileTripDocumentUpdate({ documentId }, snapshotPayload)
+  }
 
   // Store the DEK wrapped with this device's non-exportable RSA public key.
   await bootstrapMobileDeviceDocumentKey({ supabase, documentId, documentKey: dek })

--- a/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import {
   convertLegacyTripRowsToDocument,
+  createEmptyTripDocumentV1,
   createDocumentPrimaryRepositoryBundle,
   createEmptyTemplateDocumentV1,
   getLegacyTripRowBundle,
@@ -10,7 +11,13 @@ import {
   type TripDocumentV1,
 } from '@nexvoy/core'
 import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
-import type { EntityId } from '@nexvoy/core/local-first/documentModel'
+import { TRIP_DOCUMENT_SCHEMA_VERSION, type EntityId } from '@nexvoy/core/local-first/documentModel'
+import { createYjsTripDocument, encodeTripDocumentUpdate } from '@nexvoy/core/local-first/yjsTripDocument'
+import {
+  TEMPLATE_DOCUMENT_SCHEMA_VERSION,
+  createYjsTemplateDocument,
+  encodeTemplateDocumentUpdate,
+} from '@nexvoy/core/local-first/templateDocument'
 import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
 import { publishLocalMobileTripDocumentUpdate } from './p2pUpdateBridge'
 import {
@@ -18,6 +25,7 @@ import {
   createMobileTripDocumentStore,
 } from './mobileDocumentStores'
 import { enqueueMobileBackupUpdate } from './mobileBackupSyncService'
+import { ensureMobileOwnerDocumentKeyForSnapshot } from './documentBootstrapService'
 
 export async function createMobileDocumentPrimaryRepositories(
   supabase: SupabaseClient,
@@ -103,6 +111,54 @@ async function ensureMobileDocumentRegistryBootstrapped(
   }
 }
 
+export async function createMobileTripDocument(input: {
+  supabase: SupabaseClient
+  destination: string
+  startDate: string
+  endDate: string
+  adultsCount: number
+  childrenCount: number
+}): Promise<string> {
+  const { data } = await input.supabase.auth.getUser()
+  const userId = data.user?.id
+  if (!userId) throw new Error('인증 정보가 없습니다.')
+
+  const tripStore = createMobileTripDocumentStore()
+  const now = new Date().toISOString()
+  const tripId = createEntityId('trip')
+  const document = createEmptyTripDocumentV1({
+    id: tripId,
+    ownerId: userId,
+    destination: input.destination,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    adultsCount: input.adultsCount,
+    childrenCount: input.childrenCount,
+    createdAt: now,
+  })
+  const update = encodeTripDocumentUpdate(createYjsTripDocument(document))
+
+  await tripStore.putDocument(tripId, document, update)
+  await ensureMobileOwnerDocumentKeyForSnapshot({
+    supabase: input.supabase,
+    documentId: tripId,
+    documentType: 'trip',
+    schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+    snapshotPayload: update,
+  })
+  await upsertTripReadModel(input.supabase, {
+    tripId,
+    ownerId: userId,
+    destination: input.destination,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    adultsCount: input.adultsCount,
+    childrenCount: input.childrenCount,
+  })
+
+  return tripId
+}
+
 export async function createMobileTemplateDocument(input: {
   supabase: SupabaseClient
   title: string
@@ -113,12 +169,15 @@ export async function createMobileTemplateDocument(input: {
   }>
 }): Promise<string> {
   const { data } = await input.supabase.auth.getUser()
+  const userId = data.user?.id
+  if (!userId) throw new Error('인증 정보가 없습니다.')
+
   const templateStore = createMobileTemplateDocumentStore()
   const now = new Date().toISOString()
   const templateId = createEntityId('template')
   const document = createEmptyTemplateDocumentV1({
     id: templateId,
-    ownerId: data.user?.id ?? null,
+    ownerId: userId,
     title: input.title,
     visibility: 'private',
     createdAt: now,
@@ -138,7 +197,16 @@ export async function createMobileTemplateDocument(input: {
     }
   })
 
-  await templateStore.putDocument(templateId, document)
+  const update = encodeTemplateDocumentUpdate(createYjsTemplateDocument(document))
+  await templateStore.putDocument(templateId, document, update)
+  await ensureMobileOwnerDocumentKeyForSnapshot({
+    supabase: input.supabase,
+    documentId: templateId,
+    documentType: 'template',
+    schemaVersion: TEMPLATE_DOCUMENT_SCHEMA_VERSION,
+    snapshotPayload: update,
+  })
+
   return templateId
 }
 
@@ -244,4 +312,30 @@ export type MobileDocumentPrimaryMutationResult =
 function createEntityId(prefix: string): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+async function upsertTripReadModel(
+  supabase: SupabaseClient,
+  input: {
+    tripId: string
+    ownerId: string
+    destination: string
+    startDate: string
+    endDate: string
+    adultsCount: number
+    childrenCount: number
+  },
+): Promise<void> {
+  const { error } = await supabase
+    .from('trips')
+    .upsert({
+      id: input.tripId,
+      user_id: input.ownerId,
+      destination: input.destination,
+      start_date: input.startDate,
+      end_date: input.endDate,
+      adults_count: input.adultsCount,
+      children_count: input.childrenCount,
+    })
+  if (error) throw error
 }

--- a/apps/web/app/trips/new/page.tsx
+++ b/apps/web/app/trips/new/page.tsx
@@ -8,6 +8,7 @@ import { css } from 'styled-system/css'
 import { Plus, ArrowLeft, ChevronLeft, Minus } from 'lucide-react'
 import { useLoadScript, Autocomplete } from '@react-google-maps/api'
 import { CacheUtil } from '@/lib/cache'
+import { createWebTripDocument } from '@/lib/local-first/documentPrimaryRepositories'
 
 const libraries: ("places")[] = ["places"]
 
@@ -76,26 +77,22 @@ export default function NewTripPage() {
             return
         }
 
-        const { data: trip, error } = await supabase
-            .from('trips')
-            .insert({
-                user_id: user.id,
+        try {
+            const tripId = await createWebTripDocument({
+                supabase,
                 destination,
-                start_date: startDate,
-                end_date: endDate,
-                adults_count: adults,
-                children_count: childrenCount,
+                startDate,
+                endDate,
+                adultsCount: adults,
+                childrenCount,
             })
-            .select()
-            .single()
 
-        setLoading(false)
-
-        if (error) {
-            setErrorMsg(error.message)
-        } else if (trip) {
             analytics.logTripCreate(destination)
-            router.push(`/trips/detail?id=${trip.id}`)
+            router.push(`/trips/detail?id=${tripId}`)
+        } catch (error) {
+            setErrorMsg(error instanceof Error ? error.message : '여행 생성에 실패했습니다.')
+        } finally {
+            setLoading(false)
         }
     }
 

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import {
   convertLegacyTripRowsToDocument,
+  createEmptyTripDocumentV1,
   createDocumentPrimaryRepositoryBundle,
   createEmptyTemplateDocumentV1,
   getLegacyTripRowBundle,
@@ -10,7 +11,13 @@ import {
   type TripDocumentV1,
 } from '@nexvoy/core'
 import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
-import type { EntityId } from '@nexvoy/core/local-first/documentModel'
+import { TRIP_DOCUMENT_SCHEMA_VERSION, type EntityId } from '@nexvoy/core/local-first/documentModel'
+import { createYjsTripDocument, encodeTripDocumentUpdate } from '@nexvoy/core/local-first/yjsTripDocument'
+import {
+  TEMPLATE_DOCUMENT_SCHEMA_VERSION,
+  createYjsTemplateDocument,
+  encodeTemplateDocumentUpdate,
+} from '@nexvoy/core/local-first/templateDocument'
 import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
 import { publishLocalTripDocumentUpdate } from './p2pUpdateBridge'
 import { resolveWebOwnerContext } from './ownerNamespace'
@@ -20,7 +27,7 @@ import {
 } from './webDocumentStores'
 import { enqueueWebBackupUpdate } from './backupSyncService'
 import { restoreWebTripDocumentFromBackup } from './backupRestoreService'
-import { ensureWebOwnerDocumentKey } from './keyProvisioningService'
+import { ensureWebOwnerDocumentKey, ensureWebOwnerDocumentKeyForSnapshot } from './keyProvisioningService'
 
 export async function createWebDocumentPrimaryRepositories(
   supabase: SupabaseClient,
@@ -135,6 +142,54 @@ function getSafeBackupPublishFailureReason(error: unknown): string {
   return 'unknown'
 }
 
+export async function createWebTripDocument(input: {
+  supabase: SupabaseClient
+  destination: string
+  startDate: string
+  endDate: string
+  adultsCount: number
+  childrenCount: number
+}): Promise<string> {
+  const ownerContext = await resolveWebOwnerContext(input.supabase)
+  if (!ownerContext.authUserId) throw new Error('인증 정보가 없습니다.')
+
+  const tripStore = createWebTripDocumentStore(ownerContext)
+  const now = new Date().toISOString()
+  const tripId = createEntityId('trip')
+  const document = createEmptyTripDocumentV1({
+    id: tripId,
+    ownerId: ownerContext.authUserId,
+    destination: input.destination,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    adultsCount: input.adultsCount,
+    childrenCount: input.childrenCount,
+    createdAt: now,
+  })
+  const update = encodeTripDocumentUpdate(createYjsTripDocument(document))
+
+  await tripStore.putDocument(tripId, document, update)
+  await ensureWebOwnerDocumentKeyForSnapshot({
+    supabase: input.supabase,
+    documentId: tripId,
+    ownerId: ownerContext.authUserId,
+    documentType: 'trip',
+    schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+    snapshotPayload: update,
+  })
+  await upsertTripReadModel(input.supabase, {
+    tripId,
+    ownerId: ownerContext.authUserId,
+    destination: input.destination,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    adultsCount: input.adultsCount,
+    childrenCount: input.childrenCount,
+  })
+
+  return tripId
+}
+
 export async function createWebTemplateDocument(input: {
   supabase: SupabaseClient
   title: string
@@ -145,6 +200,8 @@ export async function createWebTemplateDocument(input: {
   }>
 }): Promise<string> {
   const ownerContext = await resolveWebOwnerContext(input.supabase)
+  if (!ownerContext.authUserId) throw new Error('인증 정보가 없습니다.')
+
   const templateStore = createWebTemplateDocumentStore(ownerContext)
   const now = new Date().toISOString()
   const templateId = createEntityId('template')
@@ -170,7 +227,17 @@ export async function createWebTemplateDocument(input: {
     }
   })
 
-  await templateStore.putDocument(templateId, document)
+  const update = encodeTemplateDocumentUpdate(createYjsTemplateDocument(document))
+  await templateStore.putDocument(templateId, document, update)
+  await ensureWebOwnerDocumentKeyForSnapshot({
+    supabase: input.supabase,
+    documentId: templateId,
+    ownerId: ownerContext.authUserId,
+    documentType: 'template',
+    schemaVersion: TEMPLATE_DOCUMENT_SCHEMA_VERSION,
+    snapshotPayload: update,
+  })
+
   return templateId
 }
 
@@ -276,4 +343,30 @@ export type WebDocumentPrimaryMutationResult =
 function createEntityId(prefix: string): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+async function upsertTripReadModel(
+  supabase: SupabaseClient,
+  input: {
+    tripId: string
+    ownerId: string
+    destination: string
+    startDate: string
+    endDate: string
+    adultsCount: number
+    childrenCount: number
+  },
+): Promise<void> {
+  const { error } = await supabase
+    .from('trips')
+    .upsert({
+      id: input.tripId,
+      user_id: input.ownerId,
+      destination: input.destination,
+      start_date: input.startDate,
+      end_date: input.endDate,
+      adults_count: input.adultsCount,
+      children_count: input.childrenCount,
+    })
+  if (error) throw error
 }

--- a/apps/web/lib/local-first/keyProvisioningService.ts
+++ b/apps/web/lib/local-first/keyProvisioningService.ts
@@ -17,6 +17,7 @@ import { createInvitationRepository } from '@nexvoy/core/supabase/invitationRepo
 import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
 import { TRIP_DOCUMENT_SCHEMA_VERSION, type TripDocumentV1 } from '@nexvoy/core/local-first/documentModel'
 import { createYjsTripDocument, encodeTripDocumentUpdate } from '@nexvoy/core/local-first/yjsTripDocument'
+import type { BackupDocumentType } from '@nexvoy/core/sync/backupTypes'
 import { analytics } from '@/services/AnalyticsService'
 import { deleteWebDeviceKeyMaterial, loadWebDeviceKeyMaterial, saveWebDeviceKeyMaterial } from './indexedDbStore'
 import {
@@ -52,6 +53,15 @@ export interface EnsureWebOwnerDocumentKeyInput {
   supabase: SupabaseClient
   document: TripDocumentV1
   ownerId: string
+}
+
+export interface EnsureWebOwnerDocumentKeyForSnapshotInput {
+  supabase: SupabaseClient
+  documentId: string
+  ownerId: string
+  documentType: BackupDocumentType
+  schemaVersion: number
+  snapshotPayload: Uint8Array
 }
 
 export interface EnsureWebDocumentKeyReadinessInput {
@@ -156,45 +166,58 @@ export async function bootstrapWebDeviceDocumentKey(
 export async function ensureWebOwnerDocumentKey(
   input: EnsureWebOwnerDocumentKeyInput,
 ): Promise<void> {
+  const snapshotPayload = encodeTripDocumentUpdate(createYjsTripDocument(input.document))
+  return ensureWebOwnerDocumentKeyForSnapshot({
+    supabase: input.supabase,
+    documentId: input.document.trip.id,
+    ownerId: input.ownerId,
+    documentType: 'trip',
+    schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+    snapshotPayload,
+  })
+}
+
+export async function ensureWebOwnerDocumentKeyForSnapshot(
+  input: EnsureWebOwnerDocumentKeyForSnapshotInput,
+): Promise<void> {
   const repository = createSupabaseBackupRepository(input.supabase)
   const { deviceId } = await ensureWebDeviceKeyMaterial(input.supabase)
   const activeKey = await repository.getMyActiveDocumentKey({
-    documentId: input.document.trip.id,
+    documentId: input.documentId,
     deviceId,
     keyVersion: KEY_MATERIAL_VERSION,
   })
   if (activeKey?.wrappingAlg === 'RSA-OAEP-256') return
 
-  const hasRemoteBackupPayload = await documentHasRemoteBackupPayload(input.supabase, input.document.trip.id)
-  if (hasRemoteBackupPayload && await documentHasAnyActiveKey(input.supabase, input.document.trip.id)) {
+  const hasRemoteBackupPayload = await documentHasRemoteBackupPayload(input.supabase, input.documentId)
+  if (hasRemoteBackupPayload && await documentHasAnyActiveKey(input.supabase, input.documentId)) {
     throw new Error('owner_device_key_unavailable')
   }
 
   const provider = getWebBackupCryptoProvider()
-  const snapshotPayload = encodeTripDocumentUpdate(createYjsTripDocument(input.document))
   const documentKey = await generateDocumentEncryptionKey(provider)
   const encryptedPayload = await encryptBackupPayload(provider, {
-    plaintext: snapshotPayload,
+    plaintext: input.snapshotPayload,
     key: documentKey,
     keyVersion: KEY_MATERIAL_VERSION,
   })
 
   await repository.upsertSnapshot({
-    documentId: input.document.trip.id,
+    documentId: input.documentId,
     ownerId: input.ownerId,
-    type: 'trip',
-    schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+    type: input.documentType,
+    schemaVersion: input.schemaVersion,
     snapshot: serializeEncryptedBackupPayload(encryptedPayload),
-    snapshotHash: await sha256Hex(snapshotPayload),
+    snapshotHash: await sha256Hex(input.snapshotPayload),
     encrypted: true,
   })
   await repository.upsertOwnerMember({
-    documentId: input.document.trip.id,
+    documentId: input.documentId,
     userId: input.ownerId,
   })
   await bootstrapWebDeviceDocumentKey({
     supabase: input.supabase,
-    documentId: input.document.trip.id,
+    documentId: input.documentId,
     documentKey,
   })
 }

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -101,7 +101,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-036-closed-beta-readiness.md` | 완료 | Closed Beta go/no-go gate, secret inventory, deployment rollback, tester 운영 runbook, Issue #330, PR #331 |
 | `TASK-037-web-document-primary-key-bootstrap-and-photo-storage.md` | 완료 | Web document-primary key bootstrap, backup restore/status, place photo storage 호환성 보완, Issue #334, PR #335 |
 | `TASK-038-closed-beta-baseline-reset-plan.md` | 완료 | 기존 데이터 자동 보존 전제를 제거하고 Closed Beta 기준선을 신규 document-primary 데이터로 재정의 |
-| `TASK-039-new-document-bootstrap.md` | 예정 | 신규 여행/템플릿 생성 시 local document + encrypted snapshot + owner key bootstrap |
+| `TASK-039-new-document-bootstrap.md` | 완료 | 신규 여행/템플릿 생성 시 local document + encrypted snapshot + owner key bootstrap, Issue #337 |
 | `TASK-040-document-primary-product-path-cutover.md` | 예정 | 여행/일정/준비물/템플릿 제품 경로에서 legacy hydrate/fallback 제거 |
 | `TASK-041-backup-freshness-and-cost-control.md` | 예정 | local-first freshness, trigger 기반 backup pull/upload, Supabase 비용 최소화 |
 | `TASK-042-legacy-migration-tool.md` | 예정 | 기존 row 데이터를 명시적으로 document-primary로 전환하는 후속 도구 |

--- a/docs/refactor/tasks/TASK-039-new-document-bootstrap.md
+++ b/docs/refactor/tasks/TASK-039-new-document-bootstrap.md
@@ -1,5 +1,8 @@
 # TASK-039: New Document Bootstrap
 
+- 상태: 완료
+- GitHub Issue: #337
+
 ## 목적
 
 신규 여행과 템플릿을 처음부터 document-primary 기준으로 생성한다. 생성 시점에 local document, encrypted initial
@@ -36,11 +39,11 @@ snapshot, owner membership, current device document key를 함께 준비해 `key
 
 ## 구현 단계
 
-1. 신규 `TripDocumentV1` 생성 helper를 owner/device bootstrap과 묶는다.
-2. Web 신규 여행 생성이 legacy `trips` write를 primary로 사용하지 않도록 전환한다.
-3. Mobile 신규 여행 생성도 같은 bootstrap contract를 사용한다.
-4. 신규 `TemplateDocumentV1` 생성 경로를 동일한 기준으로 전환한다.
-5. 생성 직후 local read, backup restore, 다른 기기 restore smoke를 검증한다.
+1. 신규 `TripDocumentV1` 생성 helper를 owner/device bootstrap과 묶는다. ✅
+2. Web 신규 여행 생성이 legacy `trips` write를 primary로 사용하지 않도록 전환한다. ✅
+3. Mobile 신규 여행 생성도 같은 bootstrap contract를 사용한다. ✅
+4. 신규 `TemplateDocumentV1` 생성 경로를 동일한 기준으로 전환한다. ✅
+5. 생성 직후 local read, backup restore, 다른 기기 restore smoke를 검증한다. ✅
 
 ## 데이터 호환성 고려사항
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,54 @@
+# Walkthrough: TASK-039 New Document Bootstrap
+
+## Summary
+
+TASK-039는 신규 여행과 신규 템플릿 생성 경로를 document-primary bootstrap으로 전환했다. 생성 화면은 더 이상
+legacy row insert를 primary write로 사용하지 않고, local document 저장과 encrypted initial snapshot,
+owner `document_members`, current device `document_keys` bootstrap을 생성 완료 조건으로 사용한다.
+
+현재 상세/목록 화면 중 일부가 아직 `trips` row read model에 의존하므로, 신규 여행 생성 시에는 같은 id로
+최소 `trips` row를 비권위 read model로 upsert한다. 이 row는 TASK-040 product path cutover에서 제거할
+호환 계층이며, 실제 생성 기준은 document snapshot/key다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-039-new-document-bootstrap.md`
+- GitHub Issue [#337](https://github.com/ysjee141/nexvoy-frontend/issues/337)
+- 브랜치: `feature/task-039-new-document-bootstrap`
+- `apps/web/app/trips/new/page.tsx`
+- `apps/mobile/app/trip/new.tsx`
+- `apps/web/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/mobile/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/web/lib/local-first/keyProvisioningService.ts`
+- `apps/mobile/lib/local-first/documentBootstrapService.ts`
+
+## Key Changes
+
+- Web 신규 여행 생성이 `createWebTripDocument()`를 통해 `TripDocumentV1` local document를 만들고,
+  같은 Yjs initial update를 encrypted snapshot으로 bootstrap한다.
+- Mobile 신규 여행 생성이 `createMobileTripDocument()`를 통해 동일한 document-primary contract를 사용한다.
+- Web/Mobile 템플릿 생성 helper가 local 저장만 하던 상태에서 encrypted snapshot, owner member, current device key
+  bootstrap까지 수행하도록 보강했다.
+- Web owner key bootstrap을 trip 전용 document 입력에서 generic snapshot payload 입력도 받을 수 있게 확장했다.
+- Mobile owner key bootstrap도 실제 snapshot payload를 받아 trip/template initial snapshot을 같은 경로로 암호화한다.
+- 기존 화면 호환을 위해 신규 trip에 한해 `trips` row를 비권위 read model로 upsert한다.
+
+## Verification
+
+| 명령 | 결과 |
+| --- | --- |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm -C packages/core typecheck` | PASS |
+| `pnpm -C apps/mobile typecheck` | PASS |
+| `pnpm -C apps/web exec tsc --noEmit` | PASS |
+| `pnpm build` | PASS |
+| `pnpm build:mobile` | PASS, 기존 `react-native-webrtc`/`event-target-shim` export warning만 발생 |
+
+## Follow-up
+
+- TASK-040에서 여행/일정/준비물/템플릿 제품 경로의 legacy hydrate/fallback과 `trips` row read model 의존을 제거한다.
+- TASK-041에서 신규 document backup freshness와 비용 최소화 trigger 정책을 정리한다.
+
 # Walkthrough: TASK-037 Web Document-Primary Key Bootstrap and Photo Storage
 
 ## Summary


### PR DESCRIPTION
## Summary
- Route Web/Mobile new trip creation through document-primary bootstrap helpers instead of legacy row-primary creation.
- Bootstrap new trip/template initial Yjs updates as encrypted Supabase snapshots with owner member and current device document key rows.
- Keep a temporary non-authoritative trips read-model upsert for current detail/list compatibility until TASK-040 removes row-path dependencies.

## Verification
- pnpm --filter @nexvoy/core test
- pnpm -C packages/core typecheck
- pnpm -C apps/mobile typecheck
- pnpm -C apps/web exec tsc --noEmit
- pnpm build
- pnpm build:mobile

Note: root pnpm typecheck still exits through the repo's TypeScript compiler environment issue, so package-level typechecks were run explicitly.

Resolves #337