### PR TITLE
feat(TASK-044): unify targeted document invitations

### DIFF
--- a/apps/web/app/api/invite/route.ts
+++ b/apps/web/app/api/invite/route.ts
@@ -1,83 +1,139 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { createInvitationRepository } from '@nexvoy/core/supabase/invitationRepository'
+import { createClient } from '@/lib/supabase/server'
+
+interface InviteRequestBody {
+  documentId?: unknown
+  email?: unknown
+  role?: unknown
+  destination?: unknown
+  startDate?: unknown
+  endDate?: unknown
+}
 
 export async function POST(req: NextRequest) {
-    try {
-        const { email, tripTitle, inviteUrl, inviteCode, role } = await req.json()
+  let invitationId: string | null = null
 
-        if (!email || !tripTitle || !inviteUrl || !inviteCode) {
-            return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
-        }
+  try {
+    const body = await req.json() as InviteRequestBody
+    const documentId = requiredString(body.documentId)
+    const email = normalizeEmail(body.email)
+    const role = body.role === 'viewer' ? 'viewer' : body.role === 'editor' ? 'editor' : null
+    const destination = optionalString(body.destination, 120)
+    const startDate = optionalDate(body.startDate)
+    const endDate = optionalDate(body.endDate)
 
-        const apiKey = process.env.RESEND_API_KEY
-        if (!apiKey) {
-            return NextResponse.json({ error: 'Resend API Key is not configured' }, { status: 500 })
-        }
-
-        const safeTripTitle = escapeHtml(String(tripTitle))
-        const safeInviteUrl = escapeHtml(String(inviteUrl))
-        const safeInviteCode = escapeHtml(String(inviteCode))
-        const roleLabel = role === 'viewer' ? '조회 전용' : '편집 가능'
-
-        // 라이브러리 대신 표준 fetch API를 사용하여 Resend REST API 호출
-        const response = await fetch('https://api.resend.com/emails', {
-            method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${apiKey}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                from: '온여정 <onboarding@nexvoy.xyz>',
-                to: [email],
-                subject: `[온여정] ${tripTitle} 여행의 동행자로 초대받으셨어요! ✈️`,
-                html: `
-                    <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #eee; border-radius: 12px;">
-                        <h2 style="color: #3B82F6;">온여정 초대장 ✈️</h2>
-                        <p>안녕하세요, 여행자님! 🌏</p>
-                        <p><strong>${safeTripTitle}</strong> 여정을 함께 채워갈 소중한 동행자로 초대받으셨어요.</p>
-                        <p>초대 권한: <strong>${roleLabel}</strong></p>
-                        <p>아래 링크를 통해 초대 내용을 확인하고 수락해 주시겠어요?</p>
-                        <div style="margin: 30px 0;">
-                            <a href="${safeInviteUrl}" 
-                               style="background-color: #111; color: white; padding: 12px 24px; text-decoration: none; border-radius: 8px; font-weight: bold; display: inline-block;">
-                                초대 확인하기
-                            </a>
-                        </div>
-                        <p style="color: #666; font-size: 14px;">링크가 열리지 않으면 온여정의 초대 코드 입력 화면에서 <strong>${safeInviteCode}</strong>를 입력해 주세요.</p>
-                        <p style="color: #666; font-size: 14px;">이 메일은 설레는 여정의 시작, 온여정에서 보냈어요.</p>
-                    </div>
-                `,
-            })
-        })
-
-        const data = await response.json()
-        console.log('Resend API Response:', data)
-
-        if (!response.ok) {
-            let errorMessage = data.message || 'Failed to send email'
-
-            // Resend Sandbox 관련 특수 안내
-            if (data.message?.includes('onboarding@resend.dev') || data.code === 403) {
-                errorMessage = 'Resend 무료 플랜(Sandbox)에서는 가입된 계정 이외의 이메일로 발송하려면 도메인 인증이 필요합니다.'
-            }
-
-            return NextResponse.json({
-                error: errorMessage,
-                details: data
-            }, { status: response.status })
-        }
-
-        return NextResponse.json({ success: true, data })
-    } catch (err: any) {
-        console.error('Invite API Error:', err)
-        return NextResponse.json({ error: err.message }, { status: 500 })
+    if (!documentId || !email || !role) {
+      return NextResponse.json({ error: '초대 정보를 확인해 주세요.' }, { status: 400 })
     }
+
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: '로그인이 필요합니다.' }, { status: 401 })
+    }
+    if (user.email?.toLowerCase() === email) {
+      return NextResponse.json({ error: '본인에게는 초대를 보낼 수 없습니다.' }, { status: 400 })
+    }
+
+    const repository = createInvitationRepository(supabase)
+    const invitation = await repository.createDocumentInvitationLink({
+      documentId,
+      role,
+      maxUses: 1,
+      targetEmail: email,
+      destination,
+      startDate,
+      endDate,
+    })
+    invitationId = invitation.id
+
+    const apiKey = process.env.RESEND_API_KEY
+    if (!apiKey) throw new Error('Resend API Key is not configured')
+
+    const appOrigin = process.env.NEXT_PUBLIC_APP_URL || req.nextUrl.origin
+    const inviteUrl = new URL('/join', appOrigin)
+    inviteUrl.searchParams.set('token', invitation.token)
+    const title = '새 여행'
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: '온여정 <onboarding@nexvoy.xyz>',
+        to: [email],
+        subject: `[온여정] ${title} 동행 초대`,
+        html: createInviteEmailHtml({
+          title,
+          inviteUrl: inviteUrl.toString(),
+          inviteCode: invitation.inviteCode,
+          role,
+        }),
+      }),
+    })
+
+    const resendResult = await response.json() as { message?: string; code?: number }
+    if (!response.ok) {
+      throw new Error(resendResult.message || '초대 메일을 보내지 못했습니다.')
+    }
+
+    return NextResponse.json({ invitation, inviteUrl: inviteUrl.toString() })
+  } catch (error) {
+    if (invitationId) {
+      try {
+        const supabase = await createClient()
+        await createInvitationRepository(supabase).revokeDocumentInvitationLink(invitationId)
+      } catch {
+        // The original failure remains the actionable error.
+      }
+    }
+    const message = error instanceof Error ? error.message : '초대 중 오류가 발생했습니다.'
+    const status = message === '권한이 없습니다.' ? 403 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+function createInviteEmailHtml(input: {
+  title: string
+  inviteUrl: string
+  inviteCode: string
+  role: 'editor' | 'viewer'
+}): string {
+  const title = escapeHtml(input.title)
+  const inviteUrl = escapeHtml(input.inviteUrl)
+  const inviteCode = escapeHtml(input.inviteCode)
+  const roleLabel = input.role === 'viewer' ? '조회 전용' : '편집 가능'
+  return `<div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px;border:1px solid #e5e7eb;border-radius:8px">
+    <h2 style="color:#2563eb">온여정 초대</h2>
+    <p><strong>${title}</strong> 여정의 동행자로 초대받았습니다.</p>
+    <p>권한: <strong>${roleLabel}</strong></p>
+    <p><a href="${inviteUrl}" style="background:#2563eb;color:white;padding:12px 20px;text-decoration:none;border-radius:8px;display:inline-block">초대 확인하기</a></p>
+    <p style="color:#6b7280;font-size:14px">링크가 열리지 않으면 초대 코드 <strong>${inviteCode}</strong>를 입력해 주세요.</p>
+  </div>`
+}
+
+function requiredString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function optionalString(value: unknown, maxLength: number): string | null {
+  const normalized = requiredString(value)
+  return normalized ? normalized.slice(0, maxLength) : null
+}
+
+function normalizeEmail(value: unknown): string | null {
+  const email = requiredString(value)?.toLowerCase() ?? null
+  return email && /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email) ? email : null
+}
+
+function optionalDate(value: unknown): string | null {
+  const date = requiredString(value)
+  return date && /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : null
 }
 
 function escapeHtml(value: string): string {
-    return value
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
-        .replaceAll("'", '&#39;')
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;').replaceAll("'", '&#39;')
 }

