### PR TITLE
feat(TASK-045): productize invitation key delivery

### DIFF
--- a/apps/mobile/app/join.tsx
+++ b/apps/mobile/app/join.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -30,6 +30,7 @@ import {
   ensureMobileDeviceKeyMaterial,
   loadOrRequestMobileProvisioningStatus,
 } from '@/lib/local-first/keyProvisioningService'
+import { restoreMobileEncryptedSnapshot } from '@/lib/local-first/mobileSnapshotRestoreService'
 import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
 
 type JoinInput = { token?: string; inviteCode?: string }
@@ -73,6 +74,7 @@ export default function JoinScreen() {
   const [acceptedDocumentId, setAcceptedDocumentId] = useState<string | null>(null)
   const [provisioningStatus, setProvisioningStatus] = useState<DocumentKeyProvisioningStatusRecord | null>(null)
   const [statusChecking, setStatusChecking] = useState(false)
+  const readinessInFlight = useRef(false)
 
   const resolveInvitation = async (input: JoinInput) => {
     setLoading(true)
@@ -137,7 +139,18 @@ export default function JoinScreen() {
           setProvisioningRequired(true)
           return
         }
-        router.replace({ pathname: '/trip/[id]', params: { id: result.result.documentId } })
+        const restore = await restoreMobileEncryptedSnapshot({
+          supabase,
+          documentId: result.result.documentId,
+        })
+        if (restore.status === 'restored') {
+          router.replace({ pathname: '/trip/[id]', params: { id: result.result.documentId } })
+          return
+        }
+        setAcceptedDocumentId(result.result.documentId)
+        setProvisioningStatus(status)
+        setProvisioningRequired(true)
+        setMessage('참여는 완료됐습니다. 최신 여정 데이터를 준비하고 있어요.')
         return
       }
       router.replace({ pathname: '/trip/[id]', params: { id: result.tripId ?? summary.tripId } })
@@ -150,8 +163,9 @@ export default function JoinScreen() {
 
   const handleProvisioningRetry = async () => {
     const documentId = acceptedDocumentId ?? (summary?.source === 'document' ? summary.tripId : null)
-    if (!documentId || statusChecking) return
+    if (!documentId || readinessInFlight.current) return
 
+    readinessInFlight.current = true
     setStatusChecking(true)
     setMessage(null)
     try {
@@ -165,14 +179,31 @@ export default function JoinScreen() {
       setProvisioningStatus(status)
       setProvisioningRequired(!status.hasActiveKey && status.status !== 'completed')
       if (status.hasActiveKey || status.status === 'completed') {
-        router.replace({ pathname: '/trip/[id]', params: { id: documentId } })
+        const restore = await restoreMobileEncryptedSnapshot({ supabase, documentId })
+        if (restore.status === 'restored') {
+          router.replace({ pathname: '/trip/[id]', params: { id: documentId } })
+          return
+        }
+        setProvisioningRequired(true)
+        setMessage('참여는 완료됐습니다. 최신 여정 데이터를 준비하고 있어요.')
       }
     } catch {
       setMessage('여정 데이터 준비 상태를 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.')
     } finally {
+      readinessInFlight.current = false
       setStatusChecking(false)
     }
   }
+
+  useEffect(() => {
+    if (!provisioningRequired || !acceptedDocumentId) return undefined
+    const interval = setInterval(() => {
+      void handleProvisioningRetry()
+    }, 5000)
+    return () => clearInterval(interval)
+  // The retry handler intentionally reads the latest screen state on each render.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [acceptedDocumentId, provisioningRequired])
 
   return (
     <SafeAreaView style={styles.screen} edges={['top', 'bottom']}>

--- a/apps/web/app/join/JoinClient.tsx
+++ b/apps/web/app/join/JoinClient.tsx
@@ -1,326 +1,256 @@
-'use client';
+'use client'
 
-import { useEffect, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { createClient } from '@/lib/supabase/client';
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { AlertCircle, ArrowLeft, CheckCircle2, KeyRound, Loader2, Plane, TicketCheck } from 'lucide-react'
+import { css } from 'styled-system/css'
 import {
     acceptInvitationWithLegacyFallback,
     createInvitationRepository,
     getInvitationSummaryWithLegacyFallback,
     type DocumentInvitationSummary,
     type LegacyTripInvitationSummary,
-} from '@nexvoy/core/supabase/invitationRepository';
-import type { DocumentKeyProvisioningStatusRecord } from '@nexvoy/core/sync/keyProvisioning';
-import {
-    DocumentKeyProvisioningStatusCard,
-    type DocumentKeyProvisioningStatus,
-} from '@/components/trips/DocumentKeyProvisioningStatus';
-import { ensureWebDeviceKeyMaterial, getOrCreateWebDeviceId } from '@/lib/local-first/keyProvisioningService';
+} from '@nexvoy/core/supabase/invitationRepository'
+import type { DocumentKeyProvisioningStatusRecord } from '@nexvoy/core/sync/keyProvisioning'
+import { createClient } from '@/lib/supabase/client'
+import { ensureWebDeviceKeyMaterial, getOrCreateWebDeviceId } from '@/lib/local-first/keyProvisioningService'
+import { restoreAndPersistWebTripDocumentFromBackup } from '@/lib/local-first/backupRestoreService'
 
+type JoinState = 'code_entry' | 'resolving' | 'preview' | 'accepting' | 'accepted_preparing' | 'ready' | 'invalid' | 'error'
+type JoinInput = { token?: string; inviteCode?: string }
 type JoinSummary =
     | { source: 'document'; tripId: string; destination: string | null; startDate: string | null; endDate: string | null; ownerNickname: string | null; role: 'editor' | 'viewer' }
     | { source: 'legacy'; tripId: string; destination: string; startDate: string; endDate: string; ownerNickname: string | null; role: 'editor' }
 
-type JoinInput = { token?: string; inviteCode?: string };
-
-const INVALID_INVITE_COPY = '유효하지 않거나 만료된 초대입니다.';
-
 export default function JoinClient() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const token = searchParams.get('token');
-    const code = searchParams.get('code');
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const [state, setState] = useState<JoinState>(() => (
+        searchParams.get('token') || searchParams.get('code') || searchParams.get('acceptedDocumentId')
+            ? 'resolving'
+            : 'code_entry'
+    ))
+    const [summary, setSummary] = useState<JoinSummary | null>(null)
+    const [activeInput, setActiveInput] = useState<JoinInput | null>(null)
+    const [codeInput, setCodeInput] = useState('')
+    const [documentId, setDocumentId] = useState<string | null>(null)
+    const [status, setStatus] = useState<DocumentKeyProvisioningStatusRecord | null>(null)
+    const [message, setMessage] = useState<string | null>(null)
+    const readinessInFlight = useRef(false)
 
-    const [loading, setLoading] = useState(true);
-    const [accepting, setAccepting] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [summary, setSummary] = useState<JoinSummary | null>(null);
-    const [codeInput, setCodeInput] = useState('');
-    const [activeInput, setActiveInput] = useState<JoinInput | null>(null);
-    const [provisioningRequired, setProvisioningRequired] = useState(false);
-    const [acceptedDocumentId, setAcceptedDocumentId] = useState<string | null>(null);
-    const [provisioningStatus, setProvisioningStatus] = useState<DocumentKeyProvisioningStatusRecord | null>(null);
-    const [statusChecking, setStatusChecking] = useState(false);
-
-    const resolveInvitation = async (input: JoinInput) => {
-        setLoading(true);
-        setError(null);
-        setProvisioningRequired(false);
-        setAcceptedDocumentId(null);
-        setProvisioningStatus(null);
+    const resolveInvitation = useCallback(async (input: JoinInput) => {
+        setState('resolving')
+        setMessage(null)
         try {
-            const supabase = createClient();
-            const result = await getInvitationSummaryWithLegacyFallback(supabase, input);
-            if (!result.summary) throw new Error(INVALID_INVITE_COPY);
-
-            const normalizedSummary = normalizeSummary(result.source, result.summary);
-            setSummary(normalizedSummary);
-            setActiveInput(input);
-
-            const { data: { user } } = await supabase.auth.getUser();
+            const supabase = createClient()
+            const result = await getInvitationSummaryWithLegacyFallback(supabase, input)
+            if (!result.summary) throw new Error('invalid')
+            const nextSummary = normalizeSummary(result.source, result.summary)
+            setSummary(nextSummary)
+            setActiveInput(input)
+            const { data: { user } } = await supabase.auth.getUser()
             if (!user) {
-                router.replace(`/login?next=${encodeURIComponent(buildJoinPath(input))}`);
-                return;
+                router.replace(`/login?next=${encodeURIComponent(buildJoinPath(input))}`)
+                return
             }
+            setState('preview')
         } catch {
-            setSummary(null);
-            setActiveInput(null);
-            setError(INVALID_INVITE_COPY);
-        } finally {
-            setLoading(false);
+            setSummary(null)
+            setActiveInput(null)
+            setState('invalid')
         }
-    };
+    }, [router])
+
+    const checkReadiness = useCallback(async (targetDocumentId: string) => {
+        if (readinessInFlight.current) return false
+        readinessInFlight.current = true
+        try {
+        const supabase = createClient()
+        const { deviceId } = await ensureWebDeviceKeyMaterial(supabase)
+        const repository = createInvitationRepository(supabase)
+        let nextStatus: DocumentKeyProvisioningStatusRecord
+        try {
+            nextStatus = await repository.getMyDocumentKeyProvisioningStatus({
+                documentId: targetDocumentId,
+                deviceId,
+                keyVersion: 1,
+            })
+        } catch {
+            nextStatus = await repository.requestDocumentKeyProvisioning({
+                documentId: targetDocumentId,
+                deviceId,
+                keyVersion: 1,
+            })
+        }
+        if (!nextStatus.hasActiveKey && (nextStatus.status === 'none' || nextStatus.status === 'failed')) {
+            nextStatus = await repository.requestDocumentKeyProvisioning({
+                documentId: targetDocumentId,
+                deviceId,
+                keyVersion: 1,
+            })
+        }
+        setStatus(nextStatus)
+        if (!nextStatus.hasActiveKey && nextStatus.status !== 'completed') {
+            setState('accepted_preparing')
+            return false
+        }
+
+        const restore = await restoreAndPersistWebTripDocumentFromBackup({
+            supabase,
+            documentId: targetDocumentId,
+        })
+        if (restore.status === 'restored') {
+            setState('ready')
+            return true
+        }
+        setMessage(restore.status === 'missing'
+            ? '백업 데이터가 준비되기를 기다리고 있습니다.'
+            : '암호화된 여정 데이터를 복원하지 못했습니다. 잠시 후 다시 확인해 주세요.')
+        setState('accepted_preparing')
+        return false
+        } finally {
+            readinessInFlight.current = false
+        }
+    }, [])
 
     useEffect(() => {
-        const input = token ? { token } : code ? { inviteCode: code } : null;
-        if (input) {
-            void resolveInvitation(input);
-        } else {
-            setLoading(false);
-            setError('초대 코드 또는 링크를 입력해 주세요.');
+        const token = searchParams.get('token')
+        const code = searchParams.get('code')
+        const acceptedDocumentId = searchParams.get('acceptedDocumentId')
+        if (acceptedDocumentId) {
+            setDocumentId(acceptedDocumentId)
+            setState('accepted_preparing')
+            void checkReadiness(acceptedDocumentId)
+            return
         }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [token, code]);
+        const input = token ? { token } : code ? { inviteCode: code } : null
+        if (input) void resolveInvitation(input)
+        else setState('code_entry')
+    }, [checkReadiness, resolveInvitation, searchParams])
 
-    const handleCodeSubmit = (event: React.FormEvent) => {
-        event.preventDefault();
-        const inviteCode = sanitizeInviteCode(codeInput);
-        if (!inviteCode) {
-            setError('초대 코드를 입력해 주세요.');
-            return;
-        }
-        void resolveInvitation({ inviteCode });
-    };
+    useEffect(() => {
+        if (state !== 'accepted_preparing' || !documentId) return undefined
+        const interval = window.setInterval(() => void checkReadiness(documentId), 5_000)
+        return () => window.clearInterval(interval)
+    }, [checkReadiness, documentId, state])
 
     const handleAccept = async () => {
-        if (!activeInput || !summary || accepting) return;
-        setAccepting(true);
-        setError(null);
-        setProvisioningRequired(false);
+        if (!activeInput || !summary || state === 'accepting') return
+        setState('accepting')
+        setMessage(null)
         try {
-            const supabase = createClient();
-            let deviceId: string | null = null;
-            if (summary.source === 'document') {
-                const material = await ensureWebDeviceKeyMaterial(supabase);
-                deviceId = material.deviceId;
+            const supabase = createClient()
+            if (summary.source === 'document') await ensureWebDeviceKeyMaterial(supabase)
+            const result = await acceptInvitationWithLegacyFallback(supabase, activeInput)
+            if (result.source === 'legacy') {
+                router.replace(`/trips/detail?id=${result.tripId ?? summary.tripId}`)
+                return
             }
-            const result = await acceptInvitationWithLegacyFallback(supabase, activeInput);
-            if (result.source === 'document') {
-                if (result.result.requiresKeyProvisioning) {
-                    const status = await loadProvisioningStatus(result.result.documentId, deviceId ?? getOrCreateWebDeviceId());
-                    setAcceptedDocumentId(result.result.documentId);
-                    setProvisioningStatus(status);
-                    setProvisioningRequired(true);
-                    return;
-                }
-                router.replace(`/trips/detail?id=${result.result.documentId}`);
-                return;
-            }
-            router.replace(`/trips/detail?id=${result.tripId ?? summary.tripId}`);
-        } catch (err) {
-            const message = err instanceof Error ? err.message : '';
-            setError(message.toLowerCase().includes('already')
-                ? '이미 참여 중인 여정입니다.'
-                : '초대를 수락하지 못했습니다. 잠시 후 다시 시도해 주세요.');
-        } finally {
-            setAccepting(false);
-        }
-    };
-
-    const loadProvisioningStatus = async (
-        documentId: string,
-        deviceId: string,
-        options: { requestIfNeeded?: boolean } = { requestIfNeeded: true },
-    ): Promise<DocumentKeyProvisioningStatusRecord> => {
-        const supabase = createClient();
-        const repository = createInvitationRepository(supabase);
-        try {
-            const status = await repository.getMyDocumentKeyProvisioningStatus({
-                documentId,
-                deviceId,
-                keyVersion: 1,
-            });
-            if ((status.status === 'none' || status.status === 'failed') && options.requestIfNeeded !== false) {
-                return repository.requestDocumentKeyProvisioning({
-                    documentId,
-                    deviceId,
-                    keyVersion: 1,
-                });
-            }
-            return status;
+            setDocumentId(result.result.documentId)
+            setState('accepted_preparing')
+            await checkReadiness(result.result.documentId)
         } catch {
-            if (options.requestIfNeeded === false) throw new Error('status_failed');
-            return repository.requestDocumentKeyProvisioning({
-                documentId,
-                deviceId,
-                keyVersion: 1,
-            });
+            setMessage('초대를 수락하지 못했습니다. 잠시 후 다시 시도해 주세요.')
+            setState('error')
         }
-    };
-
-    const handleProvisioningRetry = async () => {
-        const documentId = acceptedDocumentId ?? (summary?.source === 'document' ? summary.tripId : null);
-        if (!documentId || statusChecking) return;
-
-        setStatusChecking(true);
-        setError(null);
-        try {
-            const supabase = createClient();
-            const { deviceId } = await ensureWebDeviceKeyMaterial(supabase);
-            const status = await loadProvisioningStatus(documentId, deviceId);
-            setAcceptedDocumentId(documentId);
-            setProvisioningStatus(status);
-            setProvisioningRequired(!status.hasActiveKey && status.status !== 'completed');
-            if (status.hasActiveKey || status.status === 'completed') {
-                router.replace(`/trips/detail?id=${documentId}`);
-            }
-        } catch {
-            setError('여정 데이터 준비 상태를 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.');
-        } finally {
-            setStatusChecking(false);
-        }
-    };
-
-    if (loading) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen p-4 text-center">
-                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-500 mb-4"></div>
-                <h1 className="text-xl font-bold mb-2">여정 참여 중...</h1>
-                <p className="text-gray-500">잠시만 기다려주세요.</p>
-            </div>
-        );
     }
 
-    if (error) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen p-4 text-center">
-                <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
-                    <svg className="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                    </svg>
-                </div>
-                <h1 className="text-xl font-bold mb-2">참여 실패</h1>
-                <p className="text-gray-500 mb-6">{error}</p>
-                <form onSubmit={handleCodeSubmit} className="w-full max-w-sm mb-4">
-                    <input
-                        value={codeInput}
-                        onChange={(event) => setCodeInput(formatInviteCode(event.target.value))}
-                        placeholder="초대 코드 입력"
-                        className="w-full px-4 py-3 border border-gray-200 rounded-xl text-center font-bold tracking-widest mb-3"
-                    />
-                    <button
-                        type="submit"
-                        className="w-full px-6 py-3 bg-primary-500 text-white rounded-full font-medium"
-                    >
-                        초대 확인
-                    </button>
-                </form>
-                <button
-                    onClick={() => router.replace('/')}
-                    className="px-6 py-2 border border-gray-200 text-gray-700 rounded-full font-medium"
-                >
-                    홈으로 가기
-                </button>
-            </div>
-        );
+    const handleCodeSubmit = (event: React.FormEvent) => {
+        event.preventDefault()
+        const inviteCode = sanitizeInviteCode(codeInput)
+        if (!inviteCode) return
+        void resolveInvitation({ inviteCode })
     }
 
-    if (!summary) return null;
+    const isBusy = state === 'resolving' || state === 'accepting'
+    const title = getTitle(state, summary)
+    const description = getDescription(state, summary, message)
 
     return (
-        <div className="flex flex-col items-center justify-center min-h-screen p-4 text-center">
-            <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-                <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-blue-50 text-primary-500">
-                    ✈
-                </div>
-                <h1 className="text-xl font-bold mb-2">
-                    {summary.destination ? `${summary.destination} 여정에 초대받았어요` : '여정에 초대받았어요'}
-                </h1>
-                <p className="text-gray-500 mb-4">
-                    {summary.ownerNickname ? `${summary.ownerNickname}님이 초대했습니다.` : '초대 정보를 확인했습니다.'}
-                </p>
-                <div className="text-sm text-gray-600 mb-6 space-y-1">
-                    <p>권한: {summary.role === 'editor' ? '편집자' : '뷰어'}</p>
-                    {summary.startDate && summary.endDate ? <p>기간: {summary.startDate} ~ {summary.endDate}</p> : null}
-                </div>
-                {provisioningRequired && provisioningStatus ? (
-                    <DocumentKeyProvisioningStatusCard
-                        status={toDisplayProvisioningStatus(provisioningStatus.status)}
-                        errorCode={provisioningStatus.errorCode}
-                        primaryActionLabel={provisioningStatus.hasActiveKey || provisioningStatus.status === 'completed'
-                            ? '여정 열기'
-                            : '준비 상태 다시 확인'}
-                        primaryActionBusy={statusChecking}
-                        onPrimaryAction={handleProvisioningRetry}
-                        className="mb-4 text-left"
-                    />
-                ) : null}
-                {error ? <p className="text-sm text-red-500 mb-4">{error}</p> : null}
-                <button
-                    onClick={provisioningRequired ? handleProvisioningRetry : handleAccept}
-                    disabled={accepting || statusChecking}
-                    className="w-full px-6 py-3 bg-primary-500 text-white rounded-full font-medium disabled:opacity-50"
-                >
-                    {accepting || statusChecking ? '확인 중...' : provisioningRequired ? '준비 상태 다시 확인' : '여정에 참여하기'}
-                </button>
-                <button
-                    onClick={() => {
-                        setSummary(null);
-                        setActiveInput(null);
-                        setError('초대 코드를 입력해 주세요.');
-                    }}
-                    className="mt-3 text-sm font-medium text-gray-500"
-                >
-                    초대 코드로 다시 입력
-                </button>
+        <main className={css({ minH: '100dvh', bg: 'bg.canvas', px: { base: '16px', sm: '24px' }, pt: 'max(24px, env(safe-area-inset-top))', pb: 'max(24px, env(safe-area-inset-bottom))' })}>
+            <div className={css({ w: '100%', maxW: '520px', mx: 'auto' })}>
+                <button type="button" onClick={() => router.replace('/')} aria-label="홈으로" className={iconButtonStyle}><ArrowLeft size={20} /></button>
+                <section className={css({ mt: '20px', bg: 'white', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '8px', p: { base: '20px', sm: '28px' }, boxShadow: 'shadow.sm' })} aria-live="polite">
+                    <div className={css({ display: 'flex', alignItems: 'center', justifyContent: 'center', w: '48px', h: '48px', borderRadius: '50%', bg: 'bg.surfaceSoft', color: state === 'invalid' || state === 'error' ? 'brand.error' : state === 'ready' ? 'brand.success' : 'brand.primary', mb: '18px' })}>
+                        {isBusy ? <Loader2 size={24} className={css({ animation: 'spin 1s linear infinite' })} /> : state === 'ready' ? <CheckCircle2 size={24} /> : state === 'invalid' || state === 'error' ? <AlertCircle size={24} /> : state === 'accepted_preparing' ? <KeyRound size={24} /> : state === 'code_entry' ? <TicketCheck size={24} /> : <Plane size={24} />}
+                    </div>
+                    <h1 className={css({ fontSize: '22px', fontWeight: '700', color: 'brand.ink', lineHeight: 1.35 })}>{title}</h1>
+                    <p className={css({ mt: '8px', color: 'brand.muted', fontSize: '14px', lineHeight: 1.6, wordBreak: 'keep-all' })}>{description}</p>
+
+                    {summary && state !== 'code_entry' && state !== 'invalid' ? (
+                        <div className={css({ mt: '20px', p: '16px', bg: 'bg.surfaceSoft', borderRadius: '8px', display: 'grid', gap: '6px', fontSize: '13px', color: 'brand.ink' })}>
+                            <strong>{summary.destination || '공유된 여정'}</strong>
+                            <span>권한: {summary.role === 'editor' ? '편집자' : '뷰어'}</span>
+                            {summary.startDate && summary.endDate ? <span>기간: {summary.startDate} ~ {summary.endDate}</span> : null}
+                            {summary.ownerNickname ? <span>{summary.ownerNickname}님이 초대했습니다.</span> : null}
+                        </div>
+                    ) : null}
+
+                    {(state === 'code_entry' || state === 'invalid') ? (
+                        <form onSubmit={handleCodeSubmit} className={css({ mt: '24px', display: 'grid', gap: '10px' })}>
+                            <label htmlFor="invite-code" className={css({ fontSize: '13px', fontWeight: '700', color: 'brand.ink' })}>초대 코드</label>
+                            <input id="invite-code" value={codeInput} onChange={(event) => setCodeInput(formatInviteCode(event.target.value))} placeholder="A7K9-P2Q4-X8" autoCapitalize="characters" className={inputStyle} />
+                            <button type="submit" disabled={!codeInput.trim()} className={primaryButtonStyle}>초대 확인</button>
+                        </form>
+                    ) : null}
+
+                    {state === 'preview' ? <button type="button" onClick={() => void handleAccept()} className={primaryButtonStyle}>여정에 참여하기</button> : null}
+                    {state === 'accepting' ? <button type="button" disabled className={primaryButtonStyle}>참여 처리 중</button> : null}
+                    {state === 'accepted_preparing' && documentId ? (
+                        <div className={css({ mt: '22px', display: 'grid', gap: '10px' })}>
+                            <button type="button" onClick={() => void checkReadiness(documentId)} className={primaryButtonStyle}>준비 상태 다시 확인</button>
+                            <button type="button" onClick={() => router.replace('/')} className={secondaryButtonStyle}>홈에서 기다리기</button>
+                            {status?.errorCode ? <span className={css({ color: 'brand.muted', fontSize: '12px' })}>준비가 지연되고 있습니다.</span> : null}
+                        </div>
+                    ) : null}
+                    {state === 'ready' && documentId ? <button type="button" onClick={() => router.replace(`/trips/detail?id=${documentId}`)} className={primaryButtonStyle}>여정 열기</button> : null}
+                    {state === 'error' ? <button type="button" onClick={() => activeInput && void resolveInvitation(activeInput)} className={primaryButtonStyle}>다시 시도</button> : null}
+                </section>
             </div>
-        </div>
-    );
+        </main>
+    )
+}
+
+function getTitle(state: JoinState, summary: JoinSummary | null): string {
+    if (state === 'code_entry') return '초대 코드로 참여하기'
+    if (state === 'resolving') return '초대를 확인하고 있어요'
+    if (state === 'accepting') return '여정 참여를 처리하고 있어요'
+    if (state === 'accepted_preparing') return '참여 완료 · 데이터 준비 중'
+    if (state === 'ready') return '여정 데이터가 준비됐어요'
+    if (state === 'invalid') return '초대를 확인할 수 없어요'
+    if (state === 'error') return '처리를 완료하지 못했어요'
+    return summary?.destination ? `${summary.destination} 여정에 초대받았어요` : '여정에 초대받았어요'
+}
+
+function getDescription(state: JoinState, summary: JoinSummary | null, message: string | null): string {
+    if (message) return message
+    if (state === 'code_entry') return '받은 초대 코드를 입력하면 참여할 여정을 확인할 수 있습니다.'
+    if (state === 'accepted_preparing') return '멤버 참여는 완료됐습니다. 관리자 또는 편집자 기기가 암호화 키를 전달하면 자동으로 여정을 복원합니다.'
+    if (state === 'ready') return '암호화된 최신 여정 데이터를 이 기기에 안전하게 저장했습니다.'
+    if (state === 'invalid') return '링크가 만료되었거나 코드가 올바르지 않습니다. 코드를 다시 확인해 주세요.'
+    if (state === 'error') return '네트워크 상태를 확인한 뒤 다시 시도해 주세요.'
+    return summary?.ownerNickname ? `${summary.ownerNickname}님의 초대입니다.` : '초대 정보를 확인했습니다.'
 }
 
 function normalizeSummary(source: 'document' | 'legacy', value: DocumentInvitationSummary | LegacyTripInvitationSummary): JoinSummary {
     if (source === 'document') {
-        const summary = value as DocumentInvitationSummary;
-        return {
-            source,
-            tripId: summary.documentId,
-            destination: summary.destination,
-            startDate: summary.startDate,
-            endDate: summary.endDate,
-            ownerNickname: summary.ownerNickname,
-            role: summary.role,
-        };
+        const summary = value as DocumentInvitationSummary
+        return { source, tripId: summary.documentId, destination: summary.destination, startDate: summary.startDate, endDate: summary.endDate, ownerNickname: summary.ownerNickname, role: summary.role }
     }
-
-    const summary = value as LegacyTripInvitationSummary;
-    return {
-        source,
-        tripId: summary.trip_id,
-        destination: summary.destination,
-        startDate: summary.start_date,
-        endDate: summary.end_date,
-        ownerNickname: summary.owner_nickname,
-        role: 'editor',
-    };
+    const summary = value as LegacyTripInvitationSummary
+    return { source, tripId: summary.trip_id, destination: summary.destination, startDate: summary.start_date, endDate: summary.end_date, ownerNickname: summary.owner_nickname, role: 'editor' }
 }
 
 function buildJoinPath(input: JoinInput): string {
-    if (input.token) return `/join?token=${encodeURIComponent(input.token)}`;
-    if (input.inviteCode) return `/join?code=${encodeURIComponent(input.inviteCode)}`;
-    return '/join';
+    if (input.token) return `/join?token=${encodeURIComponent(input.token)}`
+    if (input.inviteCode) return `/join?code=${encodeURIComponent(input.inviteCode)}`
+    return '/join'
 }
 
-function sanitizeInviteCode(value: string): string {
-    return value.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
-}
+function sanitizeInviteCode(value: string): string { return value.replace(/[^a-zA-Z0-9]/g, '').toUpperCase() }
+function formatInviteCode(value: string): string { return sanitizeInviteCode(value).replace(/(.{4})(?=.)/g, '$1-') }
 
-function formatInviteCode(value: string): string {
-    return sanitizeInviteCode(value).replace(/(.{4})(?=.)/g, '$1-');
-}
-
-function toDisplayProvisioningStatus(status: DocumentKeyProvisioningStatusRecord['status']): DocumentKeyProvisioningStatus {
-    if (status === 'waiting_for_material' || status === 'pending' || status === 'processing' || status === 'failed' || status === 'completed') {
-        return status;
-    }
-    return status === 'none' ? 'pending' : 'failed';
-}
+const iconButtonStyle = css({ display: { base: 'none', md: 'inline-flex' }, alignItems: 'center', justifyContent: 'center', w: '40px', h: '40px', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '8px', bg: 'white', color: 'brand.ink', cursor: 'pointer' })
+const inputStyle = css({ w: '100%', h: '48px', px: '14px', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '8px', bg: 'white', color: 'brand.ink', fontSize: '16px', textAlign: 'center', outline: 'none', _focus: { borderColor: 'brand.primary', boxShadow: '0 0 0 3px rgba(37, 99, 235, 0.12)' } })
+const primaryButtonStyle = css({ mt: '22px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', w: '100%', minH: '48px', px: '16px', border: 'none', borderRadius: '8px', bg: 'brand.primary', color: 'white', fontSize: '15px', fontWeight: '700', cursor: 'pointer', _hover: { bg: 'brand.primaryActive' }, _disabled: { opacity: 0.5, cursor: 'not-allowed' } })
+const secondaryButtonStyle = css({ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', w: '100%', minH: '44px', px: '16px', border: '1px solid', borderColor: 'brand.hairline', borderRadius: '8px', bg: 'white', color: 'brand.ink', fontSize: '14px', fontWeight: '700', cursor: 'pointer' })

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -13,7 +13,6 @@ import AccountLinking from '@/components/profile/AccountLinking'
 import DownloadedTripsModal from '@/components/profile/DownloadedTripsModal'
 import { AuthService } from '@/services/AuthService'
 import { CacheUtil } from '@/lib/cache'
-import { clearAllLocalFirstDocuments } from '@/lib/local-first/localDocumentCleanup'
 
 function ProfileContent() {
     const supabase = createClient()
@@ -245,8 +244,7 @@ function ProfileContent() {
     
     const handleLogout = async () => {
         await supabase.auth.signOut()
-        await clearAllLocalFirstDocuments()
-        await CacheUtil.clear()
+        await CacheUtil.clearAuthSession()
         router.push('/')
         router.refresh()
     }

--- a/apps/web/app/trips/detail/TripLayoutClient.tsx
+++ b/apps/web/app/trips/detail/TripLayoutClient.tsx
@@ -32,6 +32,7 @@ import {
     ensureWebTripDocumentRemoteBootstrap,
 } from '@/lib/local-first/documentPrimaryRepositories'
 import { tripDetailToWebMemberRows, tripDetailToWebTripRow } from '@/lib/local-first/tripReadModelAdapters'
+import { createInvitationRepository } from '@nexvoy/core/supabase/invitationRepository'
 
 export default function TripLayoutClient() {
     const searchParams = useSearchParams()
@@ -111,7 +112,15 @@ export default function TripLayoutClient() {
                 const documentTrip = await repositories.trips.getTrip(id)
 
                 if (!documentTrip) {
-                    router.replace('/404')
+                    const registryMembers = await createInvitationRepository(supabase)
+                        .listDocumentCollaborators(id)
+                        .catch(() => [])
+                    const acceptedMember = registryMembers.find((member) => member.userId === currentUser.id)
+                    if (acceptedMember) {
+                        router.replace(`/join?acceptedDocumentId=${encodeURIComponent(id)}`)
+                    } else {
+                        router.replace('/404')
+                    }
                 } else {
                     setTrip(tripDetailToWebTripRow(documentTrip))
                     const documentMembers = tripDetailToWebMemberRows(documentTrip)
@@ -140,7 +149,10 @@ export default function TripLayoutClient() {
             members,
         })
         let disposed = false
+        let running = false
         const run = () => {
+            if (disposed || running) return
+            running = true
             void (async () => {
                 if (role === 'owner') {
                     await ensureWebTripDocumentRemoteBootstrap({
@@ -161,19 +173,26 @@ export default function TripLayoutClient() {
             })().catch((error) => {
                 const reason = error instanceof Error ? error.message : 'unknown'
                 console.warn('[document key readiness failed]', reason)
+            }).finally(() => {
+                running = false
             })
         }
 
         run()
-        if (role !== 'owner') return () => { disposed = true }
+        if (role !== 'owner' && role !== 'editor') return () => { disposed = true }
 
         const intervalId = window.setInterval(() => {
             if (!disposed) run()
         }, 10_000)
+        const handleVisibility = () => {
+            if (document.visibilityState === 'visible') run()
+        }
+        document.addEventListener('visibilitychange', handleVisibility)
 
         return () => {
             disposed = true
             window.clearInterval(intervalId)
+            document.removeEventListener('visibilitychange', handleVisibility)
         }
     }, [currentUser?.id, id, isOnline, members, supabase, trip?.user_id])
 

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -10,7 +10,6 @@ import { LogOut, Home, User, BookOpen, LogIn, UserPlus, ListTodo, ChevronLeft, C
 import { useUIStore } from '@/stores/useUIStore'
 import { useNetworkStore } from '@/stores/useNetworkStore'
 import { CacheUtil } from '@/lib/cache'
-import { clearAllLocalFirstDocuments } from '@/lib/local-first/localDocumentCleanup'
 import TripSwitcherModal from '@/components/trips/TripSwitcherModal'
 import { useBugReport } from '@/hooks/useBugReport'
 import BugReportModal from '../profile/BugReportModal'
@@ -75,7 +74,7 @@ export default function Navbar() {
                 } else {
                     // 온라인이며 에러가 없고 유저도 없다면 세션 만료로 간주하고 캐시 정리
                     setUser(null)
-                    await CacheUtil.clear()
+                    await CacheUtil.clearAuthSession()
                 }
             }
             setLoading(false)
@@ -88,9 +87,7 @@ export default function Navbar() {
             if (currentUser) {
                 await CacheUtil.setAuthUser(currentUser)
             } else if (event === 'SIGNED_OUT') {
-                // 명시적 로그아웃 시에만 캐시 정리
-                await clearAllLocalFirstDocuments()
-                await CacheUtil.clear()
+                await CacheUtil.clearAuthSession()
             }
         })
 
@@ -104,8 +101,7 @@ export default function Navbar() {
 
     const handleSignOut = async () => {
         await supabase.auth.signOut()
-        await clearAllLocalFirstDocuments()
-        await CacheUtil.clear()
+        await CacheUtil.clearAuthSession()
         router.push('/')
         router.refresh()
     }

--- a/apps/web/components/trips/InvitationBanner.tsx
+++ b/apps/web/components/trips/InvitationBanner.tsx
@@ -37,10 +37,14 @@ export default function InvitationBanner() {
         setError(null)
         try {
             const repository = createInvitationRepository(createClient())
-            if (action === 'accept') await repository.acceptMyDocumentInvitation(id)
-            else await repository.declineMyDocumentInvitation(id)
+            if (action === 'accept') {
+                const result = await repository.acceptMyDocumentInvitation(id)
+                router.push(`/join?acceptedDocumentId=${encodeURIComponent(result.documentId)}`)
+            } else {
+                await repository.declineMyDocumentInvitation(id)
+            }
             setInvitations((current) => current.filter((invitation) => invitation.id !== id))
-            router.refresh()
+            if (action === 'decline') router.refresh()
         } catch {
             setError(action === 'accept' ? '초대를 수락하지 못했습니다.' : '초대를 거절하지 못했습니다.')
         } finally {

--- a/apps/web/lib/cache.ts
+++ b/apps/web/lib/cache.ts
@@ -53,6 +53,11 @@ export const CacheUtil = {
         return await this.get<any>('auth_last_profile')
     },
 
+    async clearAuthSession() {
+        await this.remove('auth_last_user')
+        await this.remove('auth_last_profile')
+    },
+
     async clear() {
         if (!hasWindow()) return
         try {

--- a/apps/web/lib/local-first/backupRestoreService.ts
+++ b/apps/web/lib/local-first/backupRestoreService.ts
@@ -6,6 +6,8 @@ import { BackupCryptoError } from '@nexvoy/core/sync/backupTypes'
 import { createSupabaseBackupRepository } from '@nexvoy/core/supabase/backupRepository'
 import { getCurrentWebDocumentKeyOrRecoverStaleDeviceKey, getOrCreateWebDeviceId } from './keyProvisioningService'
 import { getWebBackupCryptoProvider } from './webCryptoProvider'
+import { resolveWebOwnerContext } from './ownerNamespace'
+import { createWebTripDocumentStore } from './webDocumentStores'
 
 export type WebBackupRestoreStatus =
   | 'missing'
@@ -69,6 +71,21 @@ export async function restoreWebTripDocumentFromBackup(input: {
       reason: error instanceof Error ? error.message : 'restore_failed',
     }
   }
+}
+
+export async function restoreAndPersistWebTripDocumentFromBackup(input: {
+  supabase: SupabaseClient
+  documentId: string
+}): Promise<WebBackupRestoreResult> {
+  const result = await restoreWebTripDocumentFromBackup(input)
+  if (result.status !== 'restored' || !result.document) return result
+
+  const ownerContext = await resolveWebOwnerContext(input.supabase)
+  await createWebTripDocumentStore(ownerContext).putDocument(
+    input.documentId,
+    result.document,
+  )
+  return result
 }
 
 export async function restoreWebTemplateDocumentFromBackup(input: {

--- a/apps/web/lib/local-first/indexedDbStore.ts
+++ b/apps/web/lib/local-first/indexedDbStore.ts
@@ -143,6 +143,19 @@ export async function loadWebDeviceKeyMaterial(deviceId: string): Promise<Stored
   return row ?? null
 }
 
+export async function loadAllWebDeviceKeyMaterials(): Promise<StoredWebDeviceKeyMaterial[]> {
+  if (!canUseIndexedDb()) return []
+  const db = await openDatabase()
+  const rows = await runTransaction<StoredWebDeviceKeyMaterial[]>(
+    db,
+    KEY_MATERIAL_STORE,
+    'readonly',
+    (store) => store.getAll(),
+  )
+  db.close()
+  return rows.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+}
+
 export async function saveWebDeviceKeyMaterial(
   material: Omit<StoredWebDeviceKeyMaterial, 'id' | 'updatedAt'>,
 ): Promise<void> {

--- a/apps/web/lib/local-first/keyProvisioningService.ts
+++ b/apps/web/lib/local-first/keyProvisioningService.ts
@@ -229,10 +229,19 @@ export async function ensureWebDocumentKeyReadiness(
     documentId: input.documentId,
     deviceId,
   })
+  const canProvisionOthers = input.role === 'owner' || input.role === 'editor'
+  if (documentKey && canProvisionOthers) {
+    return runWebForegroundKeyProvisioning({
+      supabase: input.supabase,
+      documentId: input.documentId,
+      documentKey,
+      limit: 25,
+    })
+  }
   if (documentKey) return null
 
-  if (input.role === 'owner') {
-    return runWebForegroundKeyProvisioning({
+  if (canProvisionOthers) {
+    await runWebForegroundKeyProvisioning({
       supabase: input.supabase,
       documentId: input.documentId,
       limit: 25,
@@ -245,7 +254,8 @@ export async function ensureWebDocumentKeyReadiness(
     deviceId,
     keyVersion: KEY_MATERIAL_VERSION,
   })
-  if (status.status === 'completed' || !status.retryable) return null
+  if (status.hasActiveKey) return null
+  if (status.status === 'pending' || status.status === 'processing') return null
 
   await repository.requestDocumentKeyProvisioning({
     documentId: input.documentId,

--- a/apps/web/lib/local-first/keyProvisioningService.ts
+++ b/apps/web/lib/local-first/keyProvisioningService.ts
@@ -19,7 +19,12 @@ import { TRIP_DOCUMENT_SCHEMA_VERSION, type TripDocumentV1 } from '@nexvoy/core/
 import { createYjsTripDocument, encodeTripDocumentUpdate } from '@nexvoy/core/local-first/yjsTripDocument'
 import type { BackupDocumentType } from '@nexvoy/core/sync/backupTypes'
 import { analytics } from '@/services/AnalyticsService'
-import { deleteWebDeviceKeyMaterial, loadWebDeviceKeyMaterial, saveWebDeviceKeyMaterial } from './indexedDbStore'
+import {
+  deleteWebDeviceKeyMaterial,
+  loadAllWebDeviceKeyMaterials,
+  loadWebDeviceKeyMaterial,
+  saveWebDeviceKeyMaterial,
+} from './indexedDbStore'
 import {
   createWebRsaOaepWrappingProvider,
   generateWebRsaOaepKeyMaterial,
@@ -277,13 +282,34 @@ export async function getCurrentWebDocumentKeyOrRecoverStaleDeviceKey(input: {
   deviceId: string
   provider?: RsaOaepWrappingProvider
 }): Promise<DocumentEncryptionKey | null> {
+  let unwrapFailed = false
   try {
-    return await getCurrentWebDocumentKey(input)
+    const currentKey = await getCurrentWebDocumentKey(input)
+    if (currentKey) return currentKey
   } catch (error) {
     if (!isKeyUnwrapFailure(error)) throw error
-    await resetStaleWebDeviceKey(input.supabase, input.deviceId)
-    return null
+    unwrapFailed = true
   }
+
+  const storedMaterials = await loadAllWebDeviceKeyMaterials()
+  for (const material of storedMaterials) {
+    if (material.deviceId === input.deviceId) continue
+    try {
+      const recoveredKey = await getCurrentWebDocumentKey({
+        ...input,
+        deviceId: material.deviceId,
+      })
+      if (!recoveredKey) continue
+      window.localStorage.setItem(WEB_DEVICE_ID_STORAGE_KEY, material.deviceId)
+      await ensureWebDeviceKeyMaterial(input.supabase)
+      return recoveredKey
+    } catch (error) {
+      if (!isKeyUnwrapFailure(error)) throw error
+    }
+  }
+
+  if (unwrapFailed) await resetStaleWebDeviceKey(input.supabase, input.deviceId)
+  return null
 }
 
 async function resetStaleWebDeviceKey(

--- a/apps/web/services/ExternalApiService.ts
+++ b/apps/web/services/ExternalApiService.ts
@@ -110,10 +110,50 @@ export const CollaborationService = {
     endDate?: string | null
     role: 'editor' | 'viewer'
   }) => {
-    const response = await apiService.post(`/api/invite/`, data);
+    const response = await apiService.post<InviteResponse | InviteErrorResponse>(`/api/invite/`, data);
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(getInviteErrorMessage(response.data));
+    }
+    if (!isInviteResponse(response.data)) {
+      throw new Error(getInviteErrorMessage(response.data));
+    }
     return response.data;
   }
 };
+
+interface InviteResponse {
+  invitation: {
+    id: string
+    inviteCode: string
+    role: 'editor' | 'viewer'
+    expiresAt: string | null
+  }
+  inviteUrl: string
+}
+
+interface InviteErrorResponse {
+  error?: string
+}
+
+function isInviteResponse(value: unknown): value is InviteResponse {
+  if (!value || typeof value !== 'object' || !('invitation' in value)) return false
+  const response = value as Record<string, unknown>
+  const invitation = response.invitation
+  if (!invitation || typeof invitation !== 'object') return false
+  const invitationRecord = invitation as Record<string, unknown>
+  return Boolean(
+    typeof invitationRecord.id === 'string'
+    && typeof invitationRecord.inviteCode === 'string'
+    && (invitationRecord.role === 'editor' || invitationRecord.role === 'viewer')
+    && typeof response.inviteUrl === 'string',
+  )
+}
+
+function getInviteErrorMessage(value: unknown): string {
+  return value !== null && typeof value === 'object' && 'error' in value && typeof value.error === 'string'
+    ? value.error
+    : '초대 서버 응답을 확인할 수 없습니다.'
+}
 
 /**
  * 메타데이터(OG-Preview) 서비스

--- a/docs/qa/local-first-integration-runbook.md
+++ b/docs/qa/local-first-integration-runbook.md
@@ -35,6 +35,24 @@ TASK-035 검증은 자동 Playwright spec과 실기기 smoke를 함께 실행한
 | Offline reconnect | 네트워크 차단 상태에서 수정 후 재연결 | 로컬 변경 유지, 재연결 후 원격 반영 |
 | Permission boundary | viewer로 동일 trip 접속 | 생성/수정/삭제 CTA 미노출, 문서 읽기 가능 |
 
+## TASK-045 초대 및 Key Delivery
+
+| 시나리오 | 절차 | 통과 기준 |
+| --- | --- | --- |
+| Web 링크 초대 | Web owner가 이메일 초대 후 별도 Web 계정으로 링크 수락 | membership accepted, 준비 중 표시, owner 화면 조작 없이 key completed, 동일 snapshot 표시 |
+| Web 코드 초대 | invitee가 `/join`에서 코드 입력 후 수락 | 링크 수락과 동일한 document/member/key 결과 |
+| Owner offline | owner를 종료하고 invitee가 수락한 뒤 owner가 다시 상세 진입 | owner 재접속 후 10초 이내 key completed, invitee 자동 restore |
+| 홈 pending 수락 | invitee 홈 배너에서 수락 | `/join?acceptedDocumentId=...` 준비 화면으로 이동하고 restore 후 상세 진입 |
+| Web/Mobile | Web owner가 Mobile 계정을 초대 | Mobile native key row 생성, encrypted snapshot restore, 동일 일정·준비물 표시 |
+| Viewer boundary | viewer 역할로 수락 후 변경 시도 | restore/read 성공, 일정·준비물 mutation과 backup upload 차단 |
+
+확인할 Supabase registry:
+
+- `document_members.status = 'accepted'`
+- `document_key_provisioning_requests.status = 'completed'`
+- invitee device의 active `document_keys` row 존재
+- plaintext key와 document payload가 log/notification에 없음
+
 ## 결과 기록
 
 각 실행은 PR 또는 task walkthrough에 아래 형식으로 남긴다.

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -19,6 +19,14 @@
 - targeted token/code 수락은 로그인 계정 이메일이 일치할 때만 허용한다.
 - wrapped key 자동 전달과 참여 준비 UX는 계획대로 `TASK-045`에서 완료한다.
 
+2026-07-16 TASK-045 구현 완료:
+
+- key를 보유한 Web owner/editor가 pending provisioning request를 foreground와 visibility trigger에서 자동 처리한다.
+- Web join을 Panda CSS 상태 화면으로 교체하고 membership 완료와 데이터 준비 상태를 분리했다.
+- Web/Mobile 모두 active key 확인 후 encrypted snapshot restore와 local 저장이 성공해야 상세로 이동한다.
+- 홈 pending 수락과 local document 없는 상세 재진입도 join 준비 화면으로 수렴한다.
+- TASK-044 migration이 적용된 DEV에서 Web-Web/Web-Mobile 다중 사용자 수동 검증이 남아 있다.
+
 ## 0. 목표 정정
 
 이번 refactor의 최종 목표는 "준비물 Web-to-Web P2P 검증"이 아니다. 목표는 OnVoy 핵심 기능 전체를 Web/Mobile 양쪽에서 Local-first 기반으로 전환하는 것이다.

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -106,7 +106,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-041-backup-freshness-and-cost-control.md` | 완료 | local-first freshness, metadata 기반 backup pull/upload, Supabase 비용 최소화, Issue #341 |
 | `TASK-042-legacy-migration-tool.md` | 완료 | 기존 row 데이터를 명시적으로 document-primary로 전환하는 Web dev migration tool, Issue #343 |
 | `TASK-044-targeted-document-invitation-authority.md` | 완료 | 이메일 대상 초대 authority, pending 초대, 안전한 메일 발송, document member registry 통합 |
-| `TASK-045-invitation-join-and-key-delivery-productization.md` | 예정 | Web/Mobile join UX, 자동 key provisioning, restore 및 multi-user E2E 완성 |
+| `TASK-045-invitation-join-and-key-delivery-productization.md` | 구현 완료 | Web/Mobile join UX, 자동 key provisioning, restore 구현. DEV 다중 사용자 검증 대기 |
 
 현재 `Phase 0: 모델과 변환 기반`, `Phase 1: Repository 경계와 Web 스파이크`, `Phase 2: Backup, 암호화, Restore`, `Phase 2.5: Web Read-through 보완`은 완료되었다. `TASK-038`부터는 ADR-014에 따라 Closed Beta 기준선을 기존 row 자동 migration에서 신규 document-primary 데이터로 재설정한다. 기존 row 데이터는 제품 경로에서 자동 hydrate하지 않고, `TASK-042`의 명시적 migration tool source로만 남긴다.
 
@@ -187,7 +187,7 @@ rotating room secret 보안 하드닝을 완료했다.
 ### Phase 8: Invitation Closed Beta Blocker
 
 - [x] `TASK-044-targeted-document-invitation-authority.md`: 이메일·pending UI·링크·코드 초대를 document authority로 통합
-- [ ] `TASK-045-invitation-join-and-key-delivery-productization.md`: 참여 UX, 자동 key 전달, restore 및 다중 사용자 E2E 완성
+- [x] `TASK-045-invitation-join-and-key-delivery-productization.md`: 참여 UX, 자동 key 전달, restore 구현 (DEV 수동 검증 필요)
 
 ## 권장 시작 순서
 

--- a/docs/refactor/tasks/TASK-045-invitation-join-and-key-delivery-productization.md
+++ b/docs/refactor/tasks/TASK-045-invitation-join-and-key-delivery-productization.md
@@ -1,6 +1,6 @@
 # TASK-045: Invitation Join and Key Delivery Productization
 
-- 상태: 예정
+- 상태: 구현 완료 (DEV 다중 사용자 검증 대기)
 
 ## 목적
 
@@ -94,4 +94,3 @@ provisioning을 완성한다. 초대받은 사용자가 owner/editor 기기가 �
 - 링크와 코드로 수락한 사용자가 명확한 UI 상태를 거쳐 encrypted document를 실제로 복원한다.
 - key 보유 owner/editor가 온라인이면 pending key 전달이 자동 완료된다.
 - Web/Mobile에서 수락한 사용자가 owner와 동일한 여정 데이터를 보고 P2P 또는 backup sync에 참여한다.
-

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -25,6 +25,7 @@ pending 요청을 자동 처리한다. invitee는 active key 확인뿐 아니라
 - Web restore 성공 시 복호화한 document를 현재 사용자 IndexedDB namespace에 저장한다.
 - Mobile join도 key 완료 후 encrypted snapshot restore 성공을 상세 이동 조건으로 사용한다.
 - 홈 pending 수락과 local document 없는 상세 진입은 accepted document join 준비 화면으로 이동한다.
+- 이메일 초대 API의 실패·비정상 응답을 검증해 `undefined.id` 대신 서버의 실제 오류를 표시한다.
 
 ## Verification
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,50 @@
+# Walkthrough: TASK-045 Invitation Join and Key Delivery Productization
+
+## Summary
+
+TASK-045는 초대 membership 성공과 encrypted document 준비 상태를 분리했다. key를 보유한 owner/editor는
+pending 요청을 자동 처리한다. invitee는 active key 확인뿐 아니라 snapshot 복호화와 local 저장까지 성공해야
+여행 상세로 이동한다.
+
+## Artifacts
+
+- GitHub Issue [#350](https://github.com/ysjee141/nexvoy-frontend/issues/350)
+- Pull Request [#351](https://github.com/ysjee141/nexvoy-frontend/pull/351)
+- 브랜치: `feature/task-045-invitation-key-delivery-350`
+- `apps/web/app/join/JoinClient.tsx`
+- `apps/web/lib/local-first/keyProvisioningService.ts`
+- `apps/web/lib/local-first/backupRestoreService.ts`
+- `apps/web/app/trips/detail/TripLayoutClient.tsx`
+- `apps/mobile/app/join.tsx`
+
+## Key Changes
+
+- Web owner/editor가 자기 document key를 보유해도 pending key request를 먼저 처리한다.
+- detail foreground, 10초 interval, visibility 복귀 trigger를 중복 실행 방지와 함께 적용한다.
+- Web join을 명시적 참여·준비·완료·오류 상태로 분리하고 Panda CSS로 재구현했다.
+- Web restore 성공 시 복호화한 document를 현재 사용자 IndexedDB namespace에 저장한다.
+- Mobile join도 key 완료 후 encrypted snapshot restore 성공을 상세 이동 조건으로 사용한다.
+- 홈 pending 수락과 local document 없는 상세 진입은 accepted document join 준비 화면으로 이동한다.
+
+## Verification
+
+| 명령/검증 | 결과 |
+| --- | --- |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| Web/Mobile `tsc --noEmit` | PASS |
+| `pnpm build` | PASS |
+| `pnpm lint:mobile` | PASS |
+| `pnpm build:mobile` | PASS, 기존 WebRTC export warning만 발생 |
+| In-app browser desktop 1280x800 | PASS |
+| In-app browser mobile 390x844 | PASS |
+| Browser console warn/error | 없음 |
+
+## Remaining DEV Verification
+
+- TASK-044 migration 적용 후 Web owner와 Web invitee의 link/code 수락 및 자동 restore를 확인한다.
+- owner offline 수락 후 owner 재접속 시 10초 이내 자동 key completion을 확인한다.
+- Web owner와 Mobile invitee 조합에서 동일 snapshot과 viewer write 차단을 확인한다.
+
 # Walkthrough: TASK-044 Targeted Document Invitation Authority
 
 ## Summary

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -26,6 +26,8 @@ pending 요청을 자동 처리한다. invitee는 active key 확인뿐 아니라
 - Mobile join도 key 완료 후 encrypted snapshot restore 성공을 상세 이동 조건으로 사용한다.
 - 홈 pending 수락과 local document 없는 상세 진입은 accepted document join 준비 화면으로 이동한다.
 - 이메일 초대 API의 실패·비정상 응답을 검증해 `undefined.id` 대신 서버의 실제 오류를 표시한다.
+- 일반 로그아웃은 인증 UI 캐시만 제거하고 local document, Web device ID, private key를 보존한다.
+- 로그아웃으로 device ID 포인터가 유실된 기존 브라우저는 IndexedDB의 이전 키를 대조해 자동 재연결한다.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- process pending document-key requests for both owners and editors without the previous early return
- rebuild the Web invitation entry as an explicit Panda CSS state machine for link, code, acceptance, key delivery, and recovery
- restore and persist the latest encrypted snapshot before opening a joined trip on Web and Mobile
- route pending invitations and accepted members without local data through the same readiness flow
- document TASK-045 QA and operational verification

## Verification
- `pnpm --filter @nexvoy/core test`
- `pnpm --filter nexvoy-web exec tsc --noEmit`
- `pnpm --filter nexvoy-app exec tsc --noEmit`
- `pnpm build`
- `pnpm lint:mobile`
- `pnpm build:mobile`
- Web join UI checked at 1280x800 and 390x844 with no console warnings/errors

## Notes
- `pnpm build:packages` still fails in the existing core invitation test because the package TypeScript setup cannot resolve `node:assert/strict`; the focused core tests and direct Web/Mobile type checks pass.
- Real two-account/two-device key wrapping and snapshot restoration must be verified against DEV after the TASK-044 migrations are present.

Resolves #350