### PR TITLE
fix(TASK-043): use document-primary trip entry paths

### DIFF
--- a/apps/mobile/lib/local-first/documentBootstrapService.ts
+++ b/apps/mobile/lib/local-first/documentBootstrapService.ts
@@ -90,6 +90,12 @@ export async function ensureMobileOwnerDocumentKey({
   if (!user) return // Unauthenticated — skip silently
 
   const backupRepository = createSupabaseBackupRepository(supabase)
+  await backupRepository.ensureDocumentBootstrapped({
+    documentId,
+    ownerId: user.id,
+    type: 'trip',
+    schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+  })
 
   // Check if this device already has a device-scoped RSA key — no-op if so.
   const activeKey = await backupRepository.getMyActiveDocumentKey({
@@ -139,6 +145,13 @@ export async function ensureMobileOwnerDocumentKeyForSnapshot({
   if (!user) throw new Error('인증 정보가 없습니다.')
 
   const backupRepository = createSupabaseBackupRepository(supabase)
+  await backupRepository.ensureDocumentBootstrapped({
+    documentId,
+    ownerId: user.id,
+    type: documentType,
+    schemaVersion,
+  })
+
   const activeKey = await backupRepository.getMyActiveDocumentKey({
     documentId,
     keyVersion: DOCUMENT_KEY_VERSION,

--- a/apps/mobile/lib/local-first/documentBootstrapService.ts
+++ b/apps/mobile/lib/local-first/documentBootstrapService.ts
@@ -92,7 +92,6 @@ export async function ensureMobileOwnerDocumentKey({
   const backupRepository = createSupabaseBackupRepository(supabase)
   await backupRepository.ensureDocumentBootstrapped({
     documentId,
-    ownerId: user.id,
     type: 'trip',
     schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
   })
@@ -147,7 +146,6 @@ export async function ensureMobileOwnerDocumentKeyForSnapshot({
   const backupRepository = createSupabaseBackupRepository(supabase)
   await backupRepository.ensureDocumentBootstrapped({
     documentId,
-    ownerId: user.id,
     type: documentType,
     schemaVersion,
   })
@@ -235,21 +233,18 @@ async function bootstrapOwnerDocument({
   const encryptedSnapshot = serializeEncryptedBackupPayload(encryptedPayload)
   const snapshotHash = await sha256Hex(snapshotPayload)
 
-  // upsertSnapshot MUST precede upsertOwnerMember: the "Insert documents as
-  // owner" RLS policy only requires owner_id = auth.uid(), but the
-  // "Insert document_members" policy requires check_is_document_owner(), which
-  // in turn requires documents.owner_id to already be set. Writing the
-  // documents row first establishes ownership for the member insert.
+  await backupRepository.ensureDocumentBootstrapped({
+    documentId,
+    type: documentType,
+    schemaVersion,
+  })
   await backupRepository.upsertSnapshot({
     documentId,
-    ownerId: userId,
-    type: documentType,
     schemaVersion,
     snapshot: encryptedSnapshot,
     snapshotHash,
     encrypted: true,
   })
-  await backupRepository.upsertOwnerMember({ documentId, userId })
   if (documentType === 'trip') {
     await saveMobileTripDocumentUpdate({ documentId }, snapshotPayload)
   }

--- a/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
@@ -126,7 +126,6 @@ async function ensureMobileDocumentRegistryBootstrapped(
   try {
     await createSupabaseBackupRepository(supabase).ensureDocumentBootstrapped({
       documentId: document.trip.id,
-      ownerId: authUserId,
     })
   } catch {
     mobileDocumentRegistryBootstrapAttempted.delete(key)

--- a/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/mobile/lib/local-first/documentPrimaryRepositories.ts
@@ -168,15 +168,6 @@ export async function createMobileTripDocument(input: {
     schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
     snapshotPayload: update,
   })
-  await upsertTripReadModel(input.supabase, {
-    tripId,
-    ownerId: userId,
-    destination: input.destination,
-    startDate: input.startDate,
-    endDate: input.endDate,
-    adultsCount: input.adultsCount,
-    childrenCount: input.childrenCount,
-  })
 
   return tripId
 }
@@ -332,32 +323,6 @@ export type MobileDocumentPrimaryMutationResult =
 function createEntityId(prefix: string): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
-}
-
-async function upsertTripReadModel(
-  supabase: SupabaseClient,
-  input: {
-    tripId: string
-    ownerId: string
-    destination: string
-    startDate: string
-    endDate: string
-    adultsCount: number
-    childrenCount: number
-  },
-): Promise<void> {
-  const { error } = await supabase
-    .from('trips')
-    .upsert({
-      id: input.tripId,
-      user_id: input.ownerId,
-      destination: input.destination,
-      start_date: input.startDate,
-      end_date: input.endDate,
-      adults_count: input.adultsCount,
-      children_count: input.childrenCount,
-    })
-  if (error) throw error
 }
 
 async function sha256Hex(bytes: Uint8Array): Promise<string> {

--- a/apps/web/app/HomeClient.tsx
+++ b/apps/web/app/HomeClient.tsx
@@ -11,6 +11,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { CacheUtil } from '@/lib/cache'
 import { promotePendingGuestDocuments } from '@/lib/local-first/guestPromotionService'
+import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import { tripSummaryToWebTripRow } from '@/lib/local-first/tripReadModelAdapters'
 import {
   Map, CheckSquare, Globe, Wallet,
   Link2, ChevronDown, ChevronUp, ArrowRight,
@@ -296,76 +298,10 @@ export default function HomeClient() {
         }
         setShowNicknamePrompt(!profile?.nickname)
 
-        // 1. 내가 멤버로 참여(수락)한 여행 ID들 가져오기
-        const { data: memberTripData, error: memberTripError } = await supabase
-            .from('trip_members')
-            .select('trip_id')
-            .eq('user_id', networkUser.id)
-            .eq('status', 'accepted')
-        if (memberTripError) throw memberTripError
-
-        const memberTripIds = memberTripData?.map((m: any) => m.trip_id) || []
-
-        // 2. 내가 소유하거나 멤버인 여행 전체 가져오기
-        let query = supabase
-            .from('trips')
-            .select('*')
-
-        if (memberTripIds.length > 0) {
-            query = query.or(`user_id.eq.${networkUser.id},id.in.(${memberTripIds.join(',')})`)
-        } else {
-            query = query.eq('user_id', networkUser.id)
-        }
-
-        const { data: trips, error: tripsError } = await query.order('start_date', { ascending: true })
-        if (tripsError) throw tripsError
-        const tripRows = trips || []
-        const tripIds = tripRows.map((trip: any) => trip.id)
-        let checklistsByTrip = new globalThis.Map<string, any[]>()
-        let itemsByChecklist = new globalThis.Map<string, any[]>()
-
-        if (tripIds.length > 0) {
-            const { data: checklistRows, error: checklistsError } = await supabase
-                .from('checklists')
-                .select('id, trip_id')
-                .in('trip_id', tripIds)
-            if (checklistsError) {
-                console.warn('Checklist progress fetch failed; rendering trips without progress', checklistsError)
-            }
-
-            ;(checklistRows || []).forEach((checklist: any) => {
-                checklistsByTrip.set(checklist.trip_id, [
-                    ...(checklistsByTrip.get(checklist.trip_id) || []),
-                    { ...checklist, checklist_items: [] },
-                ])
-            })
-
-            const checklistIds = (checklistRows || []).map((checklist: any) => checklist.id)
-            if (checklistIds.length > 0) {
-                const { data: itemRows, error: itemsError } = await supabase
-                    .from('checklist_items')
-                    .select('id, checklist_id, is_checked')
-                    .in('checklist_id', checklistIds)
-                if (itemsError) {
-                    console.warn('Checklist item progress fetch failed; rendering trips without item progress', itemsError)
-                }
-
-                ;(itemRows || []).forEach((item: any) => {
-                    itemsByChecklist.set(item.checklist_id, [
-                        ...(itemsByChecklist.get(item.checklist_id) || []),
-                        item,
-                    ])
-                })
-            }
-        }
-
-        const allTrips = tripRows.map((trip: any) => ({
-            ...trip,
-            checklists: (checklistsByTrip.get(trip.id) || []).map((checklist: any) => ({
-                ...checklist,
-                checklist_items: itemsByChecklist.get(checklist.id) || [],
-            })),
-        }))
+        const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: 'viewer' })
+        const allTrips = (await repositories.trips.listTrips(networkUser.id))
+            .map(tripSummaryToWebTripRow)
+            .sort((a, b) => a.start_date.localeCompare(b.start_date))
         processTrips(allTrips)
     } catch (e) {
         console.warn('Network sync failed, keeping local/cached state', e)

--- a/apps/web/app/api/invite/route.ts
+++ b/apps/web/app/api/invite/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export async function POST(req: NextRequest) {
     try {
-        const { email, tripTitle, tripId } = await req.json()
+        const { email, tripTitle, inviteUrl, inviteCode, role } = await req.json()
 
-        if (!email || !tripTitle) {
+        if (!email || !tripTitle || !inviteUrl || !inviteCode) {
             return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
         }
 
@@ -12,6 +12,11 @@ export async function POST(req: NextRequest) {
         if (!apiKey) {
             return NextResponse.json({ error: 'Resend API Key is not configured' }, { status: 500 })
         }
+
+        const safeTripTitle = escapeHtml(String(tripTitle))
+        const safeInviteUrl = escapeHtml(String(inviteUrl))
+        const safeInviteCode = escapeHtml(String(inviteCode))
+        const roleLabel = role === 'viewer' ? '조회 전용' : '편집 가능'
 
         // 라이브러리 대신 표준 fetch API를 사용하여 Resend REST API 호출
         const response = await fetch('https://api.resend.com/emails', {
@@ -28,14 +33,16 @@ export async function POST(req: NextRequest) {
                     <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #eee; border-radius: 12px;">
                         <h2 style="color: #3B82F6;">온여정 초대장 ✈️</h2>
                         <p>안녕하세요, 여행자님! 🌏</p>
-                        <p><strong>${tripTitle}</strong> 여정을 함께 채워갈 소중한 동행자로 초대받으셨어요.</p>
+                        <p><strong>${safeTripTitle}</strong> 여정을 함께 채워갈 소중한 동행자로 초대받으셨어요.</p>
+                        <p>초대 권한: <strong>${roleLabel}</strong></p>
                         <p>아래 링크를 통해 초대 내용을 확인하고 수락해 주시겠어요?</p>
                         <div style="margin: 30px 0;">
-                            <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://app.nexvoy.xyz'}" 
+                            <a href="${safeInviteUrl}" 
                                style="background-color: #111; color: white; padding: 12px 24px; text-decoration: none; border-radius: 8px; font-weight: bold; display: inline-block;">
                                 초대 확인하기
                             </a>
                         </div>
+                        <p style="color: #666; font-size: 14px;">링크가 열리지 않으면 온여정의 초대 코드 입력 화면에서 <strong>${safeInviteCode}</strong>를 입력해 주세요.</p>
                         <p style="color: #666; font-size: 14px;">이 메일은 설레는 여정의 시작, 온여정에서 보냈어요.</p>
                     </div>
                 `,
@@ -64,4 +71,13 @@ export async function POST(req: NextRequest) {
         console.error('Invite API Error:', err)
         return NextResponse.json({ error: err.message }, { status: 500 })
     }
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;')
 }

--- a/apps/web/app/trips/detail/TripClient.tsx
+++ b/apps/web/app/trips/detail/TripClient.tsx
@@ -23,7 +23,10 @@ import TripDetailSkeleton from './TripDetailSkeleton'
 import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
 import { flushWebBackupQueue } from '@/lib/local-first/backupSyncService'
 import { subscribeToTripDocumentUpdates } from '@/lib/local-first/indexedDbStore'
-import type { PlanTimelineItemReadModel } from '@nexvoy/core/local-first/materialize'
+import {
+    planTimelineItemToWebPlanRow,
+    tripDetailToWebTripRow,
+} from '@/lib/local-first/tripReadModelAdapters'
 import type { CreatePlanMutationInput } from '@nexvoy/core/local-first/documentMutationWriter'
 const CustomTimeDropdown = ({ timeDisplayMode, setTimeDisplayMode }: any) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -192,7 +195,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
         }
         const repositories = await createWebDocumentPrimaryRepositories(supabase)
         const data = await repositories.trips.getTrip(tripId)
-        if (data) setTrip(toLegacyTripRow(data))
+        if (data) setTrip(tripDetailToWebTripRow(data))
     }, [tripId, supabase, isOffline])
 
     const fetchPlans = useCallback(async () => {
@@ -215,7 +218,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
 
             const repositories = await createWebDocumentPrimaryRepositories(supabase)
             const data = (await repositories.plans.listPlans(tripId)).map((plan) =>
-                toLegacyPlanRow(tripId, plan),
+                planTimelineItemToWebPlanRow(tripId, plan),
             )
 
             if (data) {
@@ -238,9 +241,30 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
 
     const fetchUserRole = useCallback(async () => {
         if (!tripId) return
+        const { data: { user } } = await supabase.auth.getUser()
+        if (!user) {
+            setUserRole(null)
+            return
+        }
+
+        const repositories = await createWebDocumentPrimaryRepositories(supabase)
+        const documentTrip = await repositories.trips.getTrip(tripId)
+        if (documentTrip?.ownerId === user.id) {
+            setUserRole('owner')
+            return
+        }
+
+        const documentMember = documentTrip?.members.find((member) =>
+            member.userId === user.id && member.status === 'accepted',
+        )
+        if (documentMember) {
+            setUserRole(documentMember.role)
+            return
+        }
+
         const { data } = await collaboration.getUserRole(tripId)
         setUserRole(data as any)
-    }, [tripId])
+    }, [tripId, supabase])
 
     useEffect(() => {
         if (isActive) {
@@ -641,60 +665,6 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             )}
         </div>
     )
-}
-
-function toLegacyTripRow(trip: {
-    id: string
-    ownerId: string
-    destination: string
-    startDate: string
-    endDate: string
-    adultsCount: number
-    childrenCount: number
-    coverImageRef: string | null
-    bgColor: string | null
-}) {
-    return {
-        id: trip.id,
-        user_id: trip.ownerId,
-        destination: trip.destination,
-        start_date: trip.startDate,
-        end_date: trip.endDate,
-        adults_count: trip.adultsCount,
-        children_count: trip.childrenCount,
-        cover_image_ref: trip.coverImageRef,
-        bg_color: trip.bgColor,
-    }
-}
-
-function toLegacyPlanRow(tripId: string, plan: PlanTimelineItemReadModel) {
-    return {
-        id: plan.id,
-        trip_id: tripId,
-        title: plan.title,
-        location: plan.location,
-        address: plan.address,
-        location_lat: plan.coordinates?.lat ?? 0,
-        location_lng: plan.coordinates?.lng ?? 0,
-        google_place_id: plan.googlePlaceId,
-        image_url: plan.imageUrl,
-        photo_reference: plan.photoReference,
-        start_datetime_local: plan.startDateTimeLocal,
-        end_datetime_local: plan.endDateTimeLocal,
-        timezone_string: plan.timezone,
-        alarm_minutes_before: plan.alarmMinutesBefore,
-        alarm_sent_at: plan.alarmSentAt,
-        cost: plan.cost,
-        memo: plan.memo,
-        is_completed: plan.isCompleted,
-        is_visited: plan.isVisited,
-        plan_urls: plan.urls.map((url) => ({
-            id: url.id,
-            plan_id: url.planId,
-            url: url.url,
-            created_at: url.createdAt,
-        })),
-    }
 }
 
 function toDocumentPlanInput(planId: string, plan: {

--- a/apps/web/app/trips/detail/TripClient.tsx
+++ b/apps/web/app/trips/detail/TripClient.tsx
@@ -23,6 +23,7 @@ import TripDetailSkeleton from './TripDetailSkeleton'
 import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
 import { flushWebBackupQueue } from '@/lib/local-first/backupSyncService'
 import { subscribeToTripDocumentUpdates } from '@/lib/local-first/indexedDbStore'
+import { materializePlanTimeline } from '@nexvoy/core/local-first/materialize'
 import {
     planTimelineItemToWebPlanRow,
     tripDetailToWebTripRow,
@@ -391,15 +392,22 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
         const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
         const planId = editPlanId ?? createLocalPlanId()
         const input = toDocumentPlanInput(planId, plan)
-
-        if (editPlanId) {
-            await repositories.plans.updatePlan(tripId, {
+        const result = editPlanId
+            ? await repositories.plans.updatePlan(tripId, {
                 planId,
                 patch: input,
             })
-        } else {
-            await repositories.plans.createPlan(tripId, input)
+            : await repositories.plans.createPlan(tripId, input)
+
+        const savedPlan = materializePlanTimeline(result.document)
+            .find((candidate) => candidate.id === planId)
+        if (!savedPlan) {
+            throw new Error('일정 저장 결과를 문서에서 확인할 수 없습니다.')
         }
+        const savedRow = planTimelineItemToWebPlanRow(tripId, savedPlan)
+        setPlans((prev) => editPlanId
+            ? prev.map((candidate) => candidate.id === planId ? savedRow : candidate)
+            : [...prev, savedRow])
 
         return planId
     }, [supabase, tripId, userRole])

--- a/apps/web/app/trips/detail/TripLayoutClient.tsx
+++ b/apps/web/app/trips/detail/TripLayoutClient.tsx
@@ -27,7 +27,10 @@ import {
     subscribeToWebBackupQueue,
     type WebBackupQueueSnapshot,
 } from '@/lib/local-first/backupSyncService'
-import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import {
+    createWebDocumentPrimaryRepositories,
+    ensureWebTripDocumentRemoteBootstrap,
+} from '@/lib/local-first/documentPrimaryRepositories'
 import { tripDetailToWebMemberRows, tripDetailToWebTripRow } from '@/lib/local-first/tripReadModelAdapters'
 
 export default function TripLayoutClient() {
@@ -139,6 +142,12 @@ export default function TripLayoutClient() {
         let disposed = false
         const run = () => {
             void (async () => {
+                if (role === 'owner') {
+                    await ensureWebTripDocumentRemoteBootstrap({
+                        supabase,
+                        tripId: id,
+                    })
+                }
                 await ensureWebDocumentKeyReadiness({
                     supabase,
                     documentId: id,

--- a/apps/web/app/trips/detail/TripLayoutClient.tsx
+++ b/apps/web/app/trips/detail/TripLayoutClient.tsx
@@ -28,6 +28,7 @@ import {
     type WebBackupQueueSnapshot,
 } from '@/lib/local-first/backupSyncService'
 import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import { tripDetailToWebMemberRows, tripDetailToWebTripRow } from '@/lib/local-first/tripReadModelAdapters'
 
 export default function TripLayoutClient() {
     const searchParams = useSearchParams()
@@ -103,21 +104,20 @@ export default function TripLayoutClient() {
                 }
                 setCurrentUser(currentUser)
                 
-                // 3. 서버에서 최신 데이터 가져오기
-                const { data, error } = await supabase
-                    .from('trips')
-                    .select('*')
-                    .eq('id', id)
-                    .single()
+                const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: 'viewer' })
+                const documentTrip = await repositories.trips.getTrip(id)
 
-                if (error) throw error
-
-                if (!data) {
+                if (!documentTrip) {
                     router.replace('/404')
                 } else {
-                    setTrip(data)
-                    const { data: memberRows } = await collaboration.getMembers(id)
-                    setMembers(memberRows ?? [])
+                    setTrip(tripDetailToWebTripRow(documentTrip))
+                    const documentMembers = tripDetailToWebMemberRows(documentTrip)
+                    if (documentMembers.length > 0) {
+                        setMembers(documentMembers)
+                    } else {
+                        const { data: memberRows } = await collaboration.getMembers(id)
+                        setMembers(memberRows ?? [])
+                    }
                 }
             } catch (err) {
                 console.error('Failed to fetch trip:', err)

--- a/apps/web/components/trips/CollaboratorModal.tsx
+++ b/apps/web/components/trips/CollaboratorModal.tsx
@@ -15,7 +15,10 @@ import {
     type DocumentKeyProvisioningStatus,
 } from './DocumentKeyProvisioningStatus'
 import { ensureWebDeviceKeyMaterial, runWebForegroundKeyProvisioning } from '@/lib/local-first/keyProvisioningService'
-import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import {
+    createWebDocumentPrimaryRepositories,
+    ensureWebTripDocumentRemoteBootstrap,
+} from '@/lib/local-first/documentPrimaryRepositories'
 
 interface CollaboratorModalProps {
     isOpen: boolean
@@ -143,6 +146,11 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
         try {
             const { data: { user } } = await supabase.auth.getUser()
             if (!user) throw new Error('로그인이 필요합니다.')
+
+            await ensureWebTripDocumentRemoteBootstrap({
+                supabase,
+                tripId,
+            })
 
             const repo = createInvitationRepository(supabase)
             const invitation = await repo.createDocumentInvitationLink({

--- a/apps/web/components/trips/CollaboratorModal.tsx
+++ b/apps/web/components/trips/CollaboratorModal.tsx
@@ -144,21 +144,34 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
             const { data: { user } } = await supabase.auth.getUser()
             if (!user) throw new Error('로그인이 필요합니다.')
 
-            const { error: memberError } = await collaboration.inviteMember(tripId, email.trim(), inviteRole)
-            if (memberError) {
-                setError(memberError.message || '멤버 추가 중 오류가 발생했습니다.')
-                return
-            }
+            const repo = createInvitationRepository(supabase)
+            const invitation = await repo.createDocumentInvitationLink({
+                documentId: tripId,
+                role: inviteRole,
+                maxUses: 1,
+            })
+            const appUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin
+            const inviteUrl = `${appUrl}/join?token=${encodeURIComponent(invitation.token)}`
+
+            setGeneratedInvite({
+                id: invitation.id,
+                inviteUrl,
+                inviteCode: invitation.inviteCode,
+                role: invitation.role,
+                expiresAt: invitation.expiresAt,
+            })
 
             await CollaborationService.createInvite({
                 tripId,
                 email: email.trim(),
-                tripTitle
+                tripTitle,
+                inviteUrl,
+                inviteCode: invitation.inviteCode,
+                role: invitation.role,
             })
 
             setSuccess(`${email}님을 ${ROLE_LABELS[inviteRole]}(으)로 초대했습니다!`)
             setEmail('')
-            fetchCollaborators()
         } catch (err: any) {
             setError(err.message || '초대 중 오류가 발생했습니다.')
         } finally {

--- a/apps/web/components/trips/NewPlanModal.tsx
+++ b/apps/web/components/trips/NewPlanModal.tsx
@@ -289,6 +289,30 @@ export default function NewPlanModal({
             setError('장소를 선택하거나 직접 입력해 주세요.')
             return
         }
+        if (!selectedPlace.name.trim()) {
+            setError('장소 이름을 입력해 주세요.')
+            return
+        }
+        if (!visitDate) {
+            setError('방문 날짜를 선택해 주세요.')
+            return
+        }
+        if (tripStartDate && visitDate < tripStartDate) {
+            setError('방문 날짜가 여행 시작일보다 빠를 수 없습니다.')
+            return
+        }
+        if (tripEndDate && visitDate > tripEndDate) {
+            setError('방문 날짜가 여행 종료일보다 늦을 수 없습니다.')
+            return
+        }
+        if (!visitTime) {
+            setError('방문 시간을 선택해 주세요.')
+            return
+        }
+        if (!duration || Number.isNaN(Number(duration)) || Number(duration) <= 0) {
+            setError('체류 시간을 선택해 주세요.')
+            return
+        }
 
         setLoading(true)
         setError('')
@@ -538,7 +562,7 @@ export default function NewPlanModal({
                         </div>
                     ) : (
                         /* 단계 2: 상세 정보 입력 */
-                        <form onSubmit={handleSubmit} className={css({ display: 'flex', flexDirection: 'column', gap: '24px', animation: 'fadeIn 0.4s ease-out' })}>
+                        <form noValidate onSubmit={handleSubmit} className={css({ display: 'flex', flexDirection: 'column', gap: '24px', animation: 'fadeIn 0.4s ease-out' })}>
 
                             {/* 선택된 장소 편집 필드 */}
                             {selectedPlace && (

--- a/apps/web/components/trips/NewPlanModal.tsx
+++ b/apps/web/components/trips/NewPlanModal.tsx
@@ -285,7 +285,10 @@ export default function NewPlanModal({
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault()
-        if (!selectedPlace) return
+        if (!selectedPlace) {
+            setError('장소를 선택하거나 직접 입력해 주세요.')
+            return
+        }
 
         setLoading(true)
         setError('')

--- a/apps/web/components/trips/NewTripModal.tsx
+++ b/apps/web/components/trips/NewTripModal.tsx
@@ -8,6 +8,7 @@ import { useLoadScript, Autocomplete } from '@react-google-maps/api'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useRouter } from 'next/navigation'
 import { analytics } from '@/services/AnalyticsService'
+import { createWebTripDocument } from '@/lib/local-first/documentPrimaryRepositories'
 
 const libraries: ("places")[] = ["places"]
 
@@ -86,6 +87,16 @@ export default function NewTripModal({ isOpen, onClose, onSuccess }: NewTripModa
             return
         }
 
+        if (!startDate) {
+            setError('시작일을 선택해주세요.')
+            return
+        }
+
+        if (!endDate) {
+            setError('종료일을 선택해주세요.')
+            return
+        }
+
         if (new Date(startDate) > new Date(endDate)) {
             setError('종료일이 시작일보다 빠를 수 없습니다.')
             return
@@ -101,27 +112,19 @@ export default function NewTripModal({ isOpen, onClose, onSuccess }: NewTripModa
                 return
             }
 
-            const { data: trip, error: insertError } = await supabase
-                .from('trips')
-                .insert({
-                    user_id: user.id,
-                    destination,
-                    start_date: startDate,
-                    end_date: endDate,
-                    adults_count: adults,
-                    children_count: childrenCount,
-                })
-                .select()
-                .single()
+            const tripId = await createWebTripDocument({
+                supabase,
+                destination,
+                startDate,
+                endDate,
+                adultsCount: adults,
+                childrenCount,
+            })
 
-            if (insertError) throw insertError
-
-            if (trip) {
-                analytics.logTripCreate(destination)
-                if (onSuccess) onSuccess()
-                onClose()
-                router.push(`/trips/detail?id=${trip.id}`)
-            }
+            analytics.logTripCreate(destination)
+            if (onSuccess) onSuccess()
+            onClose()
+            router.push(`/trips/detail?id=${tripId}`)
         } catch (err: any) {
             setError(err.message || '여행을 생성하는 중 오류가 발생했습니다.')
         } finally {
@@ -169,7 +172,7 @@ export default function NewTripModal({ isOpen, onClose, onSuccess }: NewTripModa
                 </div>
 
                 <div className={css({ p: { base: '20px', sm: '32px' }, flex: 1 })}>
-                    <form onSubmit={handleSubmit} className={css({ display: 'flex', flexDirection: 'column', gap: '28px' })}>
+                    <form noValidate onSubmit={handleSubmit} className={css({ display: 'flex', flexDirection: 'column', gap: '28px' })}>
                         
                         <div className={css({ textAlign: 'center', mb: '4px' })}>
                             <div className={css({ w: '60px', h: '60px', bg: 'brand.primary/10', borderRadius: '16px', display: 'flex', alignItems: 'center', justifyContent: 'center', m: '0 auto 16px' })}>

--- a/apps/web/components/trips/RouteMapView.tsx
+++ b/apps/web/components/trips/RouteMapView.tsx
@@ -7,13 +7,16 @@ import { WifiOff, MapPin, AlertCircle } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { useNetworkStore } from '@/stores/useNetworkStore'
-import { collaboration } from '@/lib/collaboration'
 import { getCurrencyFromTimezone } from '@nexvoy/core'
 import { ExchangeService } from '@/services/ExternalApiService'
 import { PlanPhotoStorageService } from '@/services/PlanPhotoStorageService'
 import RouteMapInfoModal from '@/components/trips/RouteMapInfoModal'
 import PlanDetailModal from '@/components/trips/PlanDetailModal'
 import NewPlanModal from '@/components/trips/NewPlanModal'
+import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import { materializePlanTimeline } from '@nexvoy/core/local-first/materialize'
+import { planTimelineItemToWebPlanRow } from '@/lib/local-first/tripReadModelAdapters'
+import type { CreatePlanMutationInput } from '@nexvoy/core/local-first/documentMutationWriter'
 
 const GOOGLE_MAPS_LIBRARIES: ('places')[] = ['places']
 
@@ -194,23 +197,19 @@ export default function RouteMapView({
         let cancelled = false
 
         const fetchData = async () => {
-            const [plansResult, roleResult] = await Promise.all([
-                supabase
-                    .from('plans')
-                    .select('*')
-                    .eq('trip_id', tripId)
-                    .order('start_datetime_local', { ascending: true }),
-                collaboration.getUserRole(tripId),
+            const repositories = await createWebDocumentPrimaryRepositories(supabase)
+            const [planRows, role] = await Promise.all([
+                repositories.plans.listPlans(tripId),
+                getDocumentPrimaryUserRole(supabase, tripId),
             ])
 
             if (cancelled) return
 
-            if (plansResult.data) {
-                setPlans(plansResult.data.map((p: any) => ({ ...p, is_visited: p.is_visited ?? false })) as Plan[])
-            }
-            if (roleResult.data) {
-                setUserRole(roleResult.data as 'owner' | 'editor' | 'viewer')
-            }
+            setPlans(planRows.map((plan) => ({
+                ...planTimelineItemToWebPlanRow(tripId, plan),
+                is_visited: plan.isVisited,
+            })) as Plan[])
+            setUserRole(role)
             setDataLoaded(true)
         }
 
@@ -342,14 +341,22 @@ export default function RouteMapView({
             setPlans((prev) => prev.map((p) => (p.id === planId ? { ...p, is_visited: isVisited } : p)))
             setSelectedPlan((prev) => (prev && prev.id === planId ? { ...prev, is_visited: isVisited } : prev))
 
-            const { error } = await supabase.from('plans').update({ is_visited: isVisited }).eq('id', planId)
-            if (error) {
+            try {
+                if (!tripId || (userRole !== 'owner' && userRole !== 'editor')) {
+                    throw new Error('일정을 수정할 권한이 없습니다.')
+                }
+                const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+                await repositories.plans.updatePlan(tripId, {
+                    planId,
+                    patch: { isVisited },
+                })
+            } catch {
                 // Rollback
                 setPlans((prev) => prev.map((p) => (p.id === planId ? { ...p, is_visited: !isVisited } : p)))
                 setSelectedPlan((prev) => (prev && prev.id === planId ? { ...prev, is_visited: !isVisited } : prev))
             }
         },
-        [supabase]
+        [supabase, tripId, userRole]
     )
 
     const handleDetail = useCallback(
@@ -364,26 +371,57 @@ export default function RouteMapView({
 
     const handleEditPlan = useCallback(
         async (plan: any) => {
-            const { data: urlsData } = await supabase.from('plan_urls').select('url').eq('plan_id', plan.id)
-            setEditingPlan({ ...plan, plan_urls: urlsData || [] })
+            setEditingPlan({ ...plan, plan_urls: plan.plan_urls || [] })
             setDetailPlan(null)
             setIsEditModalOpen(true)
         },
-        [supabase]
+        []
     )
 
     // plans 재패칭 (수정/삭제 후)
     const refetchPlans = useCallback(async () => {
         if (!tripId) return
-        const { data } = await supabase
-            .from('plans')
-            .select('*')
-            .eq('trip_id', tripId)
-            .order('start_datetime_local', { ascending: true })
-        if (data) {
-            setPlans(data.map((p: any) => ({ ...p, is_visited: p.is_visited ?? false })) as Plan[])
-        }
+        const repositories = await createWebDocumentPrimaryRepositories(supabase)
+        const data = await repositories.plans.listPlans(tripId)
+        setPlans(data.map((plan) => ({
+            ...planTimelineItemToWebPlanRow(tripId, plan),
+            is_visited: plan.isVisited,
+        })) as Plan[])
     }, [tripId, supabase])
+
+    const handleSavePlan = useCallback(async ({ plan, editPlanId }: {
+        plan: any
+        editPlanId?: string
+    }): Promise<string> => {
+        if (!tripId) throw new Error('여행 정보를 찾을 수 없어요.')
+        if (userRole !== 'owner' && userRole !== 'editor') {
+            throw new Error('일정을 수정할 권한이 없습니다.')
+        }
+        const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+        const planId = editPlanId ?? createLocalPlanId()
+        const input = toDocumentPlanInput(planId, plan)
+        const result = editPlanId
+            ? await repositories.plans.updatePlan(tripId, {
+                planId,
+                patch: input,
+            })
+            : await repositories.plans.createPlan(tripId, input)
+
+        const savedPlan = materializePlanTimeline(result.document)
+            .find((candidate) => candidate.id === planId)
+        if (!savedPlan) {
+            throw new Error('일정 저장 결과를 문서에서 확인할 수 없습니다.')
+        }
+        const savedRow = {
+            ...planTimelineItemToWebPlanRow(tripId, savedPlan),
+            is_visited: savedPlan.isVisited,
+        } as Plan
+        setPlans((prev) => editPlanId
+            ? prev.map((candidate) => candidate.id === planId ? savedRow : candidate)
+            : [...prev, savedRow])
+
+        return planId
+    }, [supabase, tripId, userRole])
 
     const handleDeletePlan = useCallback(
         async (planId: string) => {
@@ -396,13 +434,19 @@ export default function RouteMapView({
                     console.warn('[RouteMapView] cleanupPlanPhotos failed (ignored)', cleanupErr)
                 }
             }
-            const { error } = await supabase.from('plans').delete().eq('id', planId)
-            if (!error) {
+            try {
+                if (!tripId || (userRole !== 'owner' && userRole !== 'editor')) {
+                    throw new Error('일정을 삭제할 권한이 없습니다.')
+                }
+                const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+                await repositories.plans.deletePlan(tripId, planId)
                 setPlans(prev => prev.filter(p => p.id !== planId))
                 setDetailPlan(null)
+            } catch {
+                // keep existing map state
             }
         },
-        [supabase, tripId]
+        [supabase, tripId, userRole]
     )
 
     /** 백그라운드/on-demand 업로드 성공 시 plans 동기화 */
@@ -624,6 +668,7 @@ export default function RouteMapView({
                     tripStartDate={tripStartDate}
                     tripEndDate={tripEndDate}
                     onPlanImageUpdated={handlePlanImageRecovered}
+                    onSavePlan={handleSavePlan}
                 />
             )}
 
@@ -690,4 +735,72 @@ export default function RouteMapView({
             )}
         </div>
     )
+}
+
+async function getDocumentPrimaryUserRole(
+    supabase: ReturnType<typeof createClient>,
+    tripId: string,
+): Promise<'owner' | 'editor' | 'viewer' | null> {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return null
+
+    const repositories = await createWebDocumentPrimaryRepositories(supabase)
+    const documentTrip = await repositories.trips.getTrip(tripId)
+    if (documentTrip?.ownerId === user.id) return 'owner'
+
+    const documentMember = documentTrip?.members.find((member) =>
+        member.userId === user.id && member.status === 'accepted',
+    )
+    return documentMember?.role ?? null
+}
+
+function toDocumentPlanInput(planId: string, plan: {
+    title: string
+    location: string | null
+    address: string | null
+    location_lat?: number | null
+    location_lng?: number | null
+    google_place_id?: string | null
+    image_url?: string | null
+    photo_reference?: string | null
+    start_datetime_local: string
+    end_datetime_local: string
+    timezone_string?: string | null
+    alarm_minutes_before?: number | null
+    alarm_sent_at?: string | null
+    cost?: number | null
+    memo?: string | null
+    is_completed?: boolean | null
+    is_visited?: boolean | null
+}): CreatePlanMutationInput {
+    const now = new Date().toISOString()
+    const lat = plan.location_lat ?? null
+    const lng = plan.location_lng ?? null
+
+    return {
+        id: planId,
+        title: plan.title,
+        location: plan.location,
+        address: plan.address,
+        coordinates: lat === null || lng === null ? null : { lat, lng },
+        googlePlaceId: plan.google_place_id ?? null,
+        imageUrl: plan.image_url ?? null,
+        photoReference: plan.photo_reference ?? null,
+        startDateTimeLocal: plan.start_datetime_local,
+        endDateTimeLocal: plan.end_datetime_local,
+        timezone: plan.timezone_string ?? 'Asia/Seoul',
+        alarmMinutesBefore: plan.alarm_minutes_before ?? null,
+        alarmSentAt: plan.alarm_sent_at ?? null,
+        cost: plan.cost ?? 0,
+        memo: plan.memo ?? null,
+        isCompleted: plan.is_completed ?? false,
+        isVisited: plan.is_visited ?? false,
+        createdAt: now,
+        updatedAt: now,
+    }
+}
+
+function createLocalPlanId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+    return `plan-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }

--- a/apps/web/lib/local-first/checklistDocumentWriter.ts
+++ b/apps/web/lib/local-first/checklistDocumentWriter.ts
@@ -171,7 +171,6 @@ async function ensureDocumentRegistryBootstrapped(
   try {
     await createSupabaseBackupRepository(supabase).ensureDocumentBootstrapped({
       documentId: tripDocument.trip.id,
-      ownerId: ownerContext.authUserId,
     })
   } catch {
     // Registry bootstrap must not affect the legacy row based checklist flow.

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -201,15 +201,6 @@ export async function createWebTripDocument(input: {
     schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
     snapshotPayload: update,
   })
-  await upsertTripReadModel(input.supabase, {
-    tripId,
-    ownerId: ownerContext.authUserId,
-    destination: input.destination,
-    startDate: input.startDate,
-    endDate: input.endDate,
-    adultsCount: input.adultsCount,
-    childrenCount: input.childrenCount,
-  })
 
   return tripId
 }
@@ -234,15 +225,6 @@ export async function ensureWebTripDocumentRemoteBootstrap(input: {
     documentType: 'trip',
     schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
     snapshotPayload: update,
-  })
-  await upsertTripReadModel(input.supabase, {
-    tripId: input.tripId,
-    ownerId: ownerContext.authUserId,
-    destination: document.trip.destination,
-    startDate: document.trip.startDate,
-    endDate: document.trip.endDate,
-    adultsCount: document.trip.adultsCount,
-    childrenCount: document.trip.childrenCount,
   })
 }
 
@@ -356,30 +338,4 @@ export type WebDocumentPrimaryMutationResult =
 function createEntityId(prefix: string): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
-}
-
-async function upsertTripReadModel(
-  supabase: SupabaseClient,
-  input: {
-    tripId: string
-    ownerId: string
-    destination: string
-    startDate: string
-    endDate: string
-    adultsCount: number
-    childrenCount: number
-  },
-): Promise<void> {
-  const { error } = await supabase
-    .from('trips')
-    .upsert({
-      id: input.tripId,
-      user_id: input.ownerId,
-      destination: input.destination,
-      start_date: input.startDate,
-      end_date: input.endDate,
-      adults_count: input.adultsCount,
-      children_count: input.childrenCount,
-    })
-  if (error) throw error
 }

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -122,7 +122,6 @@ async function ensureWebDocumentRegistryBootstrapped(
   try {
     await createSupabaseBackupRepository(supabase).ensureDocumentBootstrapped({
       documentId: document.trip.id,
-      ownerId: ownerContext.authUserId,
     })
   } catch {
     webDocumentRegistryBootstrapAttempted.delete(key)
@@ -145,7 +144,6 @@ async function ensureWebDocumentKeyForMutation(
   await ensureWebOwnerDocumentKey({
     supabase,
     document,
-    ownerId: ownerContext.authUserId,
   })
 }
 
@@ -196,7 +194,6 @@ export async function createWebTripDocument(input: {
   await ensureWebOwnerDocumentKeyForSnapshot({
     supabase: input.supabase,
     documentId: tripId,
-    ownerId: ownerContext.authUserId,
     documentType: 'trip',
     schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
     snapshotPayload: update,
@@ -221,7 +218,6 @@ export async function ensureWebTripDocumentRemoteBootstrap(input: {
   await ensureWebOwnerDocumentKeyForSnapshot({
     supabase: input.supabase,
     documentId: input.tripId,
-    ownerId: ownerContext.authUserId,
     documentType: 'trip',
     schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
     snapshotPayload: update,
@@ -270,7 +266,6 @@ export async function createWebTemplateDocument(input: {
   await ensureWebOwnerDocumentKeyForSnapshot({
     supabase: input.supabase,
     documentId: templateId,
-    ownerId: ownerContext.authUserId,
     documentType: 'template',
     schemaVersion: TEMPLATE_DOCUMENT_SCHEMA_VERSION,
     snapshotPayload: update,

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -178,6 +178,18 @@ export async function createWebTripDocument(input: {
     childrenCount: input.childrenCount,
     createdAt: now,
   })
+  const ownerMemberId = `member:${ownerContext.authUserId}`
+  document.members[ownerMemberId] = {
+    id: ownerMemberId,
+    userId: ownerContext.authUserId,
+    invitedEmail: null,
+    role: 'owner',
+    status: 'accepted',
+    nickname: null,
+    email: null,
+    createdAt: now,
+    updatedAt: now,
+  }
   const update = encodeTripDocumentUpdate(createYjsTripDocument(document))
 
   await tripStore.putDocument(tripId, document, update)

--- a/apps/web/lib/local-first/documentPrimaryRepositories.ts
+++ b/apps/web/lib/local-first/documentPrimaryRepositories.ts
@@ -214,6 +214,38 @@ export async function createWebTripDocument(input: {
   return tripId
 }
 
+export async function ensureWebTripDocumentRemoteBootstrap(input: {
+  supabase: SupabaseClient
+  tripId: string
+}): Promise<void> {
+  const ownerContext = await resolveWebOwnerContext(input.supabase)
+  if (!ownerContext.authUserId) throw new Error('인증 정보가 없습니다.')
+
+  const tripStore = createWebTripDocumentStore(ownerContext)
+  const document = await tripStore.getDocument(input.tripId)
+  if (!document) throw new Error('Trip document was not found.')
+  if (document.trip.ownerId !== ownerContext.authUserId) return
+
+  const update = encodeTripDocumentUpdate(createYjsTripDocument(document))
+  await ensureWebOwnerDocumentKeyForSnapshot({
+    supabase: input.supabase,
+    documentId: input.tripId,
+    ownerId: ownerContext.authUserId,
+    documentType: 'trip',
+    schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
+    snapshotPayload: update,
+  })
+  await upsertTripReadModel(input.supabase, {
+    tripId: input.tripId,
+    ownerId: ownerContext.authUserId,
+    destination: document.trip.destination,
+    startDate: document.trip.startDate,
+    endDate: document.trip.endDate,
+    adultsCount: document.trip.adultsCount,
+    childrenCount: document.trip.childrenCount,
+  })
+}
+
 export async function createWebTemplateDocument(input: {
   supabase: SupabaseClient
   title: string

--- a/apps/web/lib/local-first/guestPromotionService.ts
+++ b/apps/web/lib/local-first/guestPromotionService.ts
@@ -154,16 +154,18 @@ async function uploadInitialBackupSnapshot(
   const wrappedKey = await wrapDocumentEncryptionKey(provider, dek, kek, 1)
   const repository = createSupabaseBackupRepository(supabase)
 
+  await repository.ensureDocumentBootstrapped({
+    documentId: document.trip.id,
+    type: 'trip',
+    schemaVersion: document.schemaVersion,
+  })
   await repository.upsertSnapshot({
     documentId: document.trip.id,
-    ownerId: authUserId,
-    type: 'trip',
     schemaVersion: document.schemaVersion,
     snapshot: encryptedSnapshot,
     snapshotHash: await sha256Hex(snapshotUpdate),
     encrypted: true,
   })
-  await repository.upsertOwnerMember({ documentId: document.trip.id, userId: authUserId })
   await repository.upsertDocumentKey({
     documentId: document.trip.id,
     userId: authUserId,

--- a/apps/web/lib/local-first/keyProvisioningService.ts
+++ b/apps/web/lib/local-first/keyProvisioningService.ts
@@ -181,6 +181,13 @@ export async function ensureWebOwnerDocumentKeyForSnapshot(
   input: EnsureWebOwnerDocumentKeyForSnapshotInput,
 ): Promise<void> {
   const repository = createSupabaseBackupRepository(input.supabase)
+  await repository.ensureDocumentBootstrapped({
+    documentId: input.documentId,
+    ownerId: input.ownerId,
+    type: input.documentType,
+    schemaVersion: input.schemaVersion,
+  })
+
   const { deviceId } = await ensureWebDeviceKeyMaterial(input.supabase)
   const activeKey = await repository.getMyActiveDocumentKey({
     documentId: input.documentId,
@@ -210,10 +217,6 @@ export async function ensureWebOwnerDocumentKeyForSnapshot(
     snapshot: serializeEncryptedBackupPayload(encryptedPayload),
     snapshotHash: await sha256Hex(input.snapshotPayload),
     encrypted: true,
-  })
-  await repository.upsertOwnerMember({
-    documentId: input.documentId,
-    userId: input.ownerId,
   })
   await bootstrapWebDeviceDocumentKey({
     supabase: input.supabase,

--- a/apps/web/lib/local-first/keyProvisioningService.ts
+++ b/apps/web/lib/local-first/keyProvisioningService.ts
@@ -52,13 +52,11 @@ export interface BootstrapWebDeviceDocumentKeyInput {
 export interface EnsureWebOwnerDocumentKeyInput {
   supabase: SupabaseClient
   document: TripDocumentV1
-  ownerId: string
 }
 
 export interface EnsureWebOwnerDocumentKeyForSnapshotInput {
   supabase: SupabaseClient
   documentId: string
-  ownerId: string
   documentType: BackupDocumentType
   schemaVersion: number
   snapshotPayload: Uint8Array
@@ -170,7 +168,6 @@ export async function ensureWebOwnerDocumentKey(
   return ensureWebOwnerDocumentKeyForSnapshot({
     supabase: input.supabase,
     documentId: input.document.trip.id,
-    ownerId: input.ownerId,
     documentType: 'trip',
     schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
     snapshotPayload,
@@ -183,7 +180,6 @@ export async function ensureWebOwnerDocumentKeyForSnapshot(
   const repository = createSupabaseBackupRepository(input.supabase)
   await repository.ensureDocumentBootstrapped({
     documentId: input.documentId,
-    ownerId: input.ownerId,
     type: input.documentType,
     schemaVersion: input.schemaVersion,
   })
@@ -211,8 +207,6 @@ export async function ensureWebOwnerDocumentKeyForSnapshot(
 
   await repository.upsertSnapshot({
     documentId: input.documentId,
-    ownerId: input.ownerId,
-    type: input.documentType,
     schemaVersion: input.schemaVersion,
     snapshot: serializeEncryptedBackupPayload(encryptedPayload),
     snapshotHash: await sha256Hex(input.snapshotPayload),

--- a/apps/web/lib/local-first/legacyMigrationService.ts
+++ b/apps/web/lib/local-first/legacyMigrationService.ts
@@ -171,7 +171,6 @@ export async function migrateLegacyDocument(
     await ensureWebOwnerDocumentKeyForSnapshot({
       supabase,
       documentId: input.id,
-      ownerId: ownerContext.authUserId,
       documentType: 'trip',
       schemaVersion: TRIP_DOCUMENT_SCHEMA_VERSION,
       snapshotPayload: update,
@@ -207,7 +206,6 @@ export async function migrateLegacyDocument(
   await ensureWebOwnerDocumentKeyForSnapshot({
     supabase,
     documentId: input.id,
-    ownerId: ownerContext.authUserId,
     documentType: 'template',
     schemaVersion: TEMPLATE_DOCUMENT_SCHEMA_VERSION,
     snapshotPayload: update,

--- a/apps/web/lib/local-first/tripReadModelAdapters.ts
+++ b/apps/web/lib/local-first/tripReadModelAdapters.ts
@@ -1,0 +1,106 @@
+import type {
+  PlanTimelineItemReadModel,
+  TripDetailReadModel,
+  TripSummaryReadModel,
+} from '@nexvoy/core/local-first/materialize'
+
+export interface WebTripRowLike {
+  id: string
+  destination: string
+  start_date: string
+  end_date: string
+  adults_count: number
+  children_count: number
+  user_id: string
+  checklists?: { checklist_items: { is_checked: boolean }[] }[]
+}
+
+export interface WebTripMemberRowLike {
+  id: string
+  user_id: string | null
+  invited_email: string | null
+  role: 'owner' | 'editor' | 'viewer'
+  status: 'pending' | 'accepted' | 'revoked'
+  profiles?: {
+    nickname: string | null
+    email: string | null
+  } | null
+}
+
+export function tripSummaryToWebTripRow(summary: TripSummaryReadModel): WebTripRowLike {
+  return {
+    id: summary.id,
+    destination: summary.destination,
+    start_date: summary.startDate,
+    end_date: summary.endDate,
+    adults_count: summary.adultsCount,
+    children_count: summary.childrenCount,
+    user_id: summary.ownerId,
+    checklists: [{
+      checklist_items: createChecklistProgressItems(summary.checklistTotalCount, summary.checklistDoneCount),
+    }],
+  }
+}
+
+export function tripDetailToWebTripRow(detail: TripDetailReadModel): WebTripRowLike {
+  return {
+    id: detail.id,
+    destination: detail.destination,
+    start_date: detail.startDate,
+    end_date: detail.endDate,
+    adults_count: detail.adultsCount,
+    children_count: detail.childrenCount,
+    user_id: detail.ownerId,
+    checklists: [{
+      checklist_items: createChecklistProgressItems(detail.checklistTotalCount, detail.checklistDoneCount),
+    }],
+  }
+}
+
+export function tripDetailToWebMemberRows(detail: TripDetailReadModel): WebTripMemberRowLike[] {
+  return detail.members.map((member) => ({
+    id: member.id,
+    user_id: member.userId,
+    invited_email: member.invitedEmail,
+    role: member.role,
+    status: member.status,
+    profiles: {
+      nickname: member.nickname,
+      email: member.email,
+    },
+  }))
+}
+
+export function planTimelineItemToWebPlanRow(
+  tripId: string,
+  plan: PlanTimelineItemReadModel,
+): Record<string, unknown> {
+  return {
+    id: plan.id,
+    trip_id: tripId,
+    title: plan.title,
+    location: plan.location,
+    address: plan.address,
+    location_lat: plan.coordinates?.lat ?? null,
+    location_lng: plan.coordinates?.lng ?? null,
+    google_place_id: plan.googlePlaceId,
+    image_url: plan.imageUrl,
+    photo_reference: plan.photoReference,
+    start_datetime_local: plan.startDateTimeLocal,
+    end_datetime_local: plan.endDateTimeLocal,
+    timezone_string: plan.timezone,
+    alarm_minutes_before: plan.alarmMinutesBefore,
+    alarm_sent_at: plan.alarmSentAt,
+    cost: plan.cost,
+    memo: plan.memo,
+    is_completed: plan.isCompleted,
+    is_visited: plan.isVisited,
+    plan_urls: plan.urls,
+  }
+}
+
+function createChecklistProgressItems(totalCount: number, doneCount: number): { is_checked: boolean }[] {
+  return Array.from({ length: totalCount }, (_, index) => ({
+    is_checked: index < doneCount,
+  }))
+}

--- a/apps/web/services/ExternalApiService.ts
+++ b/apps/web/services/ExternalApiService.ts
@@ -102,7 +102,14 @@ export const PlacePhotoService = {
  * 협업 및 초대 서비스
  */
 export const CollaborationService = {
-  createInvite: async (data: { email: string; tripTitle: string; tripId: string }) => {
+  createInvite: async (data: {
+    email: string
+    tripTitle: string
+    tripId: string
+    inviteUrl: string
+    inviteCode: string
+    role: 'editor' | 'viewer'
+  }) => {
     const response = await apiService.post(`/api/invite/`, data);
     return response.data;
   }

--- a/packages/core/src/supabase/backupRepository.ts
+++ b/packages/core/src/supabase/backupRepository.ts
@@ -38,7 +38,12 @@ export interface SupabaseBackupRepository {
   hasDocumentKey(input: { documentId: string; userId: string; deviceId?: string | null; keyVersion?: number }): Promise<boolean>
   getMyActiveDocumentKey(input: { documentId: string; deviceId?: string | null; keyVersion?: number }): Promise<ActiveDocumentKeyRecord | null>
   upsertSnapshot(input: UpsertBackupDocumentInput): Promise<void>
-  ensureDocumentBootstrapped(input: { documentId: string; ownerId: string }): Promise<void>
+  ensureDocumentBootstrapped(input: {
+    documentId: string
+    ownerId: string
+    type?: BackupDocumentType
+    schemaVersion?: number
+  }): Promise<void>
   upsertOwnerMember(input: { documentId: string; userId: string }): Promise<void>
   upsertDocumentKey(input: {
     documentId: string
@@ -61,6 +66,7 @@ export function createSupabaseBackupRepository(sb: SupabaseClient): SupabaseBack
         .from('documents')
         .select('id')
         .eq('id', documentId)
+        .not('snapshot', 'is', null)
         .maybeSingle()
       if (error) throw error
       return Boolean(data)
@@ -118,8 +124,8 @@ export function createSupabaseBackupRepository(sb: SupabaseClient): SupabaseBack
         .upsert({
           id: input.documentId,
           owner_id: input.ownerId,
-          type: 'trip',
-          schema_version: 1,
+          type: input.type ?? 'trip',
+          schema_version: input.schemaVersion ?? 1,
         }, { onConflict: 'id', ignoreDuplicates: true })
 
       if (error) throw error

--- a/packages/core/src/supabase/backupRepository.ts
+++ b/packages/core/src/supabase/backupRepository.ts
@@ -13,8 +13,6 @@ import { createRestorePlan } from '../sync/syncState'
 
 export interface UpsertBackupDocumentInput {
   documentId: string
-  ownerId: string
-  type: BackupDocumentType
   schemaVersion: number
   snapshot: Uint8Array
   snapshotHash: string
@@ -40,11 +38,9 @@ export interface SupabaseBackupRepository {
   upsertSnapshot(input: UpsertBackupDocumentInput): Promise<void>
   ensureDocumentBootstrapped(input: {
     documentId: string
-    ownerId: string
     type?: BackupDocumentType
     schemaVersion?: number
   }): Promise<void>
-  upsertOwnerMember(input: { documentId: string; userId: string }): Promise<void>
   upsertDocumentKey(input: {
     documentId: string
     userId: string
@@ -105,46 +101,25 @@ export function createSupabaseBackupRepository(sb: SupabaseClient): SupabaseBack
     upsertSnapshot: async (input) => {
       const { error } = await sb
         .from('documents')
-        .upsert({
-          id: input.documentId,
-          owner_id: input.ownerId,
-          type: input.type,
+        .update({
           schema_version: input.schemaVersion,
           snapshot: input.snapshot,
           snapshot_hash: input.snapshotHash,
           encrypted: input.encrypted ?? true,
           updated_at: new Date().toISOString(),
         })
+        .eq('id', input.documentId)
+        .select('id')
+        .single()
 
       if (error) throw error
     },
     ensureDocumentBootstrapped: async (input) => {
-      const { error } = await sb
-        .from('documents')
-        .upsert({
-          id: input.documentId,
-          owner_id: input.ownerId,
-          type: input.type ?? 'trip',
-          schema_version: input.schemaVersion ?? 1,
-        }, { onConflict: 'id', ignoreDuplicates: true })
-
-      if (error) throw error
-
-      await createSupabaseBackupRepository(sb).upsertOwnerMember({
-        documentId: input.documentId,
-        userId: input.ownerId,
+      const { error } = await sb.rpc('bootstrap_owner_document', {
+        p_document_id: input.documentId,
+        p_type: input.type ?? 'trip',
+        p_schema_version: input.schemaVersion ?? 1,
       })
-    },
-    upsertOwnerMember: async (input) => {
-      const { error } = await sb
-        .from('document_members')
-        .upsert({
-          document_id: input.documentId,
-          user_id: input.userId,
-          role: 'owner',
-          status: 'accepted',
-          updated_at: new Date().toISOString(),
-        }, { onConflict: 'document_id,user_id' })
 
       if (error) throw error
     },

--- a/supabase/migrations/20260716000001_task043_atomic_owner_document_bootstrap.sql
+++ b/supabase/migrations/20260716000001_task043_atomic_owner_document_bootstrap.sql
@@ -1,0 +1,160 @@
+-- TASK-043: establish a document and its owner membership atomically.
+-- Client-side writes previously created these rows in separate requests, which
+-- left local-only documents whenever either RLS-protected request failed.
+
+CREATE OR REPLACE FUNCTION public.bootstrap_owner_document(
+  p_document_id uuid,
+  p_type text,
+  p_schema_version integer DEFAULT 1
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_id uuid := auth.uid();
+  existing_owner_id uuid;
+  existing_type text;
+  affected_rows integer;
+BEGIN
+  IF actor_id IS NULL THEN
+    RAISE EXCEPTION '로그인이 필요합니다.';
+  END IF;
+
+  IF p_document_id IS NULL
+    OR p_type NOT IN ('trip', 'template')
+    OR p_schema_version IS NULL
+    OR p_schema_version < 1 THEN
+    RAISE EXCEPTION '유효하지 않은 문서 생성 요청입니다.';
+  END IF;
+
+  SELECT owner_id, type
+    INTO existing_owner_id, existing_type
+  FROM public.documents
+  WHERE id = p_document_id
+  FOR UPDATE;
+
+  IF FOUND AND existing_owner_id <> actor_id THEN
+    RAISE EXCEPTION '권한이 없습니다.';
+  END IF;
+
+  IF FOUND AND existing_type <> p_type THEN
+    RAISE EXCEPTION '문서 유형이 일치하지 않습니다.';
+  END IF;
+
+  INSERT INTO public.documents (
+    id,
+    owner_id,
+    type,
+    schema_version,
+    updated_at
+  )
+  VALUES (
+    p_document_id,
+    actor_id,
+    p_type,
+    p_schema_version,
+    timezone('utc', now())
+  )
+  ON CONFLICT (id) DO UPDATE
+    SET schema_version = GREATEST(public.documents.schema_version, EXCLUDED.schema_version)
+    WHERE public.documents.owner_id = actor_id
+      AND public.documents.type = EXCLUDED.type;
+
+  GET DIAGNOSTICS affected_rows = ROW_COUNT;
+  IF affected_rows <> 1 THEN
+    RAISE EXCEPTION '권한이 없습니다.';
+  END IF;
+
+  INSERT INTO public.document_members (
+    document_id,
+    user_id,
+    role,
+    status,
+    updated_at
+  )
+  VALUES (
+    p_document_id,
+    actor_id,
+    'owner',
+    'accepted',
+    timezone('utc', now())
+  )
+  ON CONFLICT (document_id, user_id) DO UPDATE
+    SET role = 'owner',
+        status = 'accepted',
+        updated_at = EXCLUDED.updated_at;
+
+  RETURN jsonb_build_object(
+    'document_id', p_document_id,
+    'owner_id', actor_id,
+    'type', p_type,
+    'schema_version', p_schema_version
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.bootstrap_owner_document(uuid, text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bootstrap_owner_document(uuid, text, integer) TO authenticated;
+
+-- The current product starts from document-primary data. Legacy row tables are
+-- not an authority source and must not grant document access implicitly.
+CREATE OR REPLACE FUNCTION public.check_is_document_owner(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.documents
+    WHERE id = _document_id
+      AND owner_id = _user_id
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+      AND role = 'owner'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_is_document_member(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT public.check_is_document_owner(_document_id, _user_id)
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_is_document_editor(_document_id uuid, _user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT public.check_is_document_owner(_document_id, _user_id)
+  OR EXISTS (
+    SELECT 1
+    FROM public.document_members
+    WHERE document_id = _document_id
+      AND user_id = _user_id
+      AND status = 'accepted'
+      AND role IN ('owner', 'editor')
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.check_is_document_owner(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_is_document_member(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.check_is_document_editor(uuid, uuid) TO anon, authenticated;

--- a/supabase/migrations/20260716000002_task043_document_registry_write_hardening.sql
+++ b/supabase/migrations/20260716000002_task043_document_registry_write_hardening.sql
@@ -1,0 +1,10 @@
+-- TASK-043: document authority mutations must go through authenticated RPCs.
+-- Snapshot updates remain RLS-protected direct updates, while document creation
+-- and membership changes are handled by SECURITY DEFINER functions that derive
+-- the actor from auth.uid().
+
+DROP POLICY IF EXISTS "Insert documents as owner" ON public.documents;
+
+DROP POLICY IF EXISTS "Insert document members as owner" ON public.document_members;
+DROP POLICY IF EXISTS "Update document members as owner" ON public.document_members;
+DROP POLICY IF EXISTS "Delete document members as owner" ON public.document_members;

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -25,6 +25,7 @@ TASK-043은 Closed Beta 테스트 중 확인된 Web trip entry 회귀를 수정�
 - TripClient role 조회가 document owner/member snapshot을 우선 사용하고 legacy role query는 fallback으로만 사용한다.
 - Web 신규 trip document에 owner member snapshot을 추가해 owner read model이 비어 있지 않게 했다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
+- NewPlanModal form에 `noValidate`를 적용하고 방문 날짜/시간/체류 시간 검증을 React 경로에서 명시 처리한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.
 - RouteMapView의 일정 조회/수정/삭제/저장 경로도 Supabase row 직접 접근에서 document-primary repository로 전환했다.
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -24,6 +24,7 @@ TASK-043은 Closed Beta 테스트 중 확인된 Web trip entry 회귀를 수정�
 - Trip detail layout이 `repositories.trips.getTrip()` 결과를 기준으로 trip header와 member rows를 구성한다.
 - TripClient role 조회가 document owner/member snapshot을 우선 사용하고 legacy role query는 fallback으로만 사용한다.
 - Web 신규 trip document에 owner member snapshot을 추가해 owner read model이 비어 있지 않게 했다.
+- Home/Global modal의 `NewTripModal` 생성 경로도 legacy `trips.insert().select()`에서 `createWebTripDocument()`로 전환했다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
 - NewPlanModal form에 `noValidate`를 적용하고 방문 날짜/시간/체류 시간 검증을 React 경로에서 명시 처리한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -26,6 +26,7 @@ TASK-043은 Closed Beta 테스트 중 확인된 Web trip entry 회귀를 수정�
 - Web 신규 trip document에 owner member snapshot을 추가해 owner read model이 비어 있지 않게 했다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.
+- RouteMapView의 일정 조회/수정/삭제/저장 경로도 Supabase row 직접 접근에서 document-primary repository로 전환했다.
 
 ## Verification
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -7,7 +7,8 @@ TASK-043은 Closed Beta 테스트 중 확인된 Web trip entry 회귀를 수정�
 `TripDocumentV1` read model을 우선 사용하도록 정리했다. 신규 Web 여행 생성 시 owner member snapshot을
 문서에 포함해 협업/초대 UI가 owner 권한을 안정적으로 판정하도록 보강했다. 추가로 신규 document snapshot/key
 bootstrap이 owner member 생성 전에 `get_my_active_document_key`를 호출해 `권한이 없습니다.`로 실패하던 순서를
-수정했다.
+수정했다. 후속 권한 감사에서는 원격 DB migration 누락과 client-side registry upsert가 함께 문제를 만들고 있음을
+확인해, document authority 초기화를 `auth.uid()` 기반 원자 RPC로 단일화했다.
 
 ## Artifacts
 
@@ -34,6 +35,12 @@ bootstrap이 owner member 생성 전에 `get_my_active_document_key`를 호출�
 - 로컬 IndexedDB에는 여행이 있지만 Supabase `documents`/`document_members` registry가 비어 있는 중간 상태에서도, owner가 초대 생성 전에 원격 snapshot/key/read-model을 재부트스트랩하도록 보강했다.
 - 신규 Web/Mobile document-primary trip 생성 및 초대 전 원격 부트스트랩에서 legacy `trips.upsert()` dual-write를 제거했다. 원격 기준은 `documents` encrypted snapshot과 `document_members` registry로 단일화한다.
 - Web trip detail 진입 시 owner 세션은 key readiness/backup flush 전에 로컬 문서의 원격 registry/snapshot/key bootstrap을 먼저 시도한다.
+- `bootstrap_owner_document()` RPC가 `documents`와 owner `document_members`를 한 transaction에서 생성하며 client 입력 owner id를 받지 않는다.
+- snapshot 저장은 기존 `documents` row의 owner RLS UPDATE만 사용하고 document INSERT/upsert를 수행하지 않는다.
+- Web guest promotion과 Mobile 초기 snapshot도 동일한 registry bootstrap 순서를 사용한다.
+- document owner/member/editor 판정에서 legacy `trips`/`trip_members` fallback을 제거했다.
+- `documents` 직접 INSERT와 `document_members` 직접 쓰기 정책을 제거해 document authority 변경은 검증 RPC로만 수행한다.
+- 원격 Supabase에 누락되어 있던 TASK-037 member conflict index와 TASK-043 document authority migration을 적용했다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
 - NewPlanModal form에 `noValidate`를 적용하고 방문 날짜/시간/체류 시간 검증을 React 경로에서 명시 처리한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.
@@ -44,17 +51,22 @@ bootstrap이 owner member 생성 전에 `get_my_active_document_key`를 호출�
 | 명령 | 결과 |
 | --- | --- |
 | `pnpm --filter @nexvoy/core test` | PASS |
-| `pnpm -C packages/core typecheck` | PASS |
+| `pnpm typecheck` | PASS |
 | `pnpm -C apps/web exec tsc --noEmit` | PASS |
 | `pnpm build` | PASS |
 | `pnpm build:mobile` | PASS, 기존 `react-native-webrtc`/`event-target-shim` export warning만 발생 |
+| `supabase db lint --local --level error` | PASS |
+| Local RLS/RPC SQL integration | PASS: owner bootstrap/update 허용, 타 사용자 bootstrap 및 직접 INSERT 차단 |
 
 ## Notes
 
 - 이미 Supabase `documents`에 존재하는 과거 snapshot은 document-primary 데이터로 간주되어 목록에 표시될 수 있다.
   이번 수정은 legacy row-only 여행이 제품 목록에 섞이는 경로를 제거한 것이다.
-- `pnpm typecheck`는 출력상 TypeScript 오류는 없지만 workspace filter 실행이 `tsc` shim으로 빠져 exit code 1을 반환했다.
-  개별 core/web 검증과 mobile build는 통과했다.
+- 오류 기간에 encrypted snapshot 없이 특정 브라우저 IndexedDB에만 저장된 여행은 새 로그인/기기에서 자동 복원할 수 없다.
+  원본 브라우저의 local document가 남아 있다면 owner detail bootstrap으로 원격 복구할 수 있다.
+- 원격 DB에서 `20260712` 이후 migration이 누락되어 있었고, TASK-021/025/028 signaling migration은 관리 스키마
+  `realtime.messages`가 `supabase_realtime_admin` 소유라 일반 migration 계정으로 적용되지 않는다. 이 세 migration은
+  완료 처리하지 않았으며 P2P private channel 권한 배포 방식을 별도 인프라 작업으로 해결해야 한다.
 
 # Walkthrough: TASK-042 Legacy Migration Tool
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -30,6 +30,7 @@ bootstrap이 owner member 생성 전에 `get_my_active_document_key`를 호출�
 - Web/Mobile 신규 document 생성 시 `documents` owner row와 `document_members` owner row를 먼저 확보한 뒤 active key RPC를 호출한다.
 - `ensureDocumentBootstrapped()`가 trip/template type과 schema version을 입력받도록 확장했다.
 - `hasSnapshot()`은 빈 `documents` bootstrap row가 아니라 실제 snapshot payload 존재 여부를 반환하도록 정정했다.
+- 이메일 동행자 초대 경로가 legacy `trip_members.insert()`를 호출하지 않고 document invitation link RPC를 생성한 뒤 해당 링크/코드를 메일로 발송하도록 변경했다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
 - NewPlanModal form에 `noValidate`를 적용하고 방문 날짜/시간/체류 시간 검증을 React 경로에서 명시 처리한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,47 @@
+# Walkthrough: TASK-043 Document-Primary Trip Entry Fix
+
+## Summary
+
+TASK-043은 Closed Beta 테스트 중 확인된 Web trip entry 회귀를 수정했다. 홈 목록이 legacy row-only 여행을
+직접 읽던 경로를 제거하고 document-primary repository 목록으로 전환했으며, 여행 상세 진입도 `trips` row가 아니라
+`TripDocumentV1` read model을 우선 사용하도록 정리했다. 신규 Web 여행 생성 시 owner member snapshot을
+문서에 포함해 협업/초대 UI가 owner 권한을 안정적으로 판정하도록 보강했다.
+
+## Artifacts
+
+- GitHub Issue [#346](https://github.com/ysjee141/nexvoy-frontend/issues/346)
+- 브랜치: `feature/task-043-document-primary-trip-entry`
+- `apps/web/app/HomeClient.tsx`
+- `apps/web/app/trips/detail/TripLayoutClient.tsx`
+- `apps/web/app/trips/detail/TripClient.tsx`
+- `apps/web/lib/local-first/documentPrimaryRepositories.ts`
+- `apps/web/lib/local-first/tripReadModelAdapters.ts`
+
+## Key Changes
+
+- Home trip list에서 `trips`/`trip_members`/`checklists` row 직접 조회를 제거하고 `repositories.trips.listTrips()`를 사용한다.
+- `TripSummaryReadModel`/`TripDetailReadModel`을 기존 Web 카드/상세 row shape로 변환하는 adapter를 추가했다.
+- Trip detail layout이 `repositories.trips.getTrip()` 결과를 기준으로 trip header와 member rows를 구성한다.
+- TripClient role 조회가 document owner/member snapshot을 우선 사용하고 legacy role query는 fallback으로만 사용한다.
+- Web 신규 trip document에 owner member snapshot을 추가해 owner read model이 비어 있지 않게 했다.
+
+## Verification
+
+| 명령 | 결과 |
+| --- | --- |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm -C packages/core typecheck` | PASS |
+| `pnpm -C apps/web exec tsc --noEmit` | PASS |
+| `pnpm build` | PASS |
+| `pnpm build:mobile` | PASS, 기존 `react-native-webrtc`/`event-target-shim` export warning만 발생 |
+
+## Notes
+
+- 이미 Supabase `documents`에 존재하는 과거 snapshot은 document-primary 데이터로 간주되어 목록에 표시될 수 있다.
+  이번 수정은 legacy row-only 여행이 제품 목록에 섞이는 경로를 제거한 것이다.
+- `pnpm typecheck`는 출력상 TypeScript 오류는 없지만 workspace filter 실행이 `tsc` shim으로 빠져 exit code 1을 반환했다.
+  개별 core/web 검증과 mobile build는 통과했다.
+
 # Walkthrough: TASK-042 Legacy Migration Tool
 
 ## Summary

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -31,6 +31,7 @@ bootstrap이 owner member 생성 전에 `get_my_active_document_key`를 호출�
 - `ensureDocumentBootstrapped()`가 trip/template type과 schema version을 입력받도록 확장했다.
 - `hasSnapshot()`은 빈 `documents` bootstrap row가 아니라 실제 snapshot payload 존재 여부를 반환하도록 정정했다.
 - 이메일 동행자 초대 경로가 legacy `trip_members.insert()`를 호출하지 않고 document invitation link RPC를 생성한 뒤 해당 링크/코드를 메일로 발송하도록 변경했다.
+- 로컬 IndexedDB에는 여행이 있지만 Supabase `documents`/`document_members` registry가 비어 있는 중간 상태에서도, owner가 초대 생성 전에 원격 snapshot/key/read-model을 재부트스트랩하도록 보강했다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
 - NewPlanModal form에 `noValidate`를 적용하고 방문 날짜/시간/체류 시간 검증을 React 경로에서 명시 처리한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -32,6 +32,7 @@ bootstrap이 owner member 생성 전에 `get_my_active_document_key`를 호출�
 - `hasSnapshot()`은 빈 `documents` bootstrap row가 아니라 실제 snapshot payload 존재 여부를 반환하도록 정정했다.
 - 이메일 동행자 초대 경로가 legacy `trip_members.insert()`를 호출하지 않고 document invitation link RPC를 생성한 뒤 해당 링크/코드를 메일로 발송하도록 변경했다.
 - 로컬 IndexedDB에는 여행이 있지만 Supabase `documents`/`document_members` registry가 비어 있는 중간 상태에서도, owner가 초대 생성 전에 원격 snapshot/key/read-model을 재부트스트랩하도록 보강했다.
+- 신규 Web/Mobile document-primary trip 생성 및 초대 전 원격 부트스트랩에서 legacy `trips.upsert()` dual-write를 제거했다. 원격 기준은 `documents` encrypted snapshot과 `document_members` registry로 단일화한다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
 - NewPlanModal form에 `noValidate`를 적용하고 방문 날짜/시간/체류 시간 검증을 React 경로에서 명시 처리한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -5,7 +5,9 @@
 TASK-043은 Closed Beta 테스트 중 확인된 Web trip entry 회귀를 수정했다. 홈 목록이 legacy row-only 여행을
 직접 읽던 경로를 제거하고 document-primary repository 목록으로 전환했으며, 여행 상세 진입도 `trips` row가 아니라
 `TripDocumentV1` read model을 우선 사용하도록 정리했다. 신규 Web 여행 생성 시 owner member snapshot을
-문서에 포함해 협업/초대 UI가 owner 권한을 안정적으로 판정하도록 보강했다.
+문서에 포함해 협업/초대 UI가 owner 권한을 안정적으로 판정하도록 보강했다. 추가로 신규 document snapshot/key
+bootstrap이 owner member 생성 전에 `get_my_active_document_key`를 호출해 `권한이 없습니다.`로 실패하던 순서를
+수정했다.
 
 ## Artifacts
 
@@ -25,6 +27,9 @@ TASK-043은 Closed Beta 테스트 중 확인된 Web trip entry 회귀를 수정�
 - TripClient role 조회가 document owner/member snapshot을 우선 사용하고 legacy role query는 fallback으로만 사용한다.
 - Web 신규 trip document에 owner member snapshot을 추가해 owner read model이 비어 있지 않게 했다.
 - Home/Global modal의 `NewTripModal` 생성 경로도 legacy `trips.insert().select()`에서 `createWebTripDocument()`로 전환했다.
+- Web/Mobile 신규 document 생성 시 `documents` owner row와 `document_members` owner row를 먼저 확보한 뒤 active key RPC를 호출한다.
+- `ensureDocumentBootstrapped()`가 trip/template type과 schema version을 입력받도록 확장했다.
+- `hasSnapshot()`은 빈 `documents` bootstrap row가 아니라 실제 snapshot payload 존재 여부를 반환하도록 정정했다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
 - NewPlanModal form에 `noValidate`를 적용하고 방문 날짜/시간/체류 시간 검증을 React 경로에서 명시 처리한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -33,6 +33,7 @@ bootstrap이 owner member 생성 전에 `get_my_active_document_key`를 호출�
 - 이메일 동행자 초대 경로가 legacy `trip_members.insert()`를 호출하지 않고 document invitation link RPC를 생성한 뒤 해당 링크/코드를 메일로 발송하도록 변경했다.
 - 로컬 IndexedDB에는 여행이 있지만 Supabase `documents`/`document_members` registry가 비어 있는 중간 상태에서도, owner가 초대 생성 전에 원격 snapshot/key/read-model을 재부트스트랩하도록 보강했다.
 - 신규 Web/Mobile document-primary trip 생성 및 초대 전 원격 부트스트랩에서 legacy `trips.upsert()` dual-write를 제거했다. 원격 기준은 `documents` encrypted snapshot과 `document_members` registry로 단일화한다.
+- Web trip detail 진입 시 owner 세션은 key readiness/backup flush 전에 로컬 문서의 원격 registry/snapshot/key bootstrap을 먼저 시도한다.
 - NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
 - NewPlanModal form에 `noValidate`를 적용하고 방문 날짜/시간/체류 시간 검증을 React 경로에서 명시 처리한다.
 - 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -24,6 +24,8 @@ TASK-043은 Closed Beta 테스트 중 확인된 Web trip entry 회귀를 수정�
 - Trip detail layout이 `repositories.trips.getTrip()` 결과를 기준으로 trip header와 member rows를 구성한다.
 - TripClient role 조회가 document owner/member snapshot을 우선 사용하고 legacy role query는 fallback으로만 사용한다.
 - Web 신규 trip document에 owner member snapshot을 추가해 owner read model이 비어 있지 않게 했다.
+- NewPlanModal이 장소 미선택 상태에서 조용히 return하지 않고 오류 메시지를 표시한다.
+- 일정 저장 후 mutation 결과 document에서 저장된 plan을 즉시 materialize해 화면 state에 반영한다.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- switch the Web home trip list from legacy row queries to document-primary repository reads
- make trip detail layout read TripDocumentV1 detail models instead of trips rows
- resolve TripClient role from document owner/member data before falling back to legacy role lookup
- add Web read-model adapters for existing card/detail row-shaped UI
- include owner member snapshot when creating new Web trip documents

## Verification
- pnpm --filter @nexvoy/core test
- pnpm -C packages/core typecheck
- pnpm -C apps/web exec tsc --noEmit
- pnpm build
- pnpm build:mobile

Notes: pnpm typecheck currently exits 1 because workspace filter execution falls through to the tsc shim despite reporting no TypeScript errors. Individual core/web checks and mobile build passed.

Closes #346