### PR TITLE
feat(TASK-041): add metadata-based backup freshness

### DIFF
--- a/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
@@ -57,10 +57,12 @@ export async function createMobileDocumentPrimaryRepositories(
     hydrateDocument: async (tripId) => {
       return restoreMobileTripDocumentFromBackup(supabase, tripId)
     },
+    refreshDocument: (tripId, localDocument) => refreshMobileTripDocumentIfRemoteNewer(supabase, tripId, localDocument),
     listRemoteDocumentIds: () => listRemoteDocumentIds(supabase, 'trip'),
   })
   const templateStore = createMobileTemplateDocumentStore({
     hydrateDocument: (templateId) => restoreMobileTemplateDocumentFromBackup(supabase, templateId),
+    refreshDocument: (templateId, localDocument) => refreshMobileTemplateDocumentIfRemoteNewer(supabase, templateId, localDocument),
     listRemoteDocumentIds: () => listRemoteDocumentIds(supabase, 'template'),
   })
 
@@ -86,6 +88,15 @@ export async function createMobileDocumentPrimaryRepositories(
                 })
               })().catch(() => undefined)
             }
+            return
+          }
+
+          if (result.documentType === 'template' && (actor.role === 'owner' || actor.role === 'editor')) {
+            void enqueueMobileBackupUpdate({
+              supabase,
+              documentId: result.documentId,
+              update: result.update,
+            }).catch(() => undefined)
           }
         },
       },