--- a/apps/web/components/trips/CollaboratorModal.tsx
+++ b/apps/web/components/trips/CollaboratorModal.tsx
@@ -5,9 +5,8 @@ import { createClient } from '@/lib/supabase/client'
 import { css } from 'styled-system/css'
 import { X, UserPlus, Mail, Shield, Eye, Pencil, Trash2, Loader2, CheckCircle2, AlertCircle, ChevronDown, Link as LinkIcon, Copy, Share2 } from 'lucide-react'
 import { CollaborationService } from '@/services/ExternalApiService'
-import { collaboration } from '@/lib/collaboration'
 import { useScrollLock } from '@/hooks/useScrollLock'
-import { createInvitationRepository } from '@nexvoy/core/supabase/invitationRepository'
+import { createInvitationRepository, type DocumentPendingInvitation } from '@nexvoy/core/supabase/invitationRepository'
 import type { DocumentKeyProvisioningRequest } from '@nexvoy/core/sync/keyProvisioning'
 import {
     DocumentKeyProvisioningStatusBadge,
@@ -66,6 +65,7 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
     const [inviteRole, setInviteRole] = useState<'editor' | 'viewer'>('editor')
     const [loading, setLoading] = useState(false)
     const [collaborators, setCollaborators] = useState<Collaborator[]>([])
+    const [pendingInvitations, setPendingInvitations] = useState<DocumentPendingInvitation[]>([])
     const [error, setError] = useState('')
     const [success, setSuccess] = useState('')
     const [editingRoleId, setEditingRoleId] = useState<string | null>(null)
@@ -111,28 +111,32 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
     }, [isOpen, canInvite, tripId])
 
     const fetchCollaborators = async () => {
-        const { data, error } = await supabase
-            .from('trip_members')
-            .select('*, profiles(nickname, email)')
-            .eq('trip_id', tripId)
-
-        if (error) {
-            console.error('Error fetching collaborators:', error)
-            return
+        try {
+            const repository = createInvitationRepository(supabase)
+            const [rows, pending] = await Promise.all([
+                repository.listDocumentCollaborators(tripId),
+                repository.listDocumentPendingInvitations(tripId).catch(() => []),
+            ])
+            const formatted: Collaborator[] = rows.map((item) => ({
+                memberId: item.memberId,
+                userId: item.userId,
+                nickname: item.nickname,
+                email: item.email || item.invitedEmail || '',
+                role: item.role,
+                joined_at: item.createdAt,
+                status: item.status,
+            }))
+            setCollaborators(formatted)
+            setPendingInvitations(pending)
+            const { data: { user } } = await supabase.auth.getUser()
+            const actorRole = user?.id === ownerId
+                ? 'owner'
+                : formatted.find((member) => member.userId === user?.id)?.role ?? null
+            await syncCollaboratorSnapshot(formatted, actorRole)
+        } catch (fetchError) {
+            console.error('Error fetching collaborators:', fetchError)
+            setError('동행자 목록을 불러오지 못했습니다.')
         }
-
-        const formatted: Collaborator[] = (data || []).map((item: any) => ({
-            memberId: item.id,
-            userId: item.user_id || null,
-            nickname: item.profiles?.nickname || null,
-            email: item.profiles?.email || item.invited_email || '',
-            role: item.role,
-            joined_at: item.created_at,
-            status: item.status || 'accepted',
-        }))
-
-        setCollaborators(formatted)
-        await syncCollaboratorSnapshot(formatted)
     }
 
     const handleInvite = async (e: React.FormEvent) => {
@@ -152,34 +156,25 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
                 tripId,
             })
 
