### PR TITLE
feat(TASK-040): cut over document-primary product reads

### DIFF
--- a/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
@@ -1,10 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import { subtle } from 'react-native-quick-crypto'
 import {
-  convertLegacyTripRowsToDocument,
   createEmptyTripDocumentV1,
   createDocumentPrimaryRepositoryBundle,
   createEmptyTemplateDocumentV1,
-  getLegacyTripRowBundle,
   shouldBootstrapDocumentRegistry,
   type DocumentMutationResult,
   type TemplateDocumentV1,
@@ -14,18 +13,30 @@ import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepo
 import { TRIP_DOCUMENT_SCHEMA_VERSION, type EntityId } from '@nexvoy/core/local-first/documentModel'
 import { createYjsTripDocument, encodeTripDocumentUpdate } from '@nexvoy/core/local-first/yjsTripDocument'
 import {
+  applyTemplateDocumentUpdate,
   TEMPLATE_DOCUMENT_SCHEMA_VERSION,
   createYjsTemplateDocument,
   encodeTemplateDocumentUpdate,
+  readTemplateDocumentFromYjs,
 } from '@nexvoy/core/local-first/templateDocument'
 import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
+import { decryptRestoreSnapshot } from '@nexvoy/core/sync/mobileRestore'
 import { publishLocalMobileTripDocumentUpdate } from './p2pUpdateBridge'
 import {
   createMobileTemplateDocumentStore,
   createMobileTripDocumentStore,
 } from './mobileDocumentStores'
 import { enqueueMobileBackupUpdate } from './mobileBackupSyncService'
-import { ensureMobileOwnerDocumentKeyForSnapshot } from './documentBootstrapService'
+import { ensureMobileOwnerDocumentKeyForSnapshot, getMobileBackupCryptoProvider } from './documentBootstrapService'
+import { getOrCreateMobileDeviceId } from './mobileDeviceIdentity'
+import { getCurrentMobileDocumentKey } from './keyProvisioningService'
+import { restoreMobileEncryptedSnapshot } from './mobileSnapshotRestoreService'
+import {
+  applyMobileTripDocumentUpdateToDoc,
+  createMobileYjsTripDocument,
+  loadMobileTripDocumentUpdate,
+  readTripDocumentFromMobileYjs,
+} from './mobileYjsTripDocument'
 
 export async function createMobileDocumentPrimaryRepositories(
   supabase: SupabaseClient,
@@ -44,13 +55,13 @@ export async function createMobileDocumentPrimaryRepositories(
 
   const tripStore = createMobileTripDocumentStore({
     hydrateDocument: async (tripId) => {
-      const bundle = await getLegacyTripRowBundle(supabase, tripId, data.user?.id ?? null)
-      return bundle ? convertLegacyTripRowsToDocument(bundle).document : null
+      return restoreMobileTripDocumentFromBackup(supabase, tripId)
     },
+    listRemoteDocumentIds: () => listRemoteDocumentIds(supabase, 'trip'),
   })
   const templateStore = createMobileTemplateDocumentStore({
-    hydrateDocument: (templateId) => hydrateTemplateDocument(supabase, templateId),
-    listLegacyDocumentIds: () => listLegacyTemplateIds(supabase, data.user?.id ?? null),
+    hydrateDocument: (templateId) => restoreMobileTemplateDocumentFromBackup(supabase, templateId),
+    listRemoteDocumentIds: () => listRemoteDocumentIds(supabase, 'template'),
   })
 
   return createDocumentPrimaryRepositoryBundle({
@@ -210,100 +221,60 @@ export async function createMobileTemplateDocument(input: {
   return templateId
 }
 
-async function listLegacyTemplateIds(
+async function listRemoteDocumentIds(
   supabase: SupabaseClient,
-  currentUserId: string | null,
+  type: 'trip' | 'template',
 ): Promise<EntityId[]> {
-  if (!currentUserId) return []
-  const owned = supabase
-    .from('checklist_templates')
+  const { data, error } = await supabase
+    .from('documents')
     .select('id')
-    .eq('user_id', currentUserId)
-  const publicTemplates = supabase
-    .from('checklist_templates')
-    .select('id')
-    .is('user_id', null)
-  const shared = supabase
-    .from('checklist_template_shares')
-    .select('template_id')
-    .eq('shared_with_user_id', currentUserId)
-
-  const [ownedResult, publicResult, sharedResult] = await Promise.all([owned, publicTemplates, shared])
-  if (ownedResult.error) throw ownedResult.error
-  if (publicResult.error) throw publicResult.error
-  if (sharedResult.error) throw sharedResult.error
-
-  return Array.from(new Set([
-    ...(ownedResult.data ?? []).map((row) => row.id),
-    ...(publicResult.data ?? []).map((row) => row.id),
-    ...(sharedResult.data ?? []).map((row) => row.template_id),
-  ]))
+    .eq('type', type)
+    .order('updated_at', { ascending: false })
+  if (error) throw error
+  return (data ?? []).map((row) => row.id)
 }
 
-async function hydrateTemplateDocument(
+async function restoreMobileTripDocumentFromBackup(
+  supabase: SupabaseClient,
+  documentId: EntityId,
+): Promise<TripDocumentV1 | null> {
+  const outcome = await restoreMobileEncryptedSnapshot({ supabase, documentId })
+  if (outcome.status !== 'restored') return null
+
+  const update = await loadMobileTripDocumentUpdate({ documentId })
+  if (!update) return null
+
+  const doc = createMobileYjsTripDocument()
+  applyMobileTripDocumentUpdateToDoc(doc, update)
+  return readTripDocumentFromMobileYjs(doc)
+}
+
+async function restoreMobileTemplateDocumentFromBackup(
   supabase: SupabaseClient,
   templateId: EntityId,
 ): Promise<TemplateDocumentV1 | null> {
-  const { data: template, error: templateError } = await supabase
-    .from('checklist_templates')
-    .select('id, user_id, title, created_at')
-    .eq('id', templateId)
-    .maybeSingle()
-  if (templateError) throw templateError
-  if (!template) return null
+  const repository = createSupabaseBackupRepository(supabase)
+  const snapshot = await repository.getLatestSnapshot(templateId)
+  if (!snapshot) return null
 
-  const [itemsResult, sharesResult] = await Promise.all([
-    supabase
-      .from('checklist_template_items')
-      .select('id, template_id, item_name, category, is_private, created_at')
-      .eq('template_id', templateId),
-    supabase
-      .from('checklist_template_shares')
-      .select('id, template_id, shared_with_user_id, role, created_by, created_at')
-      .eq('template_id', templateId),
-  ])
-  if (itemsResult.error) throw itemsResult.error
-  if (sharesResult.error) throw sharesResult.error
-
-  const createdAt = template.created_at ?? new Date().toISOString()
-  const document = createEmptyTemplateDocumentV1({
-    id: template.id,
-    ownerId: template.user_id,
-    title: template.title,
-    visibility: (sharesResult.data?.length ?? 0) > 0 ? 'shared' : 'private',
-    createdAt,
-    updatedAt: createdAt,
-    createdFromLegacyAt: new Date().toISOString(),
+  const documentKey = await getCurrentMobileDocumentKey({
+    supabase,
+    documentId: templateId,
+    deviceId: await getOrCreateMobileDeviceId(),
   })
+  if (!documentKey) return null
 
-  ;(itemsResult.data ?? []).forEach((item, index) => {
-    const itemCreatedAt = item.created_at ?? createdAt
-    document.items[item.id] = {
-      id: item.id,
-      templateId,
-      name: item.item_name,
-      categoryName: item.category ?? '기타',
-      isPrivate: item.is_private ?? false,
-      sortOrder: index,
-      createdAt: itemCreatedAt,
-      updatedAt: itemCreatedAt,
-    }
+  const result = await decryptRestoreSnapshot({
+    provider: getMobileBackupCryptoProvider(),
+    snapshot,
+    key: documentKey,
+    hash: sha256Hex,
   })
+  if (result.kind !== 'opaque') return null
 
-  ;(sharesResult.data ?? []).forEach((share) => {
-    const shareCreatedAt = share.created_at ?? createdAt
-    document.shares[share.id] = {
-      id: share.id,
-      templateId,
-      sharedWithUserId: share.shared_with_user_id,
-      role: share.role === 'editor' ? 'editor' : 'viewer',
-      createdBy: share.created_by,
-      createdAt: shareCreatedAt,
-      updatedAt: null,
-    }
-  })
-
-  return document
+  const doc = createYjsTemplateDocument()
+  applyTemplateDocumentUpdate(doc, result.plaintext)
+  return readTemplateDocumentFromYjs(doc)
 }
 
 export type MobileDocumentPrimaryMutationResult =
@@ -338,4 +309,14 @@ async function upsertTripReadModel(
       children_count: input.childrenCount,
     })
   if (error) throw error
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const buffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(buffer).set(bytes)
+  const digest = await (subtle as unknown as Pick<SubtleCrypto, 'digest'>).digest(
+    'SHA-256',
+    buffer,
+  )
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('')
 }

--- a/apps/mobile/lib/local-first/mobileDocumentStores.ts
+++ b/apps/mobile/lib/local-first/mobileDocumentStores.ts
@@ -28,9 +28,14 @@ const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012
 
 export function createMobileTripDocumentStore(options: {
   hydrateDocument?: (documentId: EntityId) => Promise<TripDocumentV1 | null>
+  listRemoteDocumentIds?: () => Promise<EntityId[]>
 } = {}): LocalDocumentStore<TripDocumentV1> {
   return {
-    listDocumentIds: async () => listDocumentIds(TRIP_UPDATE_PREFIX),
+    listDocumentIds: async () => {
+      const localIds = await listDocumentIds(TRIP_UPDATE_PREFIX)
+      const remoteIds = await options.listRemoteDocumentIds?.() ?? []
+      return Array.from(new Set([...localIds, ...remoteIds]))
+    },
     getDocument: async (documentId) => {
       const update = await loadDocumentUpdate(TRIP_UPDATE_PREFIX, documentId)
       if (!update) {
@@ -56,13 +61,13 @@ export function createMobileTripDocumentStore(options: {
 
 export function createMobileTemplateDocumentStore(options: {
   hydrateDocument?: (documentId: EntityId) => Promise<TemplateDocumentV1 | null>
-  listLegacyDocumentIds?: () => Promise<EntityId[]>
+  listRemoteDocumentIds?: () => Promise<EntityId[]>
 } = {}): LocalDocumentStore<TemplateDocumentV1> {
   return {
     listDocumentIds: async () => {
       const localIds = await listDocumentIds(TEMPLATE_UPDATE_PREFIX)
-      const legacyIds = await options.listLegacyDocumentIds?.() ?? []
-      return Array.from(new Set([...localIds, ...legacyIds]))
+      const remoteIds = await options.listRemoteDocumentIds?.() ?? []
+      return Array.from(new Set([...localIds, ...remoteIds]))
     },
     getDocument: async (documentId) => {
       const update = await loadDocumentUpdate(TEMPLATE_UPDATE_PREFIX, documentId)

--- a/apps/web/lib/local-first/backupRestoreService.ts
+++ b/apps/web/lib/local-first/backupRestoreService.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { TripDocumentV1 } from '@nexvoy/core/local-first/documentModel'
-import { restoreTripDocumentFromBackup } from '@nexvoy/core/sync/restore'
+import type { TemplateDocumentV1 } from '@nexvoy/core/local-first/templateDocument'
+import { restoreTemplateDocumentFromBackup, restoreTripDocumentFromBackup } from '@nexvoy/core/sync/restore'
 import { BackupCryptoError } from '@nexvoy/core/sync/backupTypes'
 import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
 import { getCurrentWebDocumentKeyOrRecoverStaleDeviceKey, getOrCreateWebDeviceId } from './keyProvisioningService'
@@ -15,6 +16,12 @@ export type WebBackupRestoreStatus =
 export interface WebBackupRestoreResult {
   status: WebBackupRestoreStatus
   document: TripDocumentV1 | null
+  reason?: string
+}
+
+export interface WebTemplateBackupRestoreResult {
+  status: WebBackupRestoreStatus
+  document: TemplateDocumentV1 | null
   reason?: string
 }
 
@@ -44,6 +51,52 @@ export async function restoreWebTripDocumentFromBackup(input: {
   try {
     const plan = await repository.restore(input.documentId)
     const document = await restoreTripDocumentFromBackup({
+      provider: getWebBackupCryptoProvider(),
+      plan,
+      key: documentKey,
+      hash: sha256Hex,
+    })
+    return document
+      ? { status: 'restored', document }
+      : { status: 'missing', document: null }
+  } catch (error) {
+    if (error instanceof BackupCryptoError && error.code === 'restore_snapshot_missing') {
+      return { status: 'missing', document: null }
+    }
+    return {
+      status: 'failed',
+      document: null,
+      reason: error instanceof Error ? error.message : 'restore_failed',
+    }
+  }
+}
+
+export async function restoreWebTemplateDocumentFromBackup(input: {
+  supabase: SupabaseClient
+  documentId: string
+}): Promise<WebTemplateBackupRestoreResult> {
+  if (!(await hasActiveSession(input.supabase))) {
+    return { status: 'missing', document: null }
+  }
+
+  const repository = createSupabaseBackupRepository(input.supabase)
+  const snapshot = await repository.getLatestSnapshot(input.documentId)
+  if (!snapshot) {
+    return { status: 'missing', document: null }
+  }
+
+  const documentKey = await getCurrentWebDocumentKeyOrRecoverStaleDeviceKey({
+    supabase: input.supabase,
+    documentId: input.documentId,
+    deviceId: getOrCreateWebDeviceId(),
+  })
+  if (!documentKey) {
+    return { status: 'key_unavailable', document: null }
+  }
+
+  try {
+    const plan = await repository.restore(input.documentId)
+    const document = await restoreTemplateDocumentFromBackup({
       provider: getWebBackupCryptoProvider(),
       plan,
       key: documentKey,

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -1,10 +1,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import {
-  convertLegacyTripRowsToDocument,
   createEmptyTripDocumentV1,
   createDocumentPrimaryRepositoryBundle,
   createEmptyTemplateDocumentV1,
-  getLegacyTripRowBundle,
   shouldBootstrapDocumentRegistry,
   type DocumentMutationResult,
   type TemplateDocumentV1,
@@ -26,7 +24,7 @@ import {
   createWebTripDocumentStore,
 } from './webDocumentStores'
 import { enqueueWebBackupUpdate } from './backupSyncService'
-import { restoreWebTripDocumentFromBackup } from './backupRestoreService'
+import { restoreWebTemplateDocumentFromBackup, restoreWebTripDocumentFromBackup } from './backupRestoreService'
 import { ensureWebOwnerDocumentKey, ensureWebOwnerDocumentKeyForSnapshot } from './keyProvisioningService'
 
 export async function createWebDocumentPrimaryRepositories(
@@ -45,15 +43,16 @@ export async function createWebDocumentPrimaryRepositories(
   const tripStore = createWebTripDocumentStore(ownerContext, {
     hydrateDocument: async (tripId) => {
       const restored = await restoreWebTripDocumentFromBackup({ supabase, documentId: tripId })
-      if (restored.document) return restored.document
-
-      const bundle = await getLegacyTripRowBundle(supabase, tripId, ownerContext.authUserId)
-      return bundle ? convertLegacyTripRowsToDocument(bundle).document : null
+      return restored.document
     },
+    listRemoteDocumentIds: () => listRemoteDocumentIds(supabase, 'trip'),
   })
   const templateStore = createWebTemplateDocumentStore(ownerContext, {
-    hydrateDocument: (templateId) => hydrateTemplateDocument(supabase, templateId),
-    listLegacyDocumentIds: () => listLegacyTemplateIds(supabase, ownerContext.authUserId),
+    hydrateDocument: async (templateId) => {
+      const restored = await restoreWebTemplateDocumentFromBackup({ supabase, documentId: templateId })
+      return restored.document
+    },
+    listRemoteDocumentIds: () => listRemoteDocumentIds(supabase, 'template'),
   })
 
   return createDocumentPrimaryRepositoryBundle({
@@ -241,100 +240,17 @@ export async function createWebTemplateDocument(input: {
   return templateId
 }
 
-async function listLegacyTemplateIds(
+async function listRemoteDocumentIds(
   supabase: SupabaseClient,
-  currentUserId: string | null,
+  type: 'trip' | 'template',
 ): Promise<EntityId[]> {
-  if (!currentUserId) return []
-  const owned = supabase
-    .from('checklist_templates')
+  const { data, error } = await supabase
+    .from('documents')
     .select('id')
-    .eq('user_id', currentUserId)
-  const publicTemplates = supabase
-    .from('checklist_templates')
-    .select('id')
-    .is('user_id', null)
-  const shared = supabase
-    .from('checklist_template_shares')
-    .select('template_id')
-    .eq('shared_with_user_id', currentUserId)
-
-  const [ownedResult, publicResult, sharedResult] = await Promise.all([owned, publicTemplates, shared])
-  if (ownedResult.error) throw ownedResult.error
-  if (publicResult.error) throw publicResult.error
-  if (sharedResult.error) throw sharedResult.error
-
-  return Array.from(new Set([
-    ...(ownedResult.data ?? []).map((row) => row.id),
-    ...(publicResult.data ?? []).map((row) => row.id),
-    ...(sharedResult.data ?? []).map((row) => row.template_id),
-  ]))
-}
-
-async function hydrateTemplateDocument(
-  supabase: SupabaseClient,
-  templateId: EntityId,
-): Promise<TemplateDocumentV1 | null> {
-  const { data: template, error: templateError } = await supabase
-    .from('checklist_templates')
-    .select('id, user_id, title, created_at')
-    .eq('id', templateId)
-    .maybeSingle()
-  if (templateError) throw templateError
-  if (!template) return null
-
-  const [itemsResult, sharesResult] = await Promise.all([
-    supabase
-      .from('checklist_template_items')
-      .select('id, template_id, item_name, category, is_private, created_at')
-      .eq('template_id', templateId),
-    supabase
-      .from('checklist_template_shares')
-      .select('id, template_id, shared_with_user_id, role, created_by, created_at')
-      .eq('template_id', templateId),
-  ])
-  if (itemsResult.error) throw itemsResult.error
-  if (sharesResult.error) throw sharesResult.error
-
-  const createdAt = template.created_at ?? new Date().toISOString()
-  const document = createEmptyTemplateDocumentV1({
-    id: template.id,
-    ownerId: template.user_id,
-    title: template.title,
-    visibility: (sharesResult.data?.length ?? 0) > 0 ? 'shared' : 'private',
-    createdAt,
-    updatedAt: createdAt,
-    createdFromLegacyAt: new Date().toISOString(),
-  })
-
-  ;(itemsResult.data ?? []).forEach((item, index) => {
-    const itemCreatedAt = item.created_at ?? createdAt
-    document.items[item.id] = {
-      id: item.id,
-      templateId,
-      name: item.item_name,
-      categoryName: item.category ?? '기타',
-      isPrivate: item.is_private ?? false,
-      sortOrder: index,
-      createdAt: itemCreatedAt,
-      updatedAt: itemCreatedAt,
-    }
-  })
-
-  ;(sharesResult.data ?? []).forEach((share) => {
-    const shareCreatedAt = share.created_at ?? createdAt
-    document.shares[share.id] = {
-      id: share.id,
-      templateId,
-      sharedWithUserId: share.shared_with_user_id,
-      role: share.role === 'editor' ? 'editor' : 'viewer',
-      createdBy: share.created_by,
-      createdAt: shareCreatedAt,
-      updatedAt: null,
-    }
-  })
-
-  return document
+    .eq('type', type)
+    .order('updated_at', { ascending: false })
+  if (error) throw error
+  return (data ?? []).map((row) => row.id)
 }
 
 export type WebDocumentPrimaryMutationResult =

--- a/apps/web/lib/local-first/webDocumentStores.ts
+++ b/apps/web/lib/local-first/webDocumentStores.ts
@@ -33,7 +33,7 @@ export function createWebTripDocumentStore(
   ownerContext: WebOwnerContext,
   options: {
     hydrateDocument?: (documentId: EntityId) => Promise<TripDocumentV1 | null>
-    listLegacyDocumentIds?: () => Promise<EntityId[]>
+    listRemoteDocumentIds?: () => Promise<EntityId[]>
   } = {},
 ): LocalDocumentStore<TripDocumentV1> {
   return {
@@ -42,8 +42,8 @@ export function createWebTripDocumentStore(
       const localIds = rows
         .map((row) => row.documentId)
         .filter((documentId): documentId is string => Boolean(documentId))
-      const legacyIds = await options.listLegacyDocumentIds?.() ?? []
-      return Array.from(new Set([...localIds, ...legacyIds]))
+      const remoteIds = await options.listRemoteDocumentIds?.() ?? []
+      return Array.from(new Set([...localIds, ...remoteIds]))
     },
     getDocument: async (documentId) => {
       const update = await loadTripDocumentUpdate({
@@ -75,7 +75,7 @@ export function createWebTemplateDocumentStore(
   ownerContext: WebOwnerContext,
   options: {
     hydrateDocument?: (documentId: EntityId) => Promise<TemplateDocumentV1 | null>
-    listLegacyDocumentIds?: () => Promise<EntityId[]>
+    listRemoteDocumentIds?: () => Promise<EntityId[]>
   } = {},
 ): LocalDocumentStore<TemplateDocumentV1> {
   const namespace = getTemplateNamespace(ownerContext)
@@ -85,8 +85,8 @@ export function createWebTemplateDocumentStore(
       const localIds = rows
         .map((row) => row.documentId)
         .filter((documentId): documentId is string => Boolean(documentId))
-      const legacyIds = await options.listLegacyDocumentIds?.() ?? []
-      return Array.from(new Set([...localIds, ...legacyIds]))
+      const remoteIds = await options.listRemoteDocumentIds?.() ?? []
+      return Array.from(new Set([...localIds, ...remoteIds]))
     },
     getDocument: async (documentId) => {
       const update = await loadTripDocumentUpdate({ namespace, documentId })

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -102,7 +102,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-037-web-document-primary-key-bootstrap-and-photo-storage.md` | 완료 | Web document-primary key bootstrap, backup restore/status, place photo storage 호환성 보완, Issue #334, PR #335 |
 | `TASK-038-closed-beta-baseline-reset-plan.md` | 완료 | 기존 데이터 자동 보존 전제를 제거하고 Closed Beta 기준선을 신규 document-primary 데이터로 재정의 |
 | `TASK-039-new-document-bootstrap.md` | 완료 | 신규 여행/템플릿 생성 시 local document + encrypted snapshot + owner key bootstrap, Issue #337 |
-| `TASK-040-document-primary-product-path-cutover.md` | 예정 | 여행/일정/준비물/템플릿 제품 경로에서 legacy hydrate/fallback 제거 |
+| `TASK-040-document-primary-product-path-cutover.md` | 완료 | 여행/일정/준비물/템플릿 제품 경로에서 legacy hydrate/fallback 제거, Issue #339 |
 | `TASK-041-backup-freshness-and-cost-control.md` | 예정 | local-first freshness, trigger 기반 backup pull/upload, Supabase 비용 최소화 |
 | `TASK-042-legacy-migration-tool.md` | 예정 | 기존 row 데이터를 명시적으로 document-primary로 전환하는 후속 도구 |
 

--- a/docs/refactor/tasks/TASK-040-document-primary-product-path-cutover.md
+++ b/docs/refactor/tasks/TASK-040-document-primary-product-path-cutover.md
@@ -1,5 +1,8 @@
 # TASK-040: Document-Primary Product Path Cutover
 
+- 상태: 완료
+- GitHub Issue: #339
+
 ## 목적
 
 여행, 일정, 준비물, 템플릿 화면이 기존 row hydrate/fallback에 의존하지 않고 document-primary repository를
@@ -34,11 +37,11 @@
 
 ## 구현 단계
 
-1. 목록은 document registry/backup metadata 또는 local document list 기준으로 재정의한다.
-2. 상세/일정/준비물은 local document 없을 때 backup restore만 시도한다.
-3. legacy row hydrate fallback을 제품 경로에서 제거한다.
-4. 템플릿도 `TemplateDocumentV1` 기준으로 전환한다.
-5. 기존 row 데이터가 화면에 나타나지 않는지 확인한다.
+1. 목록은 document registry/backup metadata 또는 local document list 기준으로 재정의한다. ✅
+2. 상세/일정/준비물은 local document 없을 때 backup restore만 시도한다. ✅
+3. legacy row hydrate fallback을 제품 경로에서 제거한다. ✅
+4. 템플릿도 `TemplateDocumentV1` 기준으로 전환한다. ✅
+5. 기존 row 데이터가 화면에 나타나지 않는지 확인한다. ✅
 
 ## 데이터 호환성 고려사항
 

--- a/packages/core/src/sync/restore.ts
+++ b/packages/core/src/sync/restore.ts
@@ -4,6 +4,12 @@ import {
   readTripDocumentFromYjs,
 } from '../local-first/yjsTripDocument'
 import type { TripDocumentV1 } from '../local-first/documentModel'
+import {
+  applyTemplateDocumentUpdate,
+  createYjsTemplateDocument,
+  readTemplateDocumentFromYjs,
+  type TemplateDocumentV1,
+} from '../local-first/templateDocument'
 import type { DocumentEncryptionKey, BackupCryptoProvider } from './encryption'
 import { decryptBackupPayload } from './encryption'
 import type { RestorePlan } from './backupTypes'
@@ -13,6 +19,13 @@ import { deserializeEncryptedBackupPayload, serializeEncryptedBackupPayload } fr
 export { serializeEncryptedBackupPayload }
 
 export interface RestoreTripDocumentInput {
+  provider: BackupCryptoProvider
+  plan: RestorePlan
+  key: DocumentEncryptionKey
+  hash: (bytes: Uint8Array) => Promise<string> | string
+}
+
+export interface RestoreTemplateDocumentInput {
   provider: BackupCryptoProvider
   plan: RestorePlan
   key: DocumentEncryptionKey
@@ -35,6 +48,24 @@ export async function restoreTripDocumentFromBackup(
   }
 
   return readTripDocumentFromYjs(ydoc)
+}
+
+export async function restoreTemplateDocumentFromBackup(
+  input: RestoreTemplateDocumentInput,
+): Promise<TemplateDocumentV1 | null> {
+  const ydoc = createYjsTemplateDocument()
+  const snapshotUpdate = await decryptBackupRecord(input.provider, input.plan.snapshot.snapshot, input.key)
+
+  await verifyBackupHash(snapshotUpdate, input.plan.snapshot.snapshotHash, input.hash)
+  applyTemplateDocumentUpdate(ydoc, snapshotUpdate)
+
+  for (const update of input.plan.updates) {
+    const decryptedUpdate = await decryptBackupRecord(input.provider, update.updateBlob, input.key)
+    await verifyBackupHash(decryptedUpdate, update.updateHash, input.hash)
+    applyTemplateDocumentUpdate(ydoc, decryptedUpdate)
+  }
+
+  return readTemplateDocumentFromYjs(ydoc)
 }
 
 async function decryptBackupRecord(

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,52 @@
+# Walkthrough: TASK-040 Document-Primary Product Path Cutover
+
+## Summary
+
+TASK-040은 Web/Mobile document-primary repository의 제품 read path에서 legacy row hydrate/fallback을 제거했다.
+이제 repository 목록은 local document id와 Supabase `documents` metadata id를 기준으로 구성하고, local document가
+없을 때는 encrypted backup restore만 시도한다. 기존 row-only 여행/템플릿은 document repository 목록/상세로
+자동 hydrate되지 않는다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-040-document-primary-product-path-cutover.md`
+- GitHub Issue [#339](https://github.com/ysjee141/nexvoy-frontend/issues/339)
+- 브랜치: `feature/task-040-document-primary-product-path-cutover`
+- `packages/core/src/sync/restore.ts`
+- `apps/web/lib/local-first/backupRestoreService.ts`
+- `apps/web/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/web/lib/local-first/webDocumentStores.ts`
+- `apps/mobile/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/mobile/lib/local-first/mobileDocumentStores.ts`
+
+## Key Changes
+
+- Web/Mobile document-primary repositories에서 `getLegacyTripRowBundle` 기반 trip hydrate를 제거했다.
+- Web/Mobile template repository에서 `checklist_templates`/`checklist_template_items` 기반 hydrate/list를 제거했다.
+- local document list에 Supabase `documents` metadata id를 병합해 다른 기기에서 생성된 신규 document-primary 문서를
+  목록 후보로 볼 수 있게 했다.
+- Web backup restore service에 `TemplateDocumentV1` restore를 추가했다.
+- core `restore.ts`에 template Yjs backup replay helper를 추가했다.
+- Mobile은 template snapshot을 복호화한 뒤 `TemplateDocumentV1`로 materialize하는 restore path를 추가했다.
+
+## Verification
+
+| 명령 | 결과 |
+| --- | --- |
+| `pnpm -C packages/core typecheck` | PASS |
+| `pnpm -C apps/web exec tsc --noEmit` | PASS |
+| `pnpm -C apps/mobile typecheck` | PASS |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm build` | PASS |
+| `pnpm build:mobile` | PASS, 기존 `react-native-webrtc`/`event-target-shim` export warning만 발생 |
+
+## Follow-up
+
+- TASK-041에서 backup update enqueue/freshness 정책을 정리한다. 특히 template mutation update backup은 이번 범위에서
+  생성 snapshot restore까지만 닫았고, 후속 freshness/update 정책에서 보강한다.
+- TASK-039의 신규 trip `trips` read model upsert는 일부 화면 호환용으로 남아 있다. 완전한 row read model 의존
+  제거는 별도 UI/layout 정리와 함께 다룬다.
+
 # Walkthrough: TASK-039 New Document Bootstrap
 
 ## Summary


### PR DESCRIPTION
## Summary
- Remove legacy row hydrate/list fallback from Web/Mobile document-primary product repositories.
- List product documents from local storage plus accessible Supabase documents metadata.
- Add encrypted backup restore for TemplateDocumentV1 on Web and snapshot materialization on Mobile.

## Verification
- pnpm -C packages/core typecheck
- pnpm -C apps/web exec tsc --noEmit
- pnpm -C apps/mobile typecheck
- pnpm --filter @nexvoy/core test
- pnpm build
- pnpm build:mobile

Notes:
- Mobile build still emits the known react-native-webrtc/event-target-shim export warning.
- Template mutation update backup remains a TASK-041 freshness/update policy follow-up; this PR closes product-path legacy hydrate/list fallback.

Resolves #339