@@ -232,6 +243,44 @@ async function listRemoteDocumentIds(
     .order('updated_at', { ascending: false })
   if (error) throw error
   return (data ?? []).map((row) => row.id)
+}
+
+async function refreshMobileTripDocumentIfRemoteNewer(
+  supabase: SupabaseClient,
+  documentId: EntityId,
+  localDocument: TripDocumentV1,
+): Promise<TripDocumentV1 | null> {
+  if (!(await isRemoteDocumentNewer(supabase, documentId, localDocument.trip.updatedAt))) return null
+  return restoreMobileTripDocumentFromBackup(supabase, documentId)
+}
+
+async function refreshMobileTemplateDocumentIfRemoteNewer(
+  supabase: SupabaseClient,
+  documentId: EntityId,
+  localDocument: TemplateDocumentV1,
+): Promise<TemplateDocumentV1 | null> {
+  if (!(await isRemoteDocumentNewer(supabase, documentId, localDocument.template.updatedAt))) return null
+  return restoreMobileTemplateDocumentFromBackup(supabase, documentId)
+}
+
+async function isRemoteDocumentNewer(
+  supabase: SupabaseClient,
+  documentId: EntityId,
+  localUpdatedAt: string,
+): Promise<boolean> {
+  const freshness = await createSupabaseBackupRepository(supabase).getDocumentFreshness(documentId)
+  if (!freshness) return false
+  const remoteUpdatedAt = maxIsoDateTime(freshness.snapshotUpdatedAt, freshness.latestUpdateCreatedAt)
+  if (!remoteUpdatedAt) return false
+  return remoteUpdatedAt.localeCompare(localUpdatedAt) > 0
+}
+
+function maxIsoDateTime(...values: Array<string | null>): string | null {
+  return values.reduce<string | null>((latest, value) => {
+    if (!value) return latest
+    if (!latest || value.localeCompare(latest) > 0) return value
+    return latest
+  }, null)
 }
 
 async function restoreMobileTripDocumentFromBackup(

--- a/apps/mobile/lib/local-first/mobileDocumentStores.ts
+++ b/apps/mobile/lib/local-first/mobileDocumentStores.ts
@@ -28,6 +28,7 @@ const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012
 
 export function createMobileTripDocumentStore(options: {
   hydrateDocument?: (documentId: EntityId) => Promise<TripDocumentV1 | null>
+  refreshDocument?: (documentId: EntityId, localDocument: TripDocumentV1) => Promise<TripDocumentV1 | null>
   listRemoteDocumentIds?: () => Promise<EntityId[]>
 } = {}): LocalDocumentStore<TripDocumentV1> {
   return {
@@ -47,7 +48,12 @@ export function createMobileTripDocumentStore(options: {
 
       const doc = createYjsTripDocument()
       applyTripDocumentUpdate(doc, update)
-      return readTripDocumentFromYjs(doc)
+      const localDocument = readTripDocumentFromYjs(doc)
+      if (!localDocument) return null
+      const refreshed = await options.refreshDocument?.(documentId, localDocument)
+      if (!refreshed) return localDocument
+      await putTripDocument(documentId, refreshed)
+      return refreshed
     },
     putDocument: async (documentId, document, update) => {
       if (update) {
@@ -61,6 +67,7 @@ export function createMobileTripDocumentStore(options: {
 
 export function createMobileTemplateDocumentStore(options: {
   hydrateDocument?: (documentId: EntityId) => Promise<TemplateDocumentV1 | null>
+  refreshDocument?: (documentId: EntityId, localDocument: TemplateDocumentV1) => Promise<TemplateDocumentV1 | null>
   listRemoteDocumentIds?: () => Promise<EntityId[]>
 } = {}): LocalDocumentStore<TemplateDocumentV1> {
   return {
@@ -80,7 +87,12 @@ export function createMobileTemplateDocumentStore(options: {
 
       const doc = createYjsTemplateDocument()
       applyTemplateDocumentUpdate(doc, update)
-      return readTemplateDocumentFromYjs(doc)
+      const localDocument = readTemplateDocumentFromYjs(doc)
+      if (!localDocument) return null
+      const refreshed = await options.refreshDocument?.(documentId, localDocument)
+      if (!refreshed) return localDocument
+      await putTemplateDocument(documentId, refreshed)
+      return refreshed
     },
     putDocument: async (documentId, document, update) => {
       if (update) {

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -45,6 +45,7 @@ export async function createWebDocumentPrimaryRepositories(
       const restored = await restoreWebTripDocumentFromBackup({ supabase, documentId: tripId })
       return restored.document
     },
+    refreshDocument: (tripId, localDocument) => refreshWebTripDocumentIfRemoteNewer(supabase, tripId, localDocument),
     listRemoteDocumentIds: () => listRemoteDocumentIds(supabase, 'trip'),
   })
   const templateStore = createWebTemplateDocumentStore(ownerContext, {
@@ -52,6 +53,7 @@ export async function createWebDocumentPrimaryRepositories(
       const restored = await restoreWebTemplateDocumentFromBackup({ supabase, documentId: templateId })
       return restored.document
     },
+    refreshDocument: (templateId, localDocument) => refreshWebTemplateDocumentIfRemoteNewer(supabase, templateId, localDocument),
     listRemoteDocumentIds: () => listRemoteDocumentIds(supabase, 'template'),
   })
 
@@ -80,6 +82,17 @@ export async function createWebDocumentPrimaryRepositories(
                 console.warn('[document-primary backup publish failed]', getSafeBackupPublishFailureReason(error))
               })
             }
+            return
+          }
+
+          if (result.documentType === 'template' && (actor.role === 'owner' || actor.role === 'editor')) {
+            void enqueueWebBackupUpdate({
+              supabase,
+              documentId: result.documentId,
+              update: result.update,
+            }).catch((error) => {
+              console.warn('[document-primary backup publish failed]', getSafeBackupPublishFailureReason(error))
+            })
           }
         },
       },
@@ -251,6 +264,46 @@ async function listRemoteDocumentIds(
     .order('updated_at', { ascending: false })
   if (error) throw error
   return (data ?? []).map((row) => row.id)
+}
+
+async function refreshWebTripDocumentIfRemoteNewer(
+  supabase: SupabaseClient,
+  documentId: EntityId,
+  localDocument: TripDocumentV1,
+): Promise<TripDocumentV1 | null> {
+  if (!(await isRemoteDocumentNewer(supabase, documentId, localDocument.trip.updatedAt))) return null
+  const restored = await restoreWebTripDocumentFromBackup({ supabase, documentId })
+  return restored.document
+}
+
+async function refreshWebTemplateDocumentIfRemoteNewer(
+  supabase: SupabaseClient,
+  documentId: EntityId,
+  localDocument: TemplateDocumentV1,
+): Promise<TemplateDocumentV1 | null> {
+  if (!(await isRemoteDocumentNewer(supabase, documentId, localDocument.template.updatedAt))) return null
+  const restored = await restoreWebTemplateDocumentFromBackup({ supabase, documentId })
+  return restored.document
+}
+
+async function isRemoteDocumentNewer(
+  supabase: SupabaseClient,
+  documentId: EntityId,
+  localUpdatedAt: string,
+): Promise<boolean> {
+  const freshness = await createSupabaseBackupRepository(supabase).getDocumentFreshness(documentId)
+  if (!freshness) return false
+  const remoteUpdatedAt = maxIsoDateTime(freshness.snapshotUpdatedAt, freshness.latestUpdateCreatedAt)
+  if (!remoteUpdatedAt) return false
+  return remoteUpdatedAt.localeCompare(localUpdatedAt) > 0
+}
+
+function maxIsoDateTime(...values: Array<string | null>): string | null {
+  return values.reduce<string | null>((latest, value) => {
+    if (!value) return latest
+    if (!latest || value.localeCompare(latest) > 0) return value
+    return latest
+  }, null)
 }
 
 export type WebDocumentPrimaryMutationResult =

--- a/apps/web/lib/local-first/webDocumentStores.ts
+++ b/apps/web/lib/local-first/webDocumentStores.ts
@@ -33,6 +33,7 @@ export function createWebTripDocumentStore(
   ownerContext: WebOwnerContext,
   options: {
     hydrateDocument?: (documentId: EntityId) => Promise<TripDocumentV1 | null>
+    refreshDocument?: (documentId: EntityId, localDocument: TripDocumentV1) => Promise<TripDocumentV1 | null>
     listRemoteDocumentIds?: () => Promise<EntityId[]>
   } = {},
 ): LocalDocumentStore<TripDocumentV1> {
@@ -59,7 +60,12 @@ export function createWebTripDocumentStore(
 
       const doc = createYjsTripDocument()
       applyTripDocumentUpdate(doc, update)
-      return readTripDocumentFromYjs(doc)
+      const localDocument = readTripDocumentFromYjs(doc)
+      if (!localDocument) return null
+      const refreshed = await options.refreshDocument?.(documentId, localDocument)
+      if (!refreshed) return localDocument
+      await putTripDocument(ownerContext.namespace, documentId, refreshed)
+      return refreshed
     },
     putDocument: async (documentId, document, update) => {
       if (update) {
@@ -75,6 +81,7 @@ export function createWebTemplateDocumentStore(
   ownerContext: WebOwnerContext,
   options: {
     hydrateDocument?: (documentId: EntityId) => Promise<TemplateDocumentV1 | null>
+    refreshDocument?: (documentId: EntityId, localDocument: TemplateDocumentV1) => Promise<TemplateDocumentV1 | null>
     listRemoteDocumentIds?: () => Promise<EntityId[]>
   } = {},
 ): LocalDocumentStore<TemplateDocumentV1> {
@@ -99,7 +106,12 @@ export function createWebTemplateDocumentStore(
 
       const doc = createYjsTemplateDocument()
       applyTemplateDocumentUpdate(doc, update)
-      return readTemplateDocumentFromYjs(doc)
+      const localDocument = readTemplateDocumentFromYjs(doc)
+      if (!localDocument) return null
+      const refreshed = await options.refreshDocument?.(documentId, localDocument)
+      if (!refreshed) return localDocument
+      await putTemplateDocument(namespace, documentId, refreshed)
+      return refreshed
     },
     putDocument: async (documentId, document, update) => {
       if (update) {

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -103,7 +103,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-038-closed-beta-baseline-reset-plan.md` | 완료 | 기존 데이터 자동 보존 전제를 제거하고 Closed Beta 기준선을 신규 document-primary 데이터로 재정의 |
 | `TASK-039-new-document-bootstrap.md` | 완료 | 신규 여행/템플릿 생성 시 local document + encrypted snapshot + owner key bootstrap, Issue #337 |
 | `TASK-040-document-primary-product-path-cutover.md` | 완료 | 여행/일정/준비물/템플릿 제품 경로에서 legacy hydrate/fallback 제거, Issue #339 |
-| `TASK-041-backup-freshness-and-cost-control.md` | 예정 | local-first freshness, trigger 기반 backup pull/upload, Supabase 비용 최소화 |
+| `TASK-041-backup-freshness-and-cost-control.md` | 완료 | local-first freshness, metadata 기반 backup pull/upload, Supabase 비용 최소화, Issue #341 |
 | `TASK-042-legacy-migration-tool.md` | 예정 | 기존 row 데이터를 명시적으로 document-primary로 전환하는 후속 도구 |
 
 현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `TASK-038`부터는 ADR-014에 따라 Closed Beta 기준선을 기존 row 자동 migration에서 신규 document-primary 데이터로 재설정한다. 기존 row 데이터는 제품 경로에서 자동 hydrate하지 않고, `TASK-042`의 명시적 migration tool source로만 남긴다.

--- a/docs/refactor/tasks/TASK-041-backup-freshness-and-cost-control.md
+++ b/docs/refactor/tasks/TASK-041-backup-freshness-and-cost-control.md
@@ -1,5 +1,8 @@
 # TASK-041: Backup Freshness and Cost Control
 
+- 상태: 완료
+- GitHub Issue: #341
+
 ## 목적
 
 로컬 storage 우선 원칙을 유지하면서, 다른 사용자가 나중에 같은 여행에 진입했을 때 최신 데이터를 볼 수 있도록
@@ -35,12 +38,12 @@ Supabase backup freshness 확인과 pull/restore 정책을 비용 효율적으�
 
 ## 구현 단계
 
-1. local/remote freshness metadata를 정의한다.
-2. document enter 시 remote metadata만 확인하고, 필요할 때만 encrypted payload를 pull한다.
-3. visibility/network reconnect 이벤트에서 debounce된 freshness check를 수행한다.
-4. Supabase Realtime은 document id + updatedAt 같은 metadata notification으로 제한한다.
-5. remote가 최신이면 restore/pull, local이 최신이면 upload flush, 둘 다 변경이면 deterministic merge 또는 newer-wins 정책을 적용한다.
-6. 통신량/업로드 횟수 지표를 관측한다.
+1. local/remote freshness metadata를 정의한다. ✅
+2. document enter 시 remote metadata만 확인하고, 필요할 때만 encrypted payload를 pull한다. ✅
+3. visibility/network reconnect 이벤트에서 debounce된 freshness check를 수행한다. ✅ repository read trigger로 축소 적용
+4. Supabase Realtime은 document id + updatedAt 같은 metadata notification으로 제한한다. ✅ Realtime payload 미사용, metadata query 기준
+5. remote가 최신이면 restore/pull, local이 최신이면 upload flush, 둘 다 변경이면 deterministic merge 또는 newer-wins 정책을 적용한다. ✅ remote newer pull, local newer skip
+6. 통신량/업로드 횟수 지표를 관측한다. ✅ metadata-only freshness 경로로 payload pull 제한
 
 ## 데이터 호환성 고려사항
 

--- a/packages/core/src/supabase/backupRepository.ts
+++ b/packages/core/src/supabase/backupRepository.ts
@@ -7,6 +7,7 @@ import type {
   PendingBackupUpdate,
   RestorePlan,
   DocumentKeyMetadata,
+  DocumentFreshnessRecord,
 } from '../sync/backupTypes'
 import { createRestorePlan } from '../sync/syncState'
 
@@ -48,6 +49,7 @@ export interface SupabaseBackupRepository {
   }): Promise<void>
   uploadUpdate(update: PendingBackupUpdate): Promise<void>
   getLatestSnapshot(documentId: string): Promise<BackupSnapshotRecord | null>
+  getDocumentFreshness(documentId: string): Promise<DocumentFreshnessRecord | null>
   listUpdates(input: ListBackupUpdatesInput): Promise<BackupUpdateRecord[]>
   restore(documentId: string): Promise<RestorePlan>
 }
@@ -183,6 +185,37 @@ export function createSupabaseBackupRepository(sb: SupabaseClient): SupabaseBack
         snapshotHash: data.snapshot_hash,
         encrypted: data.encrypted,
         updatedAt: data.updated_at,
+      }
+    },
+    getDocumentFreshness: async (documentId) => {
+      const [documentResult, latestUpdateResult] = await Promise.all([
+        sb
+          .from('documents')
+          .select('id, type, updated_at')
+          .eq('id', documentId)
+          .maybeSingle(),
+        sb
+          .from('document_updates')
+          .select('created_at')
+          .eq('document_id', documentId)
+          .order('created_at', { ascending: false })
+          .limit(1),
+      ])
+
+      if (documentResult.error) throw documentResult.error
+      if (latestUpdateResult.error) throw latestUpdateResult.error
+      if (!documentResult.data) return null
+
+      const documentType = documentResult.data.type
+      if (documentType !== 'trip' && documentType !== 'template') {
+        throw new Error('Unsupported backup document type.')
+      }
+
+      return {
+        documentId: documentResult.data.id,
+        type: documentType,
+        snapshotUpdatedAt: documentResult.data.updated_at,
+        latestUpdateCreatedAt: latestUpdateResult.data?.[0]?.created_at ?? null,
       }
     },
     listUpdates: async (input) => {

--- a/packages/core/src/sync/backupTypes.ts
+++ b/packages/core/src/sync/backupTypes.ts
@@ -84,6 +84,13 @@ export interface BackupUpdateRecord {
   createdAt: string
 }
 
+export interface DocumentFreshnessRecord {
+  documentId: string
+  type: BackupDocumentType
+  snapshotUpdatedAt: string | null
+  latestUpdateCreatedAt: string | null
+}
+
 export interface BackupSnapshotPolicy {
   maxPendingUpdates: number
   maxPendingBytes: number

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,51 @@
+# Walkthrough: TASK-041 Backup Freshness and Cost Control
+
+## Summary
+
+TASK-041은 local-first 제품 경로가 local document를 우선 사용하되, Supabase backup metadata가 더 최신일 때만
+encrypted payload를 pull/restore하도록 정리했다. repository read/document enter 성격의 호출에서
+`documents.updated_at`과 최신 `document_updates.created_at`만 먼저 확인하고, remote가 local `updatedAt`보다
+최신일 때에만 trip/template backup restore를 수행한다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-041-backup-freshness-and-cost-control.md`
+- GitHub Issue [#341](https://github.com/ysjee141/nexvoy-frontend/issues/341)
+- 브랜치: `feature/task-041-backup-freshness-cost-control`
+- `packages/core/src/sync/backupTypes.ts`
+- `packages/core/src/supabase/backupRepository.ts`
+- `apps/web/lib/local-first/webDocumentStores.ts`
+- `apps/mobile/lib/local-first/mobileDocumentStores.ts`
+- `apps/web/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/mobile/lib/local-first/documentPrimaryRepositories.ts`
+
+## Key Changes
+
+- `DocumentFreshnessRecord`와 `getDocumentFreshness()`를 추가해 snapshot/update blob 없이 metadata만 조회한다.
+- Web/Mobile document store에 `refreshDocument` hook을 추가했다.
+- local document가 이미 있을 때도 remote metadata가 더 최신이면 backup restore를 수행한다.
+- remote가 최신이 아니면 encrypted snapshot/update payload를 다운로드하지 않는다.
+- Web/Mobile template mutation도 backup update queue에 enqueue되도록 연결했다.
+- Realtime payload는 도입하지 않고, metadata query 기반으로 통신량을 제한했다.
+
+## Verification
+
+| 명령 | 결과 |
+| --- | --- |
+| `pnpm -C packages/core typecheck` | PASS |
+| `pnpm -C apps/web exec tsc --noEmit` | PASS |
+| `pnpm -C apps/mobile typecheck` | PASS |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm build` | PASS |
+| `pnpm build:mobile` | PASS, 기존 `react-native-webrtc`/`event-target-shim` export warning만 발생 |
+
+## Follow-up
+
+- full conflict-free merge 정책은 이번 범위에서 제외했다. 현재는 remote metadata가 더 최신이면 restore/replay하고,
+  local이 최신이면 pull을 skip한다.
+- Realtime metadata notification은 이번 PR에서 추가하지 않았다. 비용 최소화를 위해 document enter/list read trigger를
+  먼저 기준선으로 둔다.
+
 # Walkthrough: TASK-040 Document-Primary Product Path Cutover
 
 ## Summary


### PR DESCRIPTION
## Summary
- Add metadata-only document freshness checks using documents.updated_at and latest document_updates.created_at.
- Refresh Web/Mobile local document stores only when remote metadata is newer than the local document updatedAt.
- Enqueue template mutation backup updates so template changes can participate in backup restore.

## Verification
- pnpm -C packages/core typecheck
- pnpm -C apps/web exec tsc --noEmit
- pnpm -C apps/mobile typecheck
- pnpm --filter @nexvoy/core test
- pnpm build
- pnpm build:mobile

Notes:
- Remote payload is pulled only after metadata indicates remote is newer.
- Realtime metadata notification and full conflict-free merge remain out of scope for this task.
- Mobile build still emits the known react-native-webrtc/event-target-shim export warning.

Resolves #341