-            const repo = createInvitationRepository(supabase)
-            const invitation = await repo.createDocumentInvitationLink({
+            const result = await CollaborationService.createInvite({
                 documentId: tripId,
+                email: email.trim(),
+                destination: tripTitle,
                 role: inviteRole,
-                maxUses: 1,
             })
-            const appUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin
-            const inviteUrl = `${appUrl}/join?token=${encodeURIComponent(invitation.token)}`
+            const invitation = result.invitation
 
             setGeneratedInvite({
                 id: invitation.id,
-                inviteUrl,
+                inviteUrl: result.inviteUrl,
                 inviteCode: invitation.inviteCode,
                 role: invitation.role,
                 expiresAt: invitation.expiresAt,
             })
 
-            await CollaborationService.createInvite({
-                tripId,
-                email: email.trim(),
-                tripTitle,
-                inviteUrl,
-                inviteCode: invitation.inviteCode,
-                role: invitation.role,
-            })
-
             setSuccess(`${email}님을 ${ROLE_LABELS[inviteRole]}(으)로 초대했습니다!`)
             setEmail('')
+            await fetchCollaborators()
         } catch (err: any) {
             setError(err.message || '초대 중 오류가 발생했습니다.')
         } finally {
@@ -190,10 +185,8 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
     const handleRoleChange = async (memberId: string, newRole: MemberRole) => {
         if (newRole === 'owner') return
 
-        const { error } = await collaboration.updateMemberRole(memberId, newRole)
-        if (error) {
-            alert('권한 변경 실패: ' + (typeof error === 'string' ? error : error.message))
-        } else {
+        try {
+            await createInvitationRepository(supabase).setDocumentMemberRole({ memberId, role: newRole })
             setCollaborators(prev =>
                 prev.map(m => m.memberId === memberId ? { ...m, role: newRole } : m)
             )
@@ -201,6 +194,8 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
             if (member) {
                 await upsertCollaboratorSnapshot({ ...member, role: newRole })
             }
+        } catch (roleError) {
+            alert('권한 변경 실패: ' + formatErrorMessage(roleError))
         }
         setEditingRoleId(null)
     }
@@ -208,10 +203,8 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
     const handleRemove = async (memberId: string, isSelf: boolean = false) => {
         if (!confirm(isSelf ? '정말 이 여정에서 나가시겠습니까?' : '이 멤버를 제외하시겠습니까?')) return
 
-        const { error } = await collaboration.removeMember(memberId)
-        if (error) {
-            alert((isSelf ? '나가기 실패: ' : '멤버 삭제 실패: ') + formatErrorMessage(error))
-        } else {
+        try {
+            await createInvitationRepository(supabase).revokeDocumentMember(memberId)
             if (isSelf) {
                 await revokeCollaboratorSnapshot(memberId)
                 onClose()
@@ -220,13 +213,15 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
                 await revokeCollaboratorSnapshot(memberId)
                 fetchCollaborators()
             }
+        } catch (removeError) {
+            alert((isSelf ? '나가기 실패: ' : '멤버 삭제 실패: ') + formatErrorMessage(removeError))
         }
     }
 
-    const syncCollaboratorSnapshot = async (members: Collaborator[]) => {
+    const syncCollaboratorSnapshot = async (members: Collaborator[], actorRole: MemberRole | null) => {
         try {
             const repositories = await createWebDocumentPrimaryRepositories(supabase, {
-                actorRole: currentMemberRole ?? null,
+                actorRole,
             })
             await Promise.all(members.map((member) =>
                 repositories.members.upsertMember(tripId, {
@@ -559,6 +554,18 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
                                 </p>
                             ) : null}
                         />
+                    ) : null}
+
+                    {canInvite && pendingInvitations.length > 0 ? (
+                        <div className={css({ display: 'flex', flexDirection: 'column', gap: '8px' })}>
+                            <h3 className={css({ fontSize: '14px', fontWeight: '700', color: 'brand.ink' })}>수락 대기 ({pendingInvitations.length})</h3>
+                            {pendingInvitations.map((invitation) => (
+                                <div key={invitation.id} className={css({ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px', p: '10px 12px', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '8px' })}>
+                                    <span className={css({ minW: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '13px', color: 'brand.ink' })}>{invitation.targetEmail}</span>
+                                    <span className={css({ flexShrink: 0, fontSize: '11px', color: 'brand.muted' })}>{ROLE_LABELS[invitation.role]}</span>
+                                </div>
+                            ))}
+                        </div>
                     ) : null}
 
                     <div className={css({ display: 'flex', flexDirection: 'column', gap: '12px' })}>

--- a/apps/web/components/trips/InvitationBanner.tsx
+++ b/apps/web/components/trips/InvitationBanner.tsx
@@ -1,111 +1,91 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { css } from 'styled-system/css'
-import { Mail, Check, X, Loader2 } from 'lucide-react'
+import { Check, Loader2, Mail, X } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { collaboration } from '@/lib/collaboration'
+import {
+    createInvitationRepository,
+    type PendingDocumentInvitation,
+} from '@nexvoy/core/supabase/invitationRepository'
+import { createClient } from '@/lib/supabase/client'
 
 export default function InvitationBanner() {
-    const [invitations, setInvitations] = useState<any[]>([])
+    const [invitations, setInvitations] = useState<PendingDocumentInvitation[]>([])
     const [loading, setLoading] = useState(true)
     const [processingId, setProcessingId] = useState<string | null>(null)
+    const [error, setError] = useState<string | null>(null)
     const router = useRouter()
 
     const fetchInvitations = useCallback(async () => {
-        const { data } = await collaboration.getInvitedTrips()
-        if (data) setInvitations(data)
-        setLoading(false)
+        try {
+            const rows = await createInvitationRepository(createClient()).listMyPendingDocumentInvitations()
+            setInvitations(rows)
+        } catch {
+            setError('초대 목록을 불러오지 못했습니다.')
+        } finally {
+            setLoading(false)
+        }
     }, [])
 
     useEffect(() => {
-        fetchInvitations()
+        void fetchInvitations()
     }, [fetchInvitations])
 
-    const handleAccept = async (id: string) => {
+    const processInvitation = async (id: string, action: 'accept' | 'decline') => {
         setProcessingId(id)
-        const { error } = await collaboration.acceptInvite(id)
-        if (!error) {
-            setInvitations(prev => prev.filter(inv => inv.id !== id))
-            router.refresh() // 메인 페이지의 서버 컴포넌트 데이터 갱신
-        } else {
-            alert('초대를 수락하다가 잠시 문제가 생겼어요. 다시 한번 시도해 주시겠어요?')
+        setError(null)
+        try {
+            const repository = createInvitationRepository(createClient())
+            if (action === 'accept') await repository.acceptMyDocumentInvitation(id)
+            else await repository.declineMyDocumentInvitation(id)
+            setInvitations((current) => current.filter((invitation) => invitation.id !== id))
+            router.refresh()
+        } catch {
+            setError(action === 'accept' ? '초대를 수락하지 못했습니다.' : '초대를 거절하지 못했습니다.')
+        } finally {
+            setProcessingId(null)
         }
-        setProcessingId(null)
     }
 
-    if (loading || invitations.length === 0) return null
+    if (loading || (invitations.length === 0 && !error)) return null
 
     return (
-        <div className={css({
-            bg: 'bg.softCotton',
-            borderBottom: '1px solid',
-            borderBottomColor: 'brand.border',
-            px: '20px',
-            py: '12px'
-        })}>
-            <div className={css({
-                maxW: 'screen-xl',
-                mx: 'auto',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                flexDirection: { base: 'column', sm: 'row' },
-                gap: '12px'
-            })}>
-                <div className={css({ display: 'flex', alignItems: 'center', gap: '8px', color: 'brand.primary', fontSize: '14px', fontWeight: '500' })}>
-                    <Mail size={18} />
-                    <span>반가운 소식! 새로운 여행 초대 {invitations.length}건이 도착했어요! 💌</span>
-                </div>
-
-                <div className={css({ display: 'flex', gap: '8px', w: { base: '100%', sm: 'auto' } })}>
-                    {invitations.map((inv) => (
-                        <div key={inv.id} className={css({
-                            bg: 'white',
-                            px: '12px',
-                            py: '6px',
-                            borderRadius: '8px',
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: '12px',
-                            boxShadow: 'dimensional',
-                            w: { base: '100%', sm: 'auto' },
-                            border: '1px solid',
-                            borderColor: 'brand.border'
-                        })}>
-                            <span className={css({ fontSize: '13px', fontWeight: 'bold', color: 'brand.secondary' })}>
-                                {inv.trips?.destination || '여행'}
-                            </span>
-                            <div className={css({ display: 'flex', gap: '4px' })}>
-                                <button
-                                    onClick={() => handleAccept(inv.id)}
-                                    disabled={processingId === inv.id}
-                                    className={css({
-                                        bg: 'brand.primary',
-                                        color: 'white',
-                                        border: 'none',
-                                        borderRadius: '8px',
-                                        px: '12px',
-                                        py: '6px',
-                                        fontSize: '12px',
-                                        fontWeight: 'bold',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        gap: '4px',
-                                        transition: 'all 0.2s',
-                                        _hover: { bg: 'brand.primaryDark', transform: 'scale(1.02)' },
-                                        _disabled: { opacity: 0.5 }
-                                    })}
-                                >
-                                    {processingId === inv.id ? <Loader2 size={12} className={css({ animation: 'spin 1s linear infinite' })} /> : <Check size={12} />}
-                                    수락
+        <section className={css({ bg: 'bg.softCotton', borderBottom: '1px solid', borderColor: 'brand.border', px: '20px', py: '12px' })} aria-label="여행 초대">
+            <div className={css({ maxW: 'screen-xl', mx: 'auto', display: 'flex', flexDirection: 'column', gap: '10px' })}>
+                {invitations.length > 0 && (
+                    <div className={css({ display: 'flex', alignItems: 'center', gap: '8px', color: 'brand.primary', fontSize: '14px', fontWeight: '700' })}>
+                        <Mail size={18} aria-hidden="true" />
+                        새로운 여행 초대 {invitations.length}건
+                    </div>
+                )}
+                <div className={css({ display: 'flex', flexWrap: 'wrap', gap: '8px' })}>
+                    {invitations.map((invitation) => (
+                        <article key={invitation.id} className={css({ bg: 'white', px: '12px', py: '10px', borderRadius: '8px', display: 'flex', alignItems: 'center', gap: '12px', border: '1px solid', borderColor: 'brand.border', maxW: '100%' })}>
+                            <div className={css({ minW: 0 })}>
+                                <strong className={css({ display: 'block', fontSize: '13px', color: 'brand.secondary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })}>
+                                    {invitation.destination || '새 여행'}
+                                </strong>
+                                <span className={css({ fontSize: '12px', color: 'brand.muted' })}>
+                                    {invitation.ownerNickname || '동행자'} · {invitation.role === 'editor' ? '편집 가능' : '조회 전용'}
+                                </span>
+                            </div>
+                            <div className={css({ display: 'flex', gap: '4px', flexShrink: 0 })}>
+                                <button type="button" onClick={() => void processInvitation(invitation.id, 'accept')} disabled={processingId === invitation.id} aria-label="초대 수락" className={actionButtonStyle}>
+                                    {processingId === invitation.id ? <Loader2 size={14} className={css({ animation: 'spin 1s linear infinite' })} /> : <Check size={14} />}
+                                </button>
+                                <button type="button" onClick={() => void processInvitation(invitation.id, 'decline')} disabled={processingId === invitation.id} aria-label="초대 거절" className={declineButtonStyle}>
+                                    <X size={14} />
                                 </button>
                             </div>
-                        </div>
+                        </article>
                     ))}
                 </div>
+                {error && <p role="alert" className={css({ color: 'brand.error', fontSize: '13px', fontWeight: '600' })}>{error}</p>}
             </div>
-        </div>
+        </section>
     )
 }
+
+const actionButtonStyle = css({ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', w: '32px', h: '32px', bg: 'brand.primary', color: 'white', border: 'none', borderRadius: '8px', cursor: 'pointer', _disabled: { opacity: 0.5 } })
+const declineButtonStyle = css({ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', w: '32px', h: '32px', bg: 'white', color: 'brand.muted', border: '1px solid', borderColor: 'brand.border', borderRadius: '8px', cursor: 'pointer', _disabled: { opacity: 0.5 } })

--- a/apps/web/services/ExternalApiService.ts
+++ b/apps/web/services/ExternalApiService.ts
@@ -104,10 +104,10 @@ export const PlacePhotoService = {
 export const CollaborationService = {
   createInvite: async (data: {
     email: string
-    tripTitle: string
-    tripId: string
-    inviteUrl: string
-    inviteCode: string
+    destination: string
+    documentId: string
+    startDate?: string | null
+    endDate?: string | null
     role: 'editor' | 'viewer'
   }) => {
     const response = await apiService.post(`/api/invite/`, data);

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -11,6 +11,14 @@
 - `TASK-044`에서 targeted invitation authority를 통합하고 `TASK-045`에서 join UX와 key delivery를 제품화한다.
 - 두 task의 Web/Mobile 다중 사용자 검증 완료 전 Closed Beta 초대 기능은 준비되지 않은 것으로 판정한다.
 
+2026-07-16 TASK-044 완료:
+
+- targeted invitation에 정규화된 대상 이메일과 최소 표시 metadata를 추가했다.
+- Web 메일 API가 세션과 document editor 권한을 검증하고 서버에서 token/code/link를 생성한다.
+- 홈 pending 초대와 협업자 관리가 legacy `trip_members` 대신 document registry RPC를 사용한다.
+- targeted token/code 수락은 로그인 계정 이메일이 일치할 때만 허용한다.
+- wrapped key 자동 전달과 참여 준비 UX는 계획대로 `TASK-045`에서 완료한다.
+
 ## 0. 목표 정정
 
 이번 refactor의 최종 목표는 "준비물 Web-to-Web P2P 검증"이 아니다. 목표는 OnVoy 핵심 기능 전체를 Web/Mobile 양쪽에서 Local-first 기반으로 전환하는 것이다.

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -105,7 +105,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-040-document-primary-product-path-cutover.md` | 완료 | 여행/일정/준비물/템플릿 제품 경로에서 legacy hydrate/fallback 제거, Issue #339 |
 | `TASK-041-backup-freshness-and-cost-control.md` | 완료 | local-first freshness, metadata 기반 backup pull/upload, Supabase 비용 최소화, Issue #341 |
 | `TASK-042-legacy-migration-tool.md` | 완료 | 기존 row 데이터를 명시적으로 document-primary로 전환하는 Web dev migration tool, Issue #343 |
-| `TASK-044-targeted-document-invitation-authority.md` | 예정 | 이메일 대상 초대 authority, pending 초대, 안전한 메일 발송, document member registry 통합 |
+| `TASK-044-targeted-document-invitation-authority.md` | 완료 | 이메일 대상 초대 authority, pending 초대, 안전한 메일 발송, document member registry 통합 |
 | `TASK-045-invitation-join-and-key-delivery-productization.md` | 예정 | Web/Mobile join UX, 자동 key provisioning, restore 및 multi-user E2E 완성 |
 
 현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `TASK-038`부터는 ADR-014에 따라 Closed Beta 기준선을 기존 row 자동 migration에서 신규 document-primary 데이터로 재설정한다. 기존 row 데이터는 제품 경로에서 자동 hydrate하지 않고, `TASK-042`의 명시적 migration tool source로만 남긴다.
@@ -186,7 +186,7 @@ rotating room secret 보안 하드닝을 완료했다.
 
 ### Phase 8: Invitation Closed Beta Blocker
 
-- [ ] `TASK-044-targeted-document-invitation-authority.md`: 이메일·pending UI·링크·코드 초대를 document authority로 통합
+- [x] `TASK-044-targeted-document-invitation-authority.md`: 이메일·pending UI·링크·코드 초대를 document authority로 통합
 - [ ] `TASK-045-invitation-join-and-key-delivery-productization.md`: 참여 UX, 자동 key 전달, restore 및 다중 사용자 E2E 완성
 
 ## 권장 시작 순서

--- a/docs/refactor/tasks/TASK-044-targeted-document-invitation-authority.md
+++ b/docs/refactor/tasks/TASK-044-targeted-document-invitation-authority.md
@@ -1,6 +1,6 @@
 # TASK-044: Targeted Document Invitation Authority
 
-- 상태: 예정
+- 상태: 완료
 
 ## 목적
 
@@ -84,4 +84,3 @@
 - 이메일, pending UI, 링크, 코드 초대가 하나의 document authority로 동작한다.
 - targeted invitation은 대상 계정만 수락할 수 있다.
 - accepted member가 협업자 목록, local document member snapshot, P2P peer 구성에 일관되게 반영된다.
-

--- a/packages/core/src/supabase/__tests__/invitationRepository.test.ts
+++ b/packages/core/src/supabase/__tests__/invitationRepository.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createInvitationRepository } from '../invitationRepository'
+
+const calls: Array<{ name: string; params?: Record<string, unknown> }> = []
+const responses: Record<string, unknown> = {
+  create_document_invitation_link: {
+    id: 'invite-1', document_id: 'document-1', role: 'editor', token: 'token',
+    invite_code: 'ABC123', expires_at: null, max_uses: 1,
+    target_email: 'friend@example.com', invitation_kind: 'targeted',
+  },
+  list_my_pending_document_invitations: [{
+    id: 'invite-1', document_id: 'document-1', role: 'editor', destination: '전주',
+    start_date: '2026-07-20', end_date: '2026-07-24', owner_nickname: 'owner',
+    expires_at: null, created_at: '2026-07-16T00:00:00.000Z',
+  }],
+  list_document_collaborators: [{
+    member_id: 'member-1', user_id: 'user-1', invited_email: null, nickname: 'owner',
+    email: 'owner@example.com', role: 'owner', status: 'accepted',
+    created_at: '2026-07-16T00:00:00.000Z', updated_at: '2026-07-16T00:00:00.000Z',
+  }],
+}
+
+const supabase = {
+  rpc: async (name: string, params?: Record<string, unknown>) => {
+    calls.push({ name, params })
+    return { data: responses[name] ?? null, error: null }
+  },
+} as unknown as SupabaseClient
+
+async function main(): Promise<void> {
+  const repository = createInvitationRepository(supabase)
+  const created = await repository.createDocumentInvitationLink({
+    documentId: 'document-1', role: 'editor', targetEmail: 'friend@example.com',
+    destination: '전주', startDate: '2026-07-20', endDate: '2026-07-24',
+  })
+
+  assert.equal(created.invitationKind, 'targeted')
+  assert.equal(created.targetEmail, 'friend@example.com')
+  assert.deepEqual(calls[0], {
+    name: 'create_document_invitation_link',
+    params: {
+      p_document_id: 'document-1', p_role: 'editor', p_expires_at: null, p_max_uses: 1,
+      p_target_email: 'friend@example.com', p_destination: '전주',
+      p_start_date: '2026-07-20', p_end_date: '2026-07-24',
+    },
+  })
+
+  const pending = await repository.listMyPendingDocumentInvitations()
+  assert.equal(pending[0]?.destination, '전주')
+  assert.equal(pending[0]?.ownerNickname, 'owner')
+
+  const collaborators = await repository.listDocumentCollaborators('document-1')
+  assert.equal(collaborators[0]?.role, 'owner')
+  assert.equal(collaborators[0]?.status, 'accepted')
+}
+
+void main()

--- a/packages/core/src/supabase/invitationRepository.ts
+++ b/packages/core/src/supabase/invitationRepository.ts
@@ -25,6 +25,10 @@ export interface CreateDocumentInvitationInput {
   role: DocumentInvitationRole
   expiresAt?: string | null
   maxUses?: number | null
+  targetEmail?: string | null
+  destination?: string | null
+  startDate?: string | null
+  endDate?: string | null
 }
 
 export interface CreatedDocumentInvitation {
@@ -35,6 +39,41 @@ export interface CreatedDocumentInvitation {
   inviteCode: string
   expiresAt: string | null
   maxUses: number | null
+  targetEmail: string | null
+  invitationKind: 'generic' | 'targeted'
+}
+
+export interface PendingDocumentInvitation {
+  id: string
+  documentId: string
+  role: DocumentInvitationRole
+  destination: string | null
+  startDate: string | null
+  endDate: string | null
+  ownerNickname: string | null
+  expiresAt: string | null
+  createdAt: string
+}
+
+export interface DocumentCollaborator {
+  memberId: string
+  userId: string | null
+  invitedEmail: string | null
+  nickname: string | null
+  email: string | null
+  role: DocumentInvitationRole | 'owner'
+  status: 'pending' | 'accepted' | 'revoked'
+  createdAt: string
+  updatedAt: string
+}
+
+export interface DocumentPendingInvitation {
+  id: string
+  documentId: string
+  role: DocumentInvitationRole
+  targetEmail: string
+  expiresAt: string | null
+  createdAt: string
 }
 
 export interface DocumentInvitationLookup {
@@ -159,6 +198,11 @@ export interface InvitationRepository {
   createDocumentInvitationLink(input: CreateDocumentInvitationInput): Promise<CreatedDocumentInvitation>
   getDocumentInvitationSummary(input: DocumentInvitationLookup): Promise<DocumentInvitationSummary | null>
   acceptDocumentInvitation(input: DocumentInvitationLookup): Promise<AcceptedDocumentInvitation>
+  listMyPendingDocumentInvitations(): Promise<PendingDocumentInvitation[]>
+  acceptMyDocumentInvitation(invitationId: string): Promise<AcceptedDocumentInvitation>
+  declineMyDocumentInvitation(invitationId: string): Promise<void>
+  listDocumentCollaborators(documentId: string): Promise<DocumentCollaborator[]>
+  listDocumentPendingInvitations(documentId: string): Promise<DocumentPendingInvitation[]>
   registerUserKeyMaterial(input: RegisterUserKeyMaterialInput): Promise<UserKeyMaterialRegistration>
   revokeUserKeyMaterial(input: RevokeUserKeyMaterialInput): Promise<void>
   requestDocumentKeyProvisioning(input: RequestDocumentKeyProvisioningInput): Promise<DocumentKeyProvisioningStatusRecord>
@@ -186,6 +230,10 @@ export function createInvitationRepository(sb: SupabaseClient): InvitationReposi
         p_role: input.role,
         p_expires_at: input.expiresAt ?? null,
         p_max_uses: input.maxUses ?? 1,
+        p_target_email: input.targetEmail ?? null,
+        p_destination: input.destination ?? null,
+        p_start_date: input.startDate ?? null,
+        p_end_date: input.endDate ?? null,
       })
       if (error) throw error
       return toCreatedDocumentInvitation(data)
@@ -205,6 +253,38 @@ export function createInvitationRepository(sb: SupabaseClient): InvitationReposi
       })
       if (error) throw error
       return toAcceptedDocumentInvitation(data)
+    },
+    listMyPendingDocumentInvitations: async () => {
+      const { data, error } = await sb.rpc('list_my_pending_document_invitations')
+      if (error) throw error
+      return (Array.isArray(data) ? data : []).map(toPendingDocumentInvitation)
+    },
+    acceptMyDocumentInvitation: async (invitationId) => {
+      const { data, error } = await sb.rpc('accept_my_document_invitation', {
+        p_invitation_id: invitationId,
+      })
+      if (error) throw error
+      return toAcceptedDocumentInvitation(data)
+    },
+    declineMyDocumentInvitation: async (invitationId) => {
+      const { error } = await sb.rpc('decline_my_document_invitation', {
+        p_invitation_id: invitationId,
+      })
+      if (error) throw error
+    },
+    listDocumentCollaborators: async (documentId) => {
+      const { data, error } = await sb.rpc('list_document_collaborators', {
+        p_document_id: documentId,
+      })
+      if (error) throw error
+      return (Array.isArray(data) ? data : []).map(toDocumentCollaborator)
+    },
+    listDocumentPendingInvitations: async (documentId) => {
+      const { data, error } = await sb.rpc('list_document_pending_invitations', {
+        p_document_id: documentId,
+      })
+      if (error) throw error
+      return (Array.isArray(data) ? data : []).map(toDocumentPendingInvitation)
     },
     registerUserKeyMaterial: async (input) => {
       const { data, error } = await sb.rpc('register_user_key_material', {
@@ -420,6 +500,50 @@ function toCreatedDocumentInvitation(value: unknown): CreatedDocumentInvitation 
     inviteCode: expectString(row.invite_code),
     expiresAt: nullableString(row.expires_at),
     maxUses: nullableNumber(row.max_uses),
+    targetEmail: nullableString(row.target_email),
+    invitationKind: row.invitation_kind === 'targeted' ? 'targeted' : 'generic',
+  }
+}
+
+function toPendingDocumentInvitation(value: unknown): PendingDocumentInvitation {
+  const row = expectRecord(value)
+  return {
+    id: expectString(row.id),
+    documentId: expectString(row.document_id),
+    role: expectInvitationRole(row.role),
+    destination: nullableString(row.destination),
+    startDate: nullableString(row.start_date),
+    endDate: nullableString(row.end_date),
+    ownerNickname: nullableString(row.owner_nickname),
+    expiresAt: nullableString(row.expires_at),
+    createdAt: expectString(row.created_at),
+  }
+}
+
+function toDocumentCollaborator(value: unknown): DocumentCollaborator {
+  const row = expectRecord(value)
+  return {
+    memberId: expectString(row.member_id),
+    userId: nullableString(row.user_id),
+    invitedEmail: nullableString(row.invited_email),
+    nickname: nullableString(row.nickname),
+    email: nullableString(row.email),
+    role: row.role === 'owner' ? 'owner' : expectInvitationRole(row.role),
+    status: row.status === 'pending' || row.status === 'revoked' ? row.status : 'accepted',
+    createdAt: expectString(row.created_at),
+    updatedAt: expectString(row.updated_at),
+  }
+}
+
+function toDocumentPendingInvitation(value: unknown): DocumentPendingInvitation {
+  const row = expectRecord(value)
+  return {
+    id: expectString(row.id),
+    documentId: expectString(row.document_id),
+    role: expectInvitationRole(row.role),
+    targetEmail: expectString(row.target_email),
+    expiresAt: nullableString(row.expires_at),
+    createdAt: expectString(row.created_at),
   }
 }
 

--- a/supabase/migrations/20260716000003_task044_targeted_document_invitations.sql
+++ b/supabase/migrations/20260716000003_task044_targeted_document_invitations.sql
@@ -1,0 +1,313 @@
+-- TASK-044: targeted invitation authority for document-primary collaboration.
+
+ALTER TABLE public.document_invitation_links
+  ADD COLUMN IF NOT EXISTS target_email text,
+  ADD COLUMN IF NOT EXISTS invitation_kind text NOT NULL DEFAULT 'generic'
+    CHECK (invitation_kind IN ('generic', 'targeted')),
+  ADD COLUMN IF NOT EXISTS destination text,
+  ADD COLUMN IF NOT EXISTS start_date date,
+  ADD COLUMN IF NOT EXISTS end_date date;
+
+CREATE INDEX IF NOT EXISTS document_invitation_links_target_email_idx
+  ON public.document_invitation_links(target_email)
+  WHERE target_email IS NOT NULL AND revoked_at IS NULL;
+
+ALTER FUNCTION public.create_document_invitation_link(uuid, text, timestamp with time zone, integer)
+  RENAME TO create_document_invitation_link_legacy;
+
+CREATE OR REPLACE FUNCTION public.create_document_invitation_link(
+  p_document_id uuid,
+  p_role text,
+  p_expires_at timestamp with time zone DEFAULT NULL,
+  p_max_uses integer DEFAULT 1,
+  p_target_email text DEFAULT NULL,
+  p_destination text DEFAULT NULL,
+  p_start_date date DEFAULT NULL,
+  p_end_date date DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  normalized_email text := NULLIF(lower(btrim(p_target_email)), '');
+  result jsonb;
+BEGIN
+  IF auth.uid() IS NULL OR NOT public.check_is_document_editor(p_document_id, auth.uid()) THEN
+    RAISE EXCEPTION '권한이 없습니다.';
+  END IF;
+
+  IF normalized_email IS NOT NULL AND normalized_email !~ '^[^@[:space:]]+@[^@[:space:]]+[.][^@[:space:]]+$' THEN
+    RAISE EXCEPTION '유효한 이메일 주소를 입력해 주세요.';
+  END IF;
+
+  IF normalized_email IS NOT NULL THEN
+    UPDATE public.document_invitation_links
+      SET revoked_at = timezone('utc', now()), updated_at = timezone('utc', now())
+      WHERE document_id = p_document_id
+        AND target_email = normalized_email
+        AND revoked_at IS NULL
+        AND used_count = 0;
+  END IF;
+
+  result := public.create_document_invitation_link_legacy(
+    p_document_id, p_role, p_expires_at, p_max_uses
+  );
+
+  UPDATE public.document_invitation_links
+    SET target_email = normalized_email,
+        invitation_kind = CASE WHEN normalized_email IS NULL THEN 'generic' ELSE 'targeted' END,
+        destination = NULLIF(btrim(p_destination), ''),
+        start_date = p_start_date,
+        end_date = p_end_date,
+        updated_at = timezone('utc', now())
+    WHERE id = (result ->> 'id')::uuid;
+
+  RETURN result || jsonb_build_object(
+    'target_email', normalized_email,
+    'invitation_kind', CASE WHEN normalized_email IS NULL THEN 'generic' ELSE 'targeted' END
+  );
+END;
+$$;
+
+ALTER FUNCTION public.accept_document_invitation(text, text)
+  RENAME TO accept_document_invitation_unchecked;
+
+CREATE OR REPLACE FUNCTION public.assert_targeted_invitation_recipient(p_invitation_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  expected_email text;
+  current_email text := lower(COALESCE(auth.jwt() ->> 'email', ''));
+BEGIN
+  SELECT target_email INTO expected_email
+  FROM public.document_invitation_links
+  WHERE id = p_invitation_id;
+
+  IF expected_email IS NOT NULL AND expected_email <> current_email THEN
+    RAISE EXCEPTION '이 초대는 다른 계정으로 전송되었습니다.';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.accept_document_invitation(
+  p_token text DEFAULT NULL,
+  p_invite_code text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  invitation_id uuid;
+BEGIN
+  SELECT id INTO invitation_id
+  FROM public.document_invitation_links
+  WHERE (NULLIF(p_token, '') IS NOT NULL AND token_hash = public.document_registry_hash(p_token))
+     OR (NULLIF(p_invite_code, '') IS NOT NULL AND invite_code_hash = public.document_registry_hash(
+       upper(regexp_replace(p_invite_code, '[^[:alnum:]]', '', 'g'))
+     ))
+  LIMIT 1;
+
+  IF invitation_id IS NULL THEN
+    RAISE EXCEPTION '유효하지 않거나 만료된 초대입니다.';
+  END IF;
+
+  PERFORM public.assert_targeted_invitation_recipient(invitation_id);
+  RETURN public.accept_document_invitation_unchecked(p_token, p_invite_code);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_document_invitation_summary(
+  p_token text DEFAULT NULL,
+  p_invite_code text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  link_record public.document_invitation_links%ROWTYPE;
+BEGIN
+  SELECT * INTO link_record
+  FROM public.document_invitation_links
+  WHERE (NULLIF(p_token, '') IS NOT NULL AND token_hash = public.document_registry_hash(p_token))
+     OR (NULLIF(p_invite_code, '') IS NOT NULL AND invite_code_hash = public.document_registry_hash(
+       upper(regexp_replace(p_invite_code, '[^[:alnum:]]', '', 'g'))
+     ))
+  LIMIT 1;
+
+  IF NOT FOUND OR link_record.revoked_at IS NOT NULL
+    OR (link_record.expires_at IS NOT NULL AND link_record.expires_at <= timezone('utc', now()))
+    OR (link_record.max_uses IS NOT NULL AND link_record.used_count >= link_record.max_uses) THEN
+    RAISE EXCEPTION '유효하지 않거나 만료된 초대입니다.';
+  END IF;
+
+  RETURN (
+    SELECT jsonb_build_object(
+      'document_id', d.id, 'document_type', d.type, 'role', link_record.role,
+      'expires_at', link_record.expires_at, 'destination', link_record.destination,
+      'start_date', link_record.start_date, 'end_date', link_record.end_date,
+      'owner_nickname', p.nickname,
+      'member_count', (SELECT count(*) FROM public.document_members dm
+        WHERE dm.document_id = d.id AND dm.status = 'accepted')
+    )
+    FROM public.documents d JOIN public.profiles p ON p.id = d.owner_id
+    WHERE d.id = link_record.document_id
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_my_pending_document_invitations()
+RETURNS SETOF jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'id', l.id, 'document_id', l.document_id, 'role', l.role,
+    'destination', l.destination, 'start_date', l.start_date, 'end_date', l.end_date,
+    'owner_nickname', p.nickname, 'expires_at', l.expires_at, 'created_at', l.created_at
+  )
+  FROM public.document_invitation_links l
+  JOIN public.documents d ON d.id = l.document_id
+  JOIN public.profiles p ON p.id = d.owner_id
+  WHERE auth.uid() IS NOT NULL
+    AND l.invitation_kind = 'targeted'
+    AND l.target_email = lower(COALESCE(auth.jwt() ->> 'email', ''))
+    AND l.revoked_at IS NULL AND l.used_count = 0
+    AND (l.expires_at IS NULL OR l.expires_at > timezone('utc', now()))
+  ORDER BY l.created_at DESC;
+$$;
+
+CREATE OR REPLACE FUNCTION public.accept_my_document_invitation(p_invitation_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  link_record public.document_invitation_links%ROWTYPE;
+  member_id uuid;
+  queued_count integer := 0;
+  already_accepted boolean := false;
+BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION '로그인이 필요합니다.'; END IF;
+  SELECT * INTO link_record FROM public.document_invitation_links WHERE id = p_invitation_id FOR UPDATE;
+  IF NOT FOUND OR link_record.revoked_at IS NOT NULL OR link_record.used_count > 0
+    OR (link_record.expires_at IS NOT NULL AND link_record.expires_at <= timezone('utc', now())) THEN
+    RAISE EXCEPTION '유효하지 않거나 만료된 초대입니다.';
+  END IF;
+  PERFORM public.assert_targeted_invitation_recipient(link_record.id);
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.document_members
+    WHERE document_id = link_record.document_id AND user_id = auth.uid() AND status = 'accepted'
+  ) OR public.check_is_document_owner(link_record.document_id, auth.uid())
+  INTO already_accepted;
+
+  IF NOT already_accepted THEN
+    UPDATE public.document_members
+      SET user_id = auth.uid(), role = link_record.role, status = 'accepted',
+          updated_at = timezone('utc', now())
+      WHERE document_id = link_record.document_id
+        AND invited_email = link_record.target_email AND status <> 'accepted'
+      RETURNING id INTO member_id;
+
+    IF member_id IS NULL THEN
+      INSERT INTO public.document_members(document_id, user_id, invited_email, role, status, updated_at)
+      VALUES (link_record.document_id, auth.uid(), link_record.target_email, link_record.role, 'accepted', timezone('utc', now()))
+      ON CONFLICT (document_id, user_id) DO UPDATE SET
+        status = 'accepted', updated_at = EXCLUDED.updated_at
+      RETURNING id INTO member_id;
+    END IF;
+  END IF;
+
+  UPDATE public.document_invitation_links SET used_count = 1, updated_at = timezone('utc', now())
+  WHERE id = link_record.id;
+
+  IF NOT public.check_is_document_owner(link_record.document_id, auth.uid()) THEN
+    queued_count := public.upsert_key_provisioning_requests_for_user(
+      link_record.document_id, auth.uid(), 1, auth.uid()
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'document_id', link_record.document_id, 'role', link_record.role,
+    'status', 'accepted', 'already_member', already_accepted,
+    'requires_key_provisioning', queued_count > 0,
+    'key_provisioning_status', CASE WHEN queued_count > 0 THEN 'pending' ELSE 'completed' END,
+    'queued_request_count', queued_count
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.decline_my_document_invitation(p_invitation_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM public.assert_targeted_invitation_recipient(p_invitation_id);
+  UPDATE public.document_invitation_links
+    SET revoked_at = timezone('utc', now()), updated_at = timezone('utc', now())
+    WHERE id = p_invitation_id AND used_count = 0;
+  IF NOT FOUND THEN RAISE EXCEPTION '유효하지 않거나 만료된 초대입니다.'; END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_document_collaborators(p_document_id uuid)
+RETURNS SETOF jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'member_id', dm.id, 'user_id', dm.user_id, 'invited_email', dm.invited_email,
+    'nickname', p.nickname, 'email', COALESCE(p.email, dm.invited_email),
+    'role', dm.role, 'status', dm.status, 'created_at', dm.created_at, 'updated_at', dm.updated_at
+  )
+  FROM public.document_members dm LEFT JOIN public.profiles p ON p.id = dm.user_id
+  WHERE dm.document_id = p_document_id
+    AND public.check_is_document_member(p_document_id, auth.uid())
+    AND dm.status = 'accepted'
+  ORDER BY CASE dm.role WHEN 'owner' THEN 0 ELSE 1 END, dm.created_at;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_document_pending_invitations(p_document_id uuid)
+RETURNS SETOF jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'id', l.id, 'document_id', l.document_id, 'role', l.role,
+    'target_email', l.target_email, 'expires_at', l.expires_at, 'created_at', l.created_at
+  )
+  FROM public.document_invitation_links l
+  WHERE l.document_id = p_document_id
+    AND public.check_is_document_editor(p_document_id, auth.uid())
+    AND l.invitation_kind = 'targeted' AND l.revoked_at IS NULL AND l.used_count = 0
+    AND (l.expires_at IS NULL OR l.expires_at > timezone('utc', now()))
+  ORDER BY l.created_at DESC;
+$$;
+
+REVOKE ALL ON FUNCTION public.assert_targeted_invitation_recipient(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.create_document_invitation_link_legacy(uuid, text, timestamp with time zone, integer) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.accept_document_invitation_unchecked(text, text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.create_document_invitation_link(uuid, text, timestamp with time zone, integer, text, text, date, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_document_invitation_link(uuid, text, timestamp with time zone, integer, text, text, date, date) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.accept_document_invitation(text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_document_invitation_summary(text, text) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.list_my_pending_document_invitations() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.accept_my_document_invitation(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.decline_my_document_invitation(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_document_collaborators(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_document_pending_invitations(uuid) TO authenticated;

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,50 @@
+# Walkthrough: TASK-044 Targeted Document Invitation Authority
+
+## Summary
+
+TASK-044는 이메일, 홈 pending UI, 링크, 코드 초대를 `document_invitation_links`와
+`document_members` authority로 통합했다. targeted 초대는 대상 이메일 계정만 수락할 수 있고,
+메일 API는 인증된 서버 세션과 document editor 권한으로 invitation을 생성한다.
+
+## Artifacts
+
+- GitHub Issue [#348](https://github.com/ysjee141/nexvoy-frontend/issues/348)
+- Pull Request [#349](https://github.com/ysjee141/nexvoy-frontend/pull/349)
+- 브랜치: `feature/task-044-targeted-document-invitation-authority-348`
+- `supabase/migrations/20260716000003_task044_targeted_document_invitations.sql`
+- `packages/core/src/supabase/invitationRepository.ts`
+- `apps/web/app/api/invite/route.ts`
+- `apps/web/components/trips/InvitationBanner.tsx`
+- `apps/web/components/trips/CollaboratorModal.tsx`
+
+## Key Changes
+
+- targeted invitation의 정규화 이메일, 유형, 여행 표시 metadata를 registry에 저장한다.
+- 현재 계정의 pending 목록, 수락, 거절, document collaborator 목록 RPC를 추가했다.
+- token/code 수락 시 JWT email과 target email 일치를 강제한다.
+- 기존 generic invitation과 share token 경로는 유지한다.
+- 메일 API가 임의 URL/code를 받지 않고 서버에서 생성한 `/join` URL만 발송한다.
+- 메일 실패 시 생성한 invitation을 회수한다.
+- 홈 배너와 협업자 모달의 legacy `trip_members` 의존을 제거했다.
+- accepted registry member를 local `TripDocumentV1.members` snapshot에 반영한다.
+
+## Verification
+
+| 명령 | 결과 |
+| --- | --- |
+| `pnpm --filter @nexvoy/core exec tsx src/supabase/__tests__/invitationRepository.test.ts` | PASS |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm typecheck` | PASS |
+| `pnpm build` | PASS |
+| `pnpm lint:mobile` | PASS |
+| `pnpm build:mobile` | PASS, 기존 WebRTC export warning만 발생 |
+
+## Deployment Note
+
+- migration은 DEV `ivgkqzwosbjukonlpfdw`에 먼저 적용하고 다중 사용자 초대 검증을 수행한다.
+- PROD `runbcaegpefqnljsswhv`에는 사용자 승인 후 별도로 적용한다.
+- 참여 후 wrapped document key 자동 전달과 준비 화면은 TASK-045 범위다.
+
 # Walkthrough: TASK-043 Document-Primary Trip Entry Fix
 
 ## Summary


### PR DESCRIPTION
## Summary
- add targeted document invitation metadata and account-bound accept/decline RPCs
- authenticate invitation email creation and generate token/code/link on the server
- move Web pending invitations and collaborator management from legacy `trip_members` to the document registry
- synchronize accepted registry members into the local trip document member snapshot

## Verification
- `pnpm --filter @nexvoy/core exec tsx src/supabase/__tests__/invitationRepository.test.ts`
- `pnpm --filter @nexvoy/core test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint:mobile`
- `pnpm build:mobile`

## Deployment
- Apply `20260716000003_task044_targeted_document_invitations.sql` to DEV (`ivgkqzwosbjukonlpfdw`) first.
- Apply it to PROD (`runbcaegpefqnljsswhv`) only after explicit approval.
- TASK-045 owns automatic wrapped-key delivery and final join readiness UX.

Resolves #348