### PR TITLE
feat(TASK-042): add legacy document migration tool

### DIFF
--- a/apps/web/app/dev/legacy-migration/page.tsx
+++ b/apps/web/app/dev/legacy-migration/page.tsx
@@ -1,0 +1,251 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import {
+  dryRunLegacyMigration,
+  migrateLegacyDocument,
+  scanLegacyMigrationCandidates,
+  type LegacyMigrationCandidate,
+  type LegacyMigrationDryRunReport,
+  type LegacyMigrationResult,
+} from '@/lib/local-first/legacyMigrationService'
+
+export default function LegacyMigrationPage() {
+  const [candidates, setCandidates] = useState<LegacyMigrationCandidate[]>([])
+  const [selectedKey, setSelectedKey] = useState('')
+  const [report, setReport] = useState<LegacyMigrationDryRunReport | null>(null)
+  const [result, setResult] = useState<LegacyMigrationResult | null>(null)
+  const [log, setLog] = useState<string[]>([])
+  const [isBusy, setIsBusy] = useState(false)
+
+  const supabase = useMemo(() => createClient(), [])
+  const selected = candidates.find((candidate) => candidateKey(candidate) === selectedKey) ?? null
+  const selectedReportBlocked = report ? candidateKey(report) === selectedKey && report.blocked : false
+
+  useEffect(() => {
+    void handleScan()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function handleScan() {
+    setIsBusy(true)
+    setReport(null)
+    setResult(null)
+    try {
+      appendLog('scan started')
+      const nextCandidates = await scanLegacyMigrationCandidates(supabase)
+      setCandidates(nextCandidates)
+      setSelectedKey((current) => current || (nextCandidates[0] ? candidateKey(nextCandidates[0]) : ''))
+      appendLog(`scan completed: ${nextCandidates.length} candidates`)
+    } catch (error) {
+      appendLog(`scan failed: ${formatError(error)}`)
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  async function handleDryRun() {
+    if (!selected) return
+    setIsBusy(true)
+    setResult(null)
+    try {
+      appendLog(`dry-run started: ${selected.kind}:${selected.id}`)
+      const nextReport = await dryRunLegacyMigration(supabase, selected)
+      setReport(nextReport)
+      appendLog(`dry-run completed: ${formatCounts(nextReport.entityCounts)}`)
+    } catch (error) {
+      appendLog(`dry-run failed: ${formatError(error)}`)
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  async function handleMigrate() {
+    if (!selected || selected.existingDocument) return
+    setIsBusy(true)
+    try {
+      appendLog(`migration started: ${selected.kind}:${selected.id}`)
+      const nextResult = await migrateLegacyDocument(supabase, selected)
+      setResult(nextResult)
+      appendLog(`migration ${nextResult.status}: restore=${nextResult.restoreStatus}`)
+      await handleScan()
+    } catch (error) {
+      appendLog(`migration failed: ${formatError(error)}`)
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  function appendLog(line: string) {
+    setLog((prev) => [`${new Date().toLocaleTimeString()} ${line}`, ...prev].slice(0, 80))
+  }
+
+  return (
+    <main style={{ padding: 24, maxWidth: 1080, margin: '0 auto', fontFamily: 'system-ui, sans-serif' }}>
+      <h1 style={{ margin: '0 0 8px', fontSize: 28 }}>Legacy Document Migration</h1>
+      <p style={{ margin: '0 0 24px', color: '#4b5563' }}>
+        로그인된 사용자 소유의 레거시 여행/템플릿을 선택해 document-primary snapshot으로 전환합니다.
+      </p>
+
+      <section style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 340px', gap: 20 }}>
+        <div>
+          <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+            <button type="button" onClick={handleScan} disabled={isBusy} style={buttonStyle}>
+              Scan
+            </button>
+            <button type="button" onClick={handleDryRun} disabled={isBusy || !selected} style={buttonStyle}>
+              Dry Run
+            </button>
+            <button
+              type="button"
+              onClick={handleMigrate}
+              disabled={isBusy || !selected || selected.existingDocument || selectedReportBlocked}
+              style={primaryButtonStyle}
+            >
+              Migrate Selected
+            </button>
+          </div>
+
+          <div style={{ border: '1px solid #d1d5db', borderRadius: 8, overflow: 'hidden' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+              <thead style={{ background: '#f9fafb', textAlign: 'left' }}>
+                <tr>
+                  <th style={cellStyle}>선택</th>
+                  <th style={cellStyle}>종류</th>
+                  <th style={cellStyle}>이름</th>
+                  <th style={cellStyle}>상태</th>
+                  <th style={cellStyle}>요약</th>
+                </tr>
+              </thead>
+              <tbody>
+                {candidates.map((candidate) => (
+                  <tr key={candidateKey(candidate)} style={{ borderTop: '1px solid #e5e7eb' }}>
+                    <td style={cellStyle}>
+                      <input
+                        type="radio"
+                        name="candidate"
+                        checked={selectedKey === candidateKey(candidate)}
+                        onChange={() => setSelectedKey(candidateKey(candidate))}
+                      />
+                    </td>
+                    <td style={cellStyle}>{candidate.kind}</td>
+                    <td style={cellStyle}>
+                      <div style={{ fontWeight: 600 }}>{candidate.title}</div>
+                      <div style={{ color: '#6b7280', fontSize: 12 }}>{candidate.id}</div>
+                    </td>
+                    <td style={cellStyle}>
+                      {candidate.existingDocument ? 'already migrated' : 'row-only'}
+                    </td>
+                    <td style={cellStyle}>{formatCandidateDetails(candidate)}</td>
+                  </tr>
+                ))}
+                {candidates.length === 0 && (
+                  <tr>
+                    <td colSpan={5} style={{ ...cellStyle, color: '#6b7280' }}>
+                      후보가 없습니다.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <aside style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <section style={panelStyle}>
+            <h2 style={panelTitleStyle}>Report</h2>
+            {report ? (
+              <>
+                <div style={{ fontSize: 13, color: '#374151' }}>{formatCounts(report.entityCounts)}</div>
+                <div style={{ marginTop: 10, fontSize: 13 }}>
+                  validation: {report.validationMessages.length}
+                  {report.blocked ? ' (blocked)' : ''}
+                </div>
+                <ul style={{ paddingLeft: 18, margin: '8px 0 0', fontSize: 12, color: '#4b5563' }}>
+                  {report.validationMessages.slice(0, 8).map((message) => (
+                    <li key={`${message.code}:${message.rowId ?? ''}`}>{message.code}</li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <div style={{ fontSize: 13, color: '#6b7280' }}>Dry Run 결과가 여기에 표시됩니다.</div>
+            )}
+          </section>
+
+          <section style={panelStyle}>
+            <h2 style={panelTitleStyle}>Result</h2>
+            {result ? (
+              <div style={{ fontSize: 13, color: '#374151' }}>
+                status={result.status}
+                <br />
+                restore={result.restoreStatus}
+              </div>
+            ) : (
+              <div style={{ fontSize: 13, color: '#6b7280' }}>Migration 결과가 여기에 표시됩니다.</div>
+            )}
+          </section>
+
+          <section style={panelStyle}>
+            <h2 style={panelTitleStyle}>Log</h2>
+            <pre style={{ margin: 0, whiteSpace: 'pre-wrap', fontSize: 12, color: '#111827' }}>
+              {log.join('\n')}
+            </pre>
+          </section>
+        </aside>
+      </section>
+    </main>
+  )
+}
+
+function candidateKey(candidate: Pick<LegacyMigrationCandidate, 'kind' | 'id'>): string {
+  return `${candidate.kind}:${candidate.id}`
+}
+
+function formatCandidateDetails(candidate: LegacyMigrationCandidate): string {
+  return Object.entries(candidate.details)
+    .filter(([, value]) => typeof value === 'number')
+    .map(([key, value]) => `${key}=${value}`)
+    .join(', ') || '-'
+}
+
+function formatCounts(counts: Record<string, number>): string {
+  return Object.entries(counts).map(([key, value]) => `${key}=${value}`).join(', ')
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+const cellStyle = {
+  padding: '10px 12px',
+  verticalAlign: 'top',
+} satisfies CSSProperties
+
+const buttonStyle = {
+  border: '1px solid #d1d5db',
+  borderRadius: 6,
+  background: '#fff',
+  padding: '8px 12px',
+  cursor: 'pointer',
+} satisfies CSSProperties
+
+const primaryButtonStyle = {
+  ...buttonStyle,
+  borderColor: '#111827',
+  background: '#111827',
+  color: '#fff',
+} satisfies CSSProperties
+
+const panelStyle = {
+  border: '1px solid #d1d5db',
+  borderRadius: 8,
+  padding: 14,
+  background: '#fff',
+} satisfies CSSProperties
+
+const panelTitleStyle = {
+  margin: '0 0 8px',
+  fontSize: 15,
+} satisfies CSSProperties

--- a/apps/web/lib/local-first/legacyMigrationService.ts
+++ b/apps/web/lib/local-first/legacyMigrationService.ts
@@ -1,0 +1,339 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  TRIP_DOCUMENT_SCHEMA_VERSION,
+  convertLegacyTemplateRowsToDocument,
+  convertLegacyTripRowsToDocument,
+  type LegacyTemplateRowBundle,
+  type MigrationValidationMessage,
+} from '@nexvoy/core'
+import { getLegacyTripRowBundle } from '@nexvoy/core/supabase/legacyRepository'
+import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
+import { createYjsTripDocument, encodeTripDocumentUpdate } from '@nexvoy/core/local-first/yjsTripDocument'
+import {
+  TEMPLATE_DOCUMENT_SCHEMA_VERSION,
+  createYjsTemplateDocument,
+  encodeTemplateDocumentUpdate,
+} from '@nexvoy/core/local-first/templateDocument'
+import { ensureWebOwnerDocumentKeyForSnapshot } from './keyProvisioningService'
+import { resolveWebOwnerContext } from './ownerNamespace'
+import { restoreWebTemplateDocumentFromBackup, restoreWebTripDocumentFromBackup } from './backupRestoreService'
+import { createWebTemplateDocumentStore, createWebTripDocumentStore } from './webDocumentStores'
+
+export type LegacyMigrationKind = 'trip' | 'template'
+
+export interface LegacyMigrationCandidate {
+  kind: LegacyMigrationKind
+  id: string
+  title: string
+  updatedAt: string
+  existingDocument: boolean
+  details: {
+    plans?: number
+    checklistItems?: number
+    templateItems?: number
+    shares?: number
+  }
+}
+
+export interface LegacyMigrationDryRunReport {
+  kind: LegacyMigrationKind
+  id: string
+  title: string
+  entityCounts: Record<string, number>
+  validationMessages: MigrationValidationMessage[]
+  blocked: boolean
+}
+
+export interface LegacyMigrationResult extends LegacyMigrationDryRunReport {
+  status: 'migrated' | 'skipped'
+  restoreStatus: 'restored' | 'missing' | 'key_unavailable' | 'failed'
+}
+
+export async function scanLegacyMigrationCandidates(
+  supabase: SupabaseClient,
+): Promise<LegacyMigrationCandidate[]> {
+  const userId = await requireCurrentUserId(supabase)
+  const [documentsRes, tripsRes, templatesRes] = await Promise.all([
+    supabase.from('documents').select('id,type'),
+    supabase
+      .from('trips')
+      .select('id,destination,start_date,end_date,created_at,updated_at')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false }),
+    supabase
+      .from('checklist_templates')
+      .select('id,title,user_id,created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false }),
+  ])
+
+  if (documentsRes.error) throw documentsRes.error
+  if (tripsRes.error) throw tripsRes.error
+  if (templatesRes.error) throw templatesRes.error
+
+  const existingDocuments = new Set((documentsRes.data ?? []).map((row) => row.id))
+  const tripRows = tripsRes.data ?? []
+  const templateRows = templatesRes.data ?? []
+  const [tripCounts, templateCounts] = await Promise.all([
+    getLegacyTripCounts(supabase, tripRows.map((row) => row.id)),
+    getLegacyTemplateCounts(supabase, templateRows.map((row) => row.id)),
+  ])
+
+  return [
+    ...tripRows.map((trip) => ({
+      kind: 'trip' as const,
+      id: trip.id,
+      title: `${trip.destination} (${trip.start_date} - ${trip.end_date})`,
+      updatedAt: trip.updated_at ?? trip.created_at,
+      existingDocument: existingDocuments.has(trip.id),
+      details: tripCounts.get(trip.id) ?? {},
+    })),
+    ...templateRows.map((template) => ({
+      kind: 'template' as const,
+      id: template.id,
+      title: template.title,
+      updatedAt: template.created_at,
+      existingDocument: existingDocuments.has(template.id),
+      details: templateCounts.get(template.id) ?? {},
+    })),
+  ].sort((a, b) => Number(a.existingDocument) - Number(b.existingDocument) || b.updatedAt.localeCompare(a.updatedAt))
+}
+
+export async function dryRunLegacyMigration(
+  supabase: SupabaseClient,
+  input: { kind: LegacyMigrationKind; id: string },
+): Promise<LegacyMigrationDryRunReport> {
+  const userId = await requireCurrentUserId(supabase)
+  if (input.kind === 'trip') {
+    const bundle = await getLegacyTripRowBundle(supabase, input.id, userId)
+    if (!bundle) throw new Error('legacy_trip_not_found')
+    if (bundle.trip.user_id !== userId) throw new Error('legacy_trip_not_owned_by_current_user')
+    const result = convertLegacyTripRowsToDocument(bundle)
+    return {
+      kind: 'trip',
+      id: bundle.trip.id,
+      title: bundle.trip.destination,
+      entityCounts: {
+        plans: Object.keys(result.document.plans).length,
+        planUrls: Object.keys(result.document.planUrls).length,
+        checklists: Object.keys(result.document.checklists).length,
+        checklistItems: Object.keys(result.document.checklistItems).length,
+        members: Object.keys(result.document.members).length,
+        shares: Object.keys(result.document.shares).length,
+      },
+      validationMessages: result.validationMessages,
+      blocked: result.validationMessages.some((message) => message.severity === 'error'),
+    }
+  }
+
+  const bundle = await getLegacyTemplateRowBundle(supabase, input.id, userId)
+  const result = convertLegacyTemplateRowsToDocument(bundle)
+  return {
+    kind: 'template',
+    id: bundle.template.id,
+    title: bundle.template.title,
+    entityCounts: {
+      items: Object.keys(result.document.items).length,
+      shares: Object.keys(result.document.shares).length,
+    },
+    validationMessages: result.validationMessages,
+    blocked: result.validationMessages.some((message) => message.severity === 'error'),
+  }
+}
+
+export async function migrateLegacyDocument(
+  supabase: SupabaseClient,
+  input: { kind: LegacyMigrationKind; id: string },
+): Promise<LegacyMigrationResult> {
+  const userId = await requireCurrentUserId(supabase)
+  if (await createSupabaseBackupRepository(supabase).hasSnapshot(input.id)) {
+    return {
+      ...(await dryRunLegacyMigration(supabase, input)),
+      status: 'skipped',
+      restoreStatus: 'missing',
+    }
+  }
+
+  const ownerContext = await resolveWebOwnerContext(supabase)
+  if (!ownerContext.authUserId) throw new Error('auth_user_missing')
+
+  if (input.kind === 'trip') {
+    const bundle = await getLegacyTripRowBundle(supabase, input.id, userId)
+    if (!bundle) throw new Error('legacy_trip_not_found')
+    if (bundle.trip.user_id !== userId) throw new Error('legacy_trip_not_owned_by_current_user')
+    const result = convertLegacyTripRowsToDocument(bundle)
+    if (result.validationMessages.some((message) => message.severity === 'error')) {
+      throw new Error('legacy_trip_validation_failed')
+    }
+
+    const update = encodeTripDocumentUpdate(createYjsTripDocument(result.document))
+    await createWebTripDocumentStore(ownerContext).putDocument(input.id, result.document, update)
+    await ensureWebOwnerDocumentKeyForSnapshot({
+      supabase,
+      documentId: input.id,
+      ownerId: ownerContext.authUserId,
+      documentType: 'trip',
+      schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+      snapshotPayload: update,
+    })
+    const restore = await restoreWebTripDocumentFromBackup({ supabase, documentId: input.id })
+    return {
+      kind: 'trip',
+      id: bundle.trip.id,
+      title: bundle.trip.destination,
+      entityCounts: {
+        plans: Object.keys(result.document.plans).length,
+        planUrls: Object.keys(result.document.planUrls).length,
+        checklists: Object.keys(result.document.checklists).length,
+        checklistItems: Object.keys(result.document.checklistItems).length,
+        members: Object.keys(result.document.members).length,
+        shares: Object.keys(result.document.shares).length,
+      },
+      validationMessages: result.validationMessages,
+      blocked: false,
+      status: 'migrated',
+      restoreStatus: restore.status,
+    }
+  }
+
+  const bundle = await getLegacyTemplateRowBundle(supabase, input.id, userId)
+  const result = convertLegacyTemplateRowsToDocument(bundle)
+  if (result.validationMessages.some((message) => message.severity === 'error')) {
+    throw new Error('legacy_template_validation_failed')
+  }
+
+  const update = encodeTemplateDocumentUpdate(createYjsTemplateDocument(result.document))
+  await createWebTemplateDocumentStore(ownerContext).putDocument(input.id, result.document, update)
+  await ensureWebOwnerDocumentKeyForSnapshot({
+    supabase,
+    documentId: input.id,
+    ownerId: ownerContext.authUserId,
+    documentType: 'template',
+    schemaVersion: TEMPLATE_DOCUMENT_SCHEMA_VERSION,
+    snapshotPayload: update,
+  })
+  const restore = await restoreWebTemplateDocumentFromBackup({ supabase, documentId: input.id })
+  return {
+    kind: 'template',
+    id: bundle.template.id,
+    title: bundle.template.title,
+    entityCounts: {
+      items: Object.keys(result.document.items).length,
+      shares: Object.keys(result.document.shares).length,
+    },
+    validationMessages: result.validationMessages,
+    blocked: false,
+    status: 'migrated',
+    restoreStatus: restore.status,
+  }
+}
+
+async function getLegacyTemplateRowBundle(
+  supabase: SupabaseClient,
+  templateId: string,
+  userId: string,
+): Promise<LegacyTemplateRowBundle> {
+  const [templateRes, itemsRes, sharesRes] = await Promise.all([
+    supabase
+      .from('checklist_templates')
+      .select('*')
+      .eq('id', templateId)
+      .eq('user_id', userId)
+      .maybeSingle(),
+    supabase
+      .from('checklist_template_items')
+      .select('*')
+      .eq('template_id', templateId)
+      .order('category', { ascending: true })
+      .order('created_at', { ascending: true }),
+    supabase
+      .from('checklist_template_shares')
+      .select('*')
+      .eq('template_id', templateId),
+  ])
+
+  if (templateRes.error) throw templateRes.error
+  if (itemsRes.error) throw itemsRes.error
+  if (sharesRes.error) throw sharesRes.error
+  if (!templateRes.data) throw new Error('legacy_template_not_found')
+
+  return {
+    exportedAt: new Date().toISOString(),
+    template: templateRes.data,
+    items: itemsRes.data ?? [],
+    shares: sharesRes.data ?? [],
+  }
+}
+
+async function getLegacyTripCounts(
+  supabase: SupabaseClient,
+  tripIds: string[],
+): Promise<Map<string, LegacyMigrationCandidate['details']>> {
+  if (tripIds.length === 0) return new Map()
+  const [plansRes, checklistsRes] = await Promise.all([
+    supabase.from('plans').select('trip_id').in('trip_id', tripIds),
+    supabase.from('checklists').select('id,trip_id').in('trip_id', tripIds),
+  ])
+  if (plansRes.error) throw plansRes.error
+  if (checklistsRes.error) throw checklistsRes.error
+
+  const counts = new Map<string, LegacyMigrationCandidate['details']>()
+  for (const tripId of tripIds) counts.set(tripId, { plans: 0, checklistItems: 0 })
+  for (const plan of plansRes.data ?? []) {
+    const details = counts.get(plan.trip_id) ?? {}
+    details.plans = (details.plans ?? 0) + 1
+    counts.set(plan.trip_id, details)
+  }
+
+  const checklistIds = (checklistsRes.data ?? []).map((row) => row.id)
+  if (checklistIds.length === 0) return counts
+  const itemsRes = await supabase
+    .from('checklist_items')
+    .select('checklist_id')
+    .in('checklist_id', checklistIds)
+  if (itemsRes.error) throw itemsRes.error
+
+  const tripIdByChecklistId = new Map((checklistsRes.data ?? []).map((row) => [row.id, row.trip_id]))
+  for (const item of itemsRes.data ?? []) {
+    const tripId = tripIdByChecklistId.get(item.checklist_id)
+    if (!tripId) continue
+    const details = counts.get(tripId) ?? {}
+    details.checklistItems = (details.checklistItems ?? 0) + 1
+    counts.set(tripId, details)
+  }
+  return counts
+}
+
+async function getLegacyTemplateCounts(
+  supabase: SupabaseClient,
+  templateIds: string[],
+): Promise<Map<string, LegacyMigrationCandidate['details']>> {
+  if (templateIds.length === 0) return new Map()
+  const [itemsRes, sharesRes] = await Promise.all([
+    supabase.from('checklist_template_items').select('template_id').in('template_id', templateIds),
+    supabase.from('checklist_template_shares').select('template_id').in('template_id', templateIds),
+  ])
+  if (itemsRes.error) throw itemsRes.error
+  if (sharesRes.error) throw sharesRes.error
+
+  const counts = new Map<string, LegacyMigrationCandidate['details']>()
+  for (const templateId of templateIds) counts.set(templateId, { templateItems: 0, shares: 0 })
+  for (const item of itemsRes.data ?? []) {
+    const details = counts.get(item.template_id) ?? {}
+    details.templateItems = (details.templateItems ?? 0) + 1
+    counts.set(item.template_id, details)
+  }
+  for (const share of sharesRes.data ?? []) {
+    const details = counts.get(share.template_id) ?? {}
+    details.shares = (details.shares ?? 0) + 1
+    counts.set(share.template_id, details)
+  }
+  return counts
+}
+
+async function requireCurrentUserId(supabase: SupabaseClient): Promise<string> {
+  const { data, error } = await supabase.auth.getUser()
+  if (error) throw error
+  if (!data.user) throw new Error('auth_user_missing')
+  return data.user.id
+}

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -36,7 +36,7 @@
 | 영역 | 현재 상태 | 판정 |
 |------|----------|------|
 | TripDocumentV1 모델 | trips/plans/checklists/members/assets/tombstones 기반 있음. templates는 ADR-013에 따라 별도 `TemplateDocumentV1` boundary | 기반 완료, templates 후속 |
-| legacy row -> document 변환 | trip/plans/checklists/members 변환 기반 있음 | Closed Beta 필수 경로에서 제외, TASK-042로 이관 |
+| legacy row -> document 변환 | trip/plans/checklists/members와 template 변환 기반 있음. `/dev/legacy-migration` 수동 도구로 snapshot/key bootstrap 가능 | Closed Beta 필수 경로에서는 제외, 후속 수동 복구 경로 확보 |
 | Web 준비물 | local-first/dual-write/P2P 화면 연결됨 | 부분 완료 |
 | Mobile 준비물 | Yjs runtime/apply adapter는 있으나 화면 write path는 legacy 중심 | 미완료 |
 | Web 일정 | document model에는 포함되나 화면 CRUD는 legacy Supabase 중심 | 미완료 |

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -104,7 +104,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-039-new-document-bootstrap.md` | 완료 | 신규 여행/템플릿 생성 시 local document + encrypted snapshot + owner key bootstrap, Issue #337 |
 | `TASK-040-document-primary-product-path-cutover.md` | 완료 | 여행/일정/준비물/템플릿 제품 경로에서 legacy hydrate/fallback 제거, Issue #339 |
 | `TASK-041-backup-freshness-and-cost-control.md` | 완료 | local-first freshness, metadata 기반 backup pull/upload, Supabase 비용 최소화, Issue #341 |
-| `TASK-042-legacy-migration-tool.md` | 예정 | 기존 row 데이터를 명시적으로 document-primary로 전환하는 후속 도구 |
+| `TASK-042-legacy-migration-tool.md` | 완료 | 기존 row 데이터를 명시적으로 document-primary로 전환하는 Web dev migration tool, Issue #343 |
 
 현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `TASK-038`부터는 ADR-014에 따라 Closed Beta 기준선을 기존 row 자동 migration에서 신규 document-primary 데이터로 재설정한다. 기존 row 데이터는 제품 경로에서 자동 hydrate하지 않고, `TASK-042`의 명시적 migration tool source로만 남긴다.
 

--- a/docs/refactor/tasks/TASK-042-legacy-migration-tool.md
+++ b/docs/refactor/tasks/TASK-042-legacy-migration-tool.md
@@ -60,3 +60,20 @@ Closed Beta 기준선에서는 기존 데이터를 무시하지만, 향후 필�
 ## 완료 조건
 
 - 기존 데이터를 수동 선택 방식으로 안전하게 document-primary로 전환할 수 있다.
+
+## 구현 결과
+
+- GitHub Issue: [#343](https://github.com/ysjee141/nexvoy-frontend/issues/343)
+- Web dev route: `/dev/legacy-migration`
+- Runbook: `docs/runbooks/legacy-document-migration.md`
+
+이번 도구는 서버 service-role script가 아니라 로그인된 Web 세션에서 실행한다. `document_keys` bootstrap은 현재
+브라우저 디바이스의 RSA key material을 사용해야 fresh restore가 가능하므로, 브라우저 실행 방식이 더 안전하다.
+
+구현된 동작:
+
+- current user 소유 legacy trips/templates 중 `documents` row가 없는 후보를 scan한다.
+- 선택 항목에 대해 dry-run 변환 report와 validation message를 보여준다.
+- trip row bundle은 `TripDocumentV1`, template row bundle은 `TemplateDocumentV1`로 변환한다.
+- migration 실행 시 local IndexedDB document update와 Supabase encrypted snapshot/member/key를 함께 만든다.
+- migration 직후 backup restore smoke를 수행하고 restore status를 결과에 표시한다.

--- a/docs/runbooks/legacy-document-migration.md
+++ b/docs/runbooks/legacy-document-migration.md
@@ -1,0 +1,46 @@
+# Legacy Document Migration Runbook
+
+TASK-042 provides a manual migration path for legacy Supabase row data. It is not part of the Closed Beta product flow and must not run automatically.
+
+## When To Use
+
+- Use only after the new document-primary flow is stable.
+- Use for selected legacy trips or templates owned by the signed-in user.
+- Do not use it as a silent compatibility layer for product screens.
+
+## Tool
+
+Open the web app with a signed-in owner account, then visit:
+
+```text
+/dev/legacy-migration
+```
+
+The tool runs in the browser because it must use the current Web device key material to create a usable encrypted snapshot and `document_keys` entry.
+
+## Procedure
+
+1. Click `Scan` to list row-only legacy trips/templates.
+2. Select one item.
+3. Click `Dry Run` and inspect entity counts and validation messages.
+4. Click `Migrate Selected`.
+5. Confirm the result shows `status=migrated` and `restore=restored`.
+
+Already migrated documents are shown as `already migrated` and are not overwritten.
+
+## Rollback
+
+Legacy rows are not deleted. If a migration must be rolled back, remove generated rows for the document id from:
+
+- `document_updates`
+- `document_keys`
+- `document_members`
+- `documents`
+
+Then clear the same document id from local IndexedDB for the testing browser profile.
+
+## Notes
+
+- Public/default templates are not migrated by this tool; only current-user owned templates are candidates.
+- Warnings in dry-run reports do not block migration unless marked as `error`.
+- A failed migration should leave the original legacy rows unchanged.

--- a/packages/core/src/local-first/__tests__/migrations.test.ts
+++ b/packages/core/src/local-first/__tests__/migrations.test.ts
@@ -1,5 +1,10 @@
 import type { TripDocumentV1 } from '../documentModel'
-import { convertLegacyTripRowsToDocument, type LegacyTripRowBundle } from '../migrations'
+import {
+  convertLegacyTemplateRowsToDocument,
+  convertLegacyTripRowsToDocument,
+  type LegacyTemplateRowBundle,
+  type LegacyTripRowBundle,
+} from '../migrations'
 
 const legacyBundle = {
   exportedAt: '2026-06-29T00:00:00.000Z',
@@ -214,4 +219,80 @@ if (!migrationResult.legacyRowMap.some((row) => row.pathInDocument === 'checklis
 
 if (!migrationResult.validationMessages.some((message) => message.code === 'orphan_checklist_item')) {
   throw new Error('Orphan checklist item should produce a validation warning.')
+}
+
+const legacyTemplateBundle = {
+  exportedAt: '2026-06-29T00:00:00.000Z',
+  template: {
+    id: 'template-1',
+    user_id: 'user-1',
+    title: 'Beach pack',
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-02T00:00:00.000Z',
+  },
+  items: [
+    {
+      id: 'template-item-2',
+      template_id: 'template-1',
+      item_name: 'Sunscreen',
+      category: 'Toiletries',
+      is_private: false,
+      created_at: '2026-06-02T00:00:00.000Z',
+    },
+    {
+      id: 'template-item-1',
+      template_id: 'template-1',
+      item_name: 'Passport',
+      category: 'Documents',
+      is_private: null,
+      sort_order: 0,
+      created_at: '2026-06-01T00:00:00.000Z',
+      updated_at: null,
+    },
+    {
+      id: 'template-item-orphan',
+      template_id: 'other-template',
+      item_name: 'Skipped',
+      category: null,
+      is_private: false,
+      created_at: '2026-06-01T00:00:00.000Z',
+    },
+  ],
+  shares: [
+    {
+      id: 'template-share-1',
+      template_id: 'template-1',
+      shared_with_user_id: 'user-2',
+      role: 'admin',
+      created_by: 'user-1',
+      created_at: '2026-06-03T00:00:00.000Z',
+    },
+  ],
+} satisfies LegacyTemplateRowBundle
+
+const templateMigrationResult = convertLegacyTemplateRowsToDocument(legacyTemplateBundle)
+const templateDocument = templateMigrationResult.document
+
+if (templateDocument.template.id !== legacyTemplateBundle.template.id) {
+  throw new Error('Template id should be preserved as document id.')
+}
+
+if (templateDocument.template.visibility !== 'private') {
+  throw new Error('User-owned legacy template should become a private template document.')
+}
+
+if (templateDocument.items['template-item-orphan']) {
+  throw new Error('Cross-template item should be skipped.')
+}
+
+if (templateDocument.items['template-item-2']?.sortOrder !== 1) {
+  throw new Error('Template item fallback sort order should preserve sorted legacy order.')
+}
+
+if (templateDocument.shares['template-share-1']?.role !== 'viewer') {
+  throw new Error('Unknown template share role should normalize to viewer.')
+}
+
+if (!templateMigrationResult.validationMessages.some((message) => message.code === 'cross_template_row_skipped')) {
+  throw new Error('Cross-template row should produce a validation warning.')
 }

--- a/packages/core/src/local-first/documentModel.ts
+++ b/packages/core/src/local-first/documentModel.ts
@@ -226,14 +226,21 @@ export type LegacyTripRowTable =
   | 'trip_invitation_links'
   | 'assets'
 
+export type LegacyTemplateRowTable =
+  | 'checklist_templates'
+  | 'checklist_template_items'
+  | 'checklist_template_shares'
+
+export type LegacyRowTable = LegacyTripRowTable | LegacyTemplateRowTable
+
 export interface LegacyRowDocumentPath {
-  tableName: LegacyTripRowTable
+  tableName: LegacyRowTable
   rowId: EntityId
   pathInDocument: string
 }
 
 export function getLegacyRowDocumentPath(
-  tableName: LegacyTripRowTable,
+  tableName: LegacyRowTable,
   rowId: EntityId,
 ): LegacyRowDocumentPath {
   const collectionPath = getLegacyRowDocumentCollectionPath(tableName)
@@ -245,7 +252,7 @@ export function getLegacyRowDocumentPath(
   }
 }
 
-export function getLegacyRowDocumentCollectionPath(tableName: LegacyTripRowTable): string {
+export function getLegacyRowDocumentCollectionPath(tableName: LegacyRowTable): string {
   switch (tableName) {
     case 'trips':
       return 'trip'
@@ -271,5 +278,11 @@ export function getLegacyRowDocumentCollectionPath(tableName: LegacyTripRowTable
       return 'invitationLinks'
     case 'assets':
       return 'assets'
+    case 'checklist_templates':
+      return 'template'
+    case 'checklist_template_items':
+      return 'items'
+    case 'checklist_template_shares':
+      return 'shares'
   }
 }

--- a/packages/core/src/local-first/migrations.ts
+++ b/packages/core/src/local-first/migrations.ts
@@ -16,6 +16,12 @@ import {
   getLegacyRowDocumentPath,
 } from './documentModel'
 import { createEmptyTripDocumentV1 } from './tripDocument'
+import {
+  createEmptyTemplateDocumentV1,
+  type TemplateDocumentV1,
+  type TemplateItemNode,
+  type TemplateShareNode,
+} from './templateDocument'
 
 export type MigrationValidationSeverity = 'warning' | 'error'
 
@@ -45,6 +51,19 @@ export interface LegacyTripRowBundle {
 
 export interface TripDocumentMigrationResult {
   document: TripDocumentV1
+  legacyRowMap: LegacyRowDocumentPath[]
+  validationMessages: MigrationValidationMessage[]
+}
+
+export interface LegacyTemplateRowBundle {
+  template: LegacyTemplateRow
+  items?: LegacyTemplateItemRow[]
+  shares?: LegacyTemplateShareRow[]
+  exportedAt?: string
+}
+
+export interface TemplateDocumentMigrationResult {
+  document: TemplateDocumentV1
   legacyRowMap: LegacyRowDocumentPath[]
   validationMessages: MigrationValidationMessage[]
 }
@@ -189,6 +208,35 @@ export interface LegacyAssetRow {
   created_at: string
 }
 
+export interface LegacyTemplateRow {
+  id: string
+  user_id: string | null
+  title: string
+  created_at: string
+  updated_at?: string | null
+}
+
+export interface LegacyTemplateItemRow {
+  id: string
+  template_id: string
+  item_name: string
+  category: string | null
+  is_private: boolean | null
+  sort_order?: number | null
+  created_at: string
+  updated_at?: string | null
+}
+
+export interface LegacyTemplateShareRow {
+  id: string
+  template_id: string
+  shared_with_user_id: string
+  role: string
+  created_by: string | null
+  created_at: string
+  updated_at?: string | null
+}
+
 export function convertLegacyTripRowsToDocument(
   bundle: LegacyTripRowBundle,
 ): TripDocumentMigrationResult {
@@ -326,6 +374,51 @@ export function convertLegacyTripRowsToDocument(
   for (const asset of bundle.assets ?? []) {
     document.assets[asset.id] = toAssetRefNode(asset)
     legacyRowMap.push(getLegacyRowDocumentPath('assets', asset.id))
+  }
+
+  return {
+    document,
+    legacyRowMap,
+    validationMessages,
+  }
+}
+
+export function convertLegacyTemplateRowsToDocument(
+  bundle: LegacyTemplateRowBundle,
+): TemplateDocumentMigrationResult {
+  const validationMessages: MigrationValidationMessage[] = []
+  const legacyRowMap: LegacyRowDocumentPath[] = []
+  const document = createEmptyTemplateDocumentV1({
+    id: bundle.template.id,
+    ownerId: bundle.template.user_id,
+    title: bundle.template.title,
+    visibility: bundle.template.user_id ? 'private' : 'public',
+    createdAt: bundle.template.created_at,
+    updatedAt: bundle.template.updated_at ?? bundle.template.created_at,
+    createdFromLegacyAt: bundle.exportedAt,
+  })
+
+  legacyRowMap.push(getLegacyRowDocumentPath('checklist_templates', bundle.template.id))
+
+  const sortedItems = [...(bundle.items ?? [])].sort(compareTemplateItemsForLegacyOrder)
+  let migratedItemIndex = 0
+  sortedItems.forEach((item) => {
+    if (!isTemplateScopedRow(item, bundle.template.id, 'checklist_template_items', validationMessages)) {
+      return
+    }
+
+    document.items[item.id] = toTemplateItemNode(item, migratedItemIndex)
+    migratedItemIndex += 1
+    legacyRowMap.push(getLegacyRowDocumentPath('checklist_template_items', item.id))
+  })
+
+  for (const share of bundle.shares ?? []) {
+    if (!isTemplateScopedRow(share, bundle.template.id, 'checklist_template_shares', validationMessages)) {
+      continue
+    }
+
+    document.shares[share.id] = toTemplateShareNode(share, validationMessages)
+    legacyRowMap.push(getLegacyRowDocumentPath('checklist_template_shares', share.id))
   }
 
   return {
@@ -500,6 +593,46 @@ function comparePlansForDocumentOrder(a: PlanNode, b: PlanNode): number {
   )
 }
 
+function compareTemplateItemsForLegacyOrder(
+  a: LegacyTemplateItemRow,
+  b: LegacyTemplateItemRow,
+): number {
+  return (
+    (a.sort_order ?? Number.MAX_SAFE_INTEGER) - (b.sort_order ?? Number.MAX_SAFE_INTEGER) ||
+    (a.category ?? '').localeCompare(b.category ?? '') ||
+    a.created_at.localeCompare(b.created_at) ||
+    a.id.localeCompare(b.id)
+  )
+}
+
+function toTemplateItemNode(row: LegacyTemplateItemRow, fallbackSortOrder: number): TemplateItemNode {
+  return {
+    id: row.id,
+    templateId: row.template_id,
+    name: row.item_name,
+    categoryName: row.category ?? '',
+    isPrivate: row.is_private ?? false,
+    sortOrder: row.sort_order ?? fallbackSortOrder,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at ?? row.created_at,
+  }
+}
+
+function toTemplateShareNode(
+  row: LegacyTemplateShareRow,
+  validationMessages: MigrationValidationMessage[],
+): TemplateShareNode {
+  return {
+    id: row.id,
+    templateId: row.template_id,
+    sharedWithUserId: row.shared_with_user_id,
+    role: normalizeTemplateShareRole(row.role, row.id, validationMessages),
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at ?? null,
+  }
+}
+
 export function compareChecklistItemsForLegacyOrder(
   a: ChecklistItemNode,
   b: ChecklistItemNode,
@@ -604,6 +737,23 @@ function normalizeInvitationRole(
   return 'viewer'
 }
 
+function normalizeTemplateShareRole(
+  role: string,
+  rowId: string,
+  validationMessages: MigrationValidationMessage[],
+): TemplateShareNode['role'] {
+  if (role === 'viewer' || role === 'editor') return role
+
+  pushValidation(validationMessages, {
+    code: 'unknown_template_share_role_normalized',
+    message: `Template share ${rowId} had unknown role ${role} and was normalized to viewer.`,
+    rowId,
+    tableName: 'checklist_template_shares',
+  })
+
+  return 'viewer'
+}
+
 function validateLegacyChecklistState(
   item: ChecklistItemNode,
   validationMessages: MigrationValidationMessage[],
@@ -649,6 +799,24 @@ function isTripScopedRow(
   pushValidation(validationMessages, {
     code: 'cross_trip_row_skipped',
     message: `${tableName}.${row.id} belongs to trip ${row.trip_id}, not ${tripId}.`,
+    rowId: row.id,
+    tableName,
+  })
+
+  return false
+}
+
+function isTemplateScopedRow(
+  row: { id: string; template_id: string },
+  templateId: EntityId,
+  tableName: string,
+  validationMessages: MigrationValidationMessage[],
+): boolean {
+  if (row.template_id === templateId) return true
+
+  pushValidation(validationMessages, {
+    code: 'cross_template_row_skipped',
+    message: `${tableName}.${row.id} belongs to template ${row.template_id}, not ${templateId}.`,
     rowId: row.id,
     tableName,
   })

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,45 @@
+# Walkthrough: TASK-042 Legacy Migration Tool
+
+## Summary
+
+TASK-042는 Closed Beta 제품 경로에서 제외한 기존 Supabase row 데이터를, 향후 필요 시 사용자가 명시적으로 선택해
+document-primary snapshot으로 전환할 수 있는 Web dev migration tool을 추가했다. 자동 migration/hydrate는
+되살리지 않고, 로그인된 Web 세션의 현재 device key material로 encrypted snapshot, owner member, document key를
+함께 bootstrap한다.
+
+## Artifacts
+
+- `docs/refactor/tasks/TASK-042-legacy-migration-tool.md`
+- GitHub Issue [#343](https://github.com/ysjee141/nexvoy-frontend/issues/343)
+- 브랜치: `feature/task-042-legacy-migration-tool`
+- `packages/core/src/local-first/migrations.ts`
+- `apps/web/lib/local-first/legacyMigrationService.ts`
+- `apps/web/app/dev/legacy-migration/page.tsx`
+- `docs/runbooks/legacy-document-migration.md`
+
+## Key Changes
+
+- `LegacyTemplateRowBundle`과 `convertLegacyTemplateRowsToDocument()`를 추가해 legacy template rows를
+  `TemplateDocumentV1`로 변환한다.
+- `/dev/legacy-migration`에서 current user 소유 row-only trip/template 후보를 scan한다.
+- dry-run report가 변환 entity count와 validation message를 표시한다.
+- migration 실행 시 local IndexedDB document update와 Supabase encrypted snapshot/member/key를 함께 생성한다.
+- migration 직후 backup restore smoke를 수행해 current Web device key로 복구 가능한지 확인한다.
+
+## Verification
+
+| 명령 | 결과 |
+| --- | --- |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm -C packages/core typecheck` | PASS |
+| `pnpm -C apps/web exec tsc --noEmit` | PASS |
+| `pnpm build` | PASS |
+
+## Follow-up
+
+- Mobile에서 마이그레이션된 snapshot restore smoke는 실제 기기/시뮬레이터 계정으로 수동 확인한다.
+- 이 도구는 public/default template migration을 다루지 않는다. 필요하면 별도 정책 결정 후 확장한다.
+
 # Walkthrough: TASK-041 Backup Freshness and Cost Control
 
 ## Summary


### PR DESCRIPTION
## Summary\n- add a Web dev migration route at /dev/legacy-migration for explicit legacy row -> document-primary conversion\n- add TemplateDocumentV1 legacy conversion support and migration tests\n- bootstrap local document update, encrypted Supabase snapshot, owner member, and current Web device document key during migration\n- document the manual migration and rollback flow in a runbook\n\n## Verification\n- pnpm --filter @nexvoy/core test\n- pnpm -C packages/core typecheck\n- pnpm -C apps/web exec tsc --noEmit\n- pnpm build\n\nCloses #343