### PR TITLE
feat(TASK-050): cut over Web product flows to server authority

### DIFF
--- a/apps/web/app/HomeClient.tsx
+++ b/apps/web/app/HomeClient.tsx
@@ -10,8 +10,11 @@ import TripSection from '@/components/trips/TripSection'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { CacheUtil } from '@/lib/cache'
-import { promotePendingGuestDocuments } from '@/lib/local-first/guestPromotionService'
-import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import {
+  createWebProductDocumentRepositories,
+  refreshWebProductList,
+  subscribeWebProductAccount,
+} from '@/lib/local-first/repositoryFactory'
 import { tripSummaryToWebTripRow } from '@/lib/local-first/tripReadModelAdapters'
 import {
   Map, CheckSquare, Globe, Wallet,
@@ -276,13 +279,6 @@ export default function HomeClient() {
             return
         }
         setUser(networkUser)
-        const promotionResult = await promotePendingGuestDocuments(supabase)
-        if (promotionResult.conflicts > 0) {
-            alert('이미 계정에 연결된 같은 여행 문서가 있어, 게스트 문서는 덮어쓰지 않고 보관했어요.')
-        }
-        if (promotionResult.failed > 0) {
-            alert('게스트 문서를 계정에 연결하는 중 일부 백업이 완료되지 않았어요. 다음 로그인 때 다시 시도할게요.')
-        }
         // 오프라인 UI 판정을 위해 유저 정보 캐싱
         await CacheUtil.setAuthUser(networkUser)
 
@@ -298,7 +294,8 @@ export default function HomeClient() {
         }
         setShowNicknamePrompt(!profile?.nickname)
 
-        const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: 'viewer' })
+        await refreshWebProductList(supabase, 'trip')
+        const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: 'viewer' })
         const allTrips = (await repositories.trips.listTrips(networkUser.id))
             .map(tripSummaryToWebTripRow)
             .sort((a, b) => a.start_date.localeCompare(b.start_date))
@@ -315,14 +312,6 @@ export default function HomeClient() {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event: AuthChangeEvent, session: Session | null) => {
       if (session?.user) {
         setUser(session.user)
-        void promotePendingGuestDocuments(supabase).then((result) => {
-          if (result.conflicts > 0) {
-            alert('이미 계정에 연결된 같은 여행 문서가 있어, 게스트 문서는 덮어쓰지 않고 보관했어요.')
-          }
-          if (result.failed > 0) {
-            alert('게스트 문서를 계정에 연결하는 중 일부 백업이 완료되지 않았어요. 다음 로그인 때 다시 시도할게요.')
-          }
-        })
         fetchNetworkBackground()
       } else if (event === 'SIGNED_OUT') {
         setUser(null)
@@ -351,6 +340,11 @@ export default function HomeClient() {
         } else {
             setNickname(localUser.email?.split('@')[0] || '여행자')
         }
+        const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: 'viewer' })
+        const localTrips = (await repositories.trips.listTrips(localUser.id))
+          .map(tripSummaryToWebTripRow)
+          .sort((a, b) => a.start_date.localeCompare(b.start_date))
+        processTrips(localTrips)
       }
       // 세션을 확인했든 못 했든 초기 로딩 해제 (화면 진입)
       setLoading(false)
@@ -362,6 +356,21 @@ export default function HomeClient() {
         fetchNetworkBackground()
     })
   }, [supabase, processTrips, fetchNetworkBackground])
+
+  useEffect(() => {
+    if (!user?.id) return undefined
+    let unsubscribe: (() => void) | undefined
+    void subscribeWebProductAccount(supabase, 'trip', () => {
+      void createWebProductDocumentRepositories(supabase, { actorRole: 'viewer' })
+        .then((repositories) => repositories.trips.listTrips(user.id))
+        .then((trips) => processTrips(
+          trips
+            .map(tripSummaryToWebTripRow)
+            .sort((a, b) => a.start_date.localeCompare(b.start_date)),
+        ))
+    }).then((next) => { unsubscribe = next })
+    return () => unsubscribe?.()
+  }, [processTrips, supabase, user?.id])
 
   // 탭 파라미터에 따른 스크롤 처리
   useEffect(() => {

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -13,6 +13,10 @@ import AccountLinking from '@/components/profile/AccountLinking'
 import DownloadedTripsModal from '@/components/profile/DownloadedTripsModal'
 import { AuthService } from '@/services/AuthService'
 import { CacheUtil } from '@/lib/cache'
+import {
+    createWebProductDocumentRepositories,
+    refreshWebProductList,
+} from '@/lib/local-first/repositoryFactory'
 
 function ProfileContent() {
     const supabase = createClient()
@@ -79,42 +83,12 @@ function ProfileContent() {
                 setNickname(profileData.nickname || currentUser.email?.split('@')[0] || '')
             }
 
-            // 통계 가져오기
-            const { data: trips } = await supabase
-                .from('trips')
-                .select('id, start_date, end_date')
-                .eq('user_id', currentUser.id)
-
-            const allTrips = trips || []
-            const tripIds = allTrips.map((t: any) => t.id)
-
-            let totalPlans = 0
-            let totalChecked = 0
-            let totalItems = 0
-
-            if (tripIds.length > 0) {
-                const { count: planCount } = await supabase
-                    .from('plans')
-                    .select('id', { count: 'exact', head: true })
-                    .in('trip_id', tripIds)
-                totalPlans = planCount || 0
-
-                const { data: checklists } = await supabase
-                    .from('checklists')
-                    .select('id')
-                    .in('trip_id', tripIds)
-
-                const checklistIds = checklists?.map((c: any) => c.id) || []
-                if (checklistIds.length > 0) {
-                    const { data: checkItems } = await supabase
-                        .from('checklist_items')
-                        .select('is_checked')
-                        .in('checklist_id', checklistIds)
-
-                    totalItems = checkItems?.length || 0
-                    totalChecked = checkItems?.filter((i: any) => i.is_checked).length || 0
-                }
-            }
+            await refreshWebProductList(supabase, 'trip')
+            const repositories = await createWebProductDocumentRepositories(supabase)
+            const allTrips = (await repositories.trips.listTrips(currentUser.id))
+                .filter((trip) => trip.ownerId === currentUser.id)
+            const tripDetails = await Promise.all(allTrips.map((trip) => repositories.trips.getTrip(trip.id)))
+            const totalPlans = tripDetails.reduce((sum, trip) => sum + (trip?.planCount ?? 0), 0)
 
             const today = new Date()
             today.setHours(0, 0, 0, 0)
@@ -123,9 +97,9 @@ function ProfileContent() {
             let upcomingCount = 0
             let totalDaysResult = 0
 
-            allTrips.forEach((t: any) => {
-                const start = new Date(t.start_date)
-                const end = new Date(t.end_date)
+            allTrips.forEach((trip) => {
+                const start = new Date(trip.startDate)
+                const end = new Date(trip.endDate)
                 start.setHours(0, 0, 0, 0)
                 end.setHours(23, 59, 59, 999)
 

--- a/apps/web/app/profile/places-visited/page.tsx
+++ b/apps/web/app/profile/places-visited/page.tsx
@@ -2,6 +2,10 @@
 
 import { useState, useEffect } from 'react'
 import { createClient } from '@/lib/supabase/client'
+import {
+    createWebProductDocumentRepositories,
+    refreshWebProductList,
+} from '@/lib/local-first/repositoryFactory'
 import { css } from 'styled-system/css'
 import { MapPin, Search, ChevronLeft, Calendar, Footprints, Heart, Sparkles } from 'lucide-react'
 import { formatDate } from '@nexvoy/core'
@@ -77,20 +81,24 @@ export default function PlacesVisitedPage() {
             const { data: { user } } = await supabase.auth.getUser()
             if (!user) return
 
-            // 1. 사용자의 모든 여행 가져오기
-            const { data: trips } = await supabase
-                .from('trips')
-                .select('id, destination, start_date')
-                .eq('user_id', user.id)
-            
-            const tripIds = trips?.map((t: any) => t.id) || []
+            await refreshWebProductList(supabase, 'trip')
+            const repositories = await createWebProductDocumentRepositories(supabase)
+            const tripSummaries = (await repositories.trips.listTrips(user.id))
+                .filter((trip) => trip.ownerId === user.id)
+            const trips = tripSummaries.map((trip) => ({
+                id: trip.id,
+                destination: trip.destination,
+                start_date: trip.startDate,
+            }))
+            const tripIds = trips.map((trip) => trip.id)
 
             if (tripIds.length > 0) {
-                // 2. 해당 여행들에 속한 장소들 인출
-                const { data: plans } = await supabase
-                    .from('plans')
-                    .select('location, trip_id')
-                    .in('trip_id', tripIds)
+                const plans = (await Promise.all(tripIds.map(async (tripId) =>
+                    (await repositories.plans.listPlans(tripId)).map((plan) => ({
+                        location: plan.location,
+                        trip_id: tripId,
+                    })),
+                ))).flat()
 
                 if (plans) {
                     // 3. 집계 및 중복 제거 로직
@@ -108,7 +116,7 @@ export default function PlacesVisitedPage() {
                         
                         // 해당 장소가 포함된 여행(trip_id) 중복 체크
                         const tripId = plan.trip_id
-                        const tripDetail = trips?.find((t: any) => t.id === tripId)
+                        const tripDetail = trips.find((trip) => trip.id === tripId)
                         
                         if (tripDetail) {
                             const alreadyAdded = acc[loc].associatedTrips.some(t => t.id === tripId)

--- a/apps/web/app/profile/travel-log/page.tsx
+++ b/apps/web/app/profile/travel-log/page.tsx
@@ -9,6 +9,10 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import Skeleton from '@/components/ui/Skeleton'
 import CommonListSkeleton from '@/components/common/CommonListSkeleton'
+import {
+    createWebProductDocumentRepositories,
+    refreshWebProductList,
+} from '@/lib/local-first/repositoryFactory'
 
 interface Trip {
     id: string
@@ -35,11 +39,17 @@ export default function TravelLogPage() {
             const { data: { user } } = await supabase.auth.getUser()
             if (!user) return
 
-            const { data: trips } = await supabase
-                .from('trips')
-                .select('id, destination, start_date, end_date')
-                .eq('user_id', user.id)
-                .order('start_date', { ascending: false })
+            await refreshWebProductList(supabase, 'trip')
+            const repositories = await createWebProductDocumentRepositories(supabase)
+            const trips = (await repositories.trips.listTrips(user.id))
+                .filter((trip) => trip.ownerId === user.id)
+                .map((trip) => ({
+                    id: trip.id,
+                    destination: trip.destination,
+                    start_date: trip.startDate,
+                    end_date: trip.endDate,
+                }))
+                .sort((left, right) => right.start_date.localeCompare(left.start_date))
 
             if (trips) {
                 const today = new Date()

--- a/apps/web/app/templates/page.tsx
+++ b/apps/web/app/templates/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from '@/lib/supabase/client'
 import { css } from 'styled-system/css'
 import Link from 'next/link'
 import { Plus, ListTodo } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Skeleton from '@/components/ui/Skeleton'
 import CommonListSkeleton from '@/components/common/CommonListSkeleton'
@@ -12,7 +12,11 @@ import type { TemplateWithPreview } from '@nexvoy/types'
 
 import { useUIStore } from '@/stores/useUIStore'
 import { CacheUtil } from '@/lib/cache'
-import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import {
+    createWebProductDocumentRepositories,
+    refreshWebProductList,
+    subscribeWebProductAccount,
+} from '@/lib/local-first/repositoryFactory'
 
 export default function TemplatesPage() {
     const supabase = createClient()
@@ -28,17 +32,16 @@ export default function TemplatesPage() {
     const [templates, setTemplates] = useState<TemplateWithPreview[]>([])
     const [loading, setLoading] = useState(true)
 
-    useEffect(() => {
-        async function fetchTemplates() {
-            const { data: { user: networkUser } } = await supabase.auth.getUser()
-            const user = networkUser || await CacheUtil.getAuthUser()
+    const fetchTemplates = useCallback(async (refreshServer: boolean) => {
+        const { data: { session } } = await supabase.auth.getSession()
+        const user = session?.user || await CacheUtil.getAuthUser()
+        if (!user) {
+            router.push('/login')
+            return
+        }
 
-            if (!user) {
-                router.push('/login')
-                return
-            }
-
-            const repositories = await createWebDocumentPrimaryRepositories(supabase)
+        const repositories = await createWebProductDocumentRepositories(supabase)
+        const applyLocalTemplates = async () => {
             const templateSummaries = await repositories.templates.listTemplates(user.id)
             setTemplates(templateSummaries.map((template) => ({
                 id: template.id,
@@ -55,10 +58,24 @@ export default function TemplatesPage() {
             })))
             setLoading(false)
         }
+        await applyLocalTemplates()
+        if (refreshServer) {
+            await refreshWebProductList(supabase, 'template')
+            await applyLocalTemplates()
+        }
+    }, [router, supabase])
 
-        fetchTemplates()
+    useEffect(() => {
+        void fetchTemplates(true)
     // 모달이 닫힐 때(false로 변경) 목록을 다시 가져와 UI를 갱신한다.
-    }, [supabase, router, isNewTemplateModalOpen, isEditTemplateModalOpen])
+    }, [fetchTemplates, isNewTemplateModalOpen, isEditTemplateModalOpen])
+
+    useEffect(() => {
+        let unsubscribe: (() => void) | undefined
+        void subscribeWebProductAccount(supabase, 'template', () => { void fetchTemplates(false) })
+            .then((next) => { unsubscribe = next })
+        return () => unsubscribe?.()
+    }, [fetchTemplates, supabase])
 
     if (loading) {
         return (

--- a/apps/web/app/trips/checklist/ChecklistClient.tsx
+++ b/apps/web/app/trips/checklist/ChecklistClient.tsx
@@ -15,8 +15,7 @@ import { useNetworkStore } from '@/stores/useNetworkStore'
 import { CATEGORIES } from '@/constants/checklist'
 import ChecklistSkeleton from './ChecklistSkeleton'
 import { createWebRepositories } from '@/lib/local-first/repositoryFactory'
-import { subscribeToTripDocumentUpdates } from '@/lib/local-first/indexedDbStore'
-import P2PConnectionStatusBadge, { type P2PConnectionStatus } from '@/components/trips/P2PConnectionStatusBadge'
+import { subscribeWebProductResource } from '@/lib/local-first/repositoryFactory'
 
 const getMemberDisplayName = (p: any, isMe: boolean = false) => {
     if (!p) return isMe ? '나' : '동행자'
@@ -374,25 +373,24 @@ export default function ChecklistPage({
     isActive = true,
     tripId: propsTripId,
     isOffline = false,
-    p2pStatus = 'idle',
 }: {
     isActive?: boolean
     tripId?: string
     isOffline?: boolean
-    p2pStatus?: P2PConnectionStatus
 }) {
     const searchParams = useSearchParams()
     const tripId = propsTripId || searchParams.get('id')
     const supabase = useMemo(() => createClient(), [])
     const repositories = useMemo(() => createWebRepositories(supabase), [supabase])
     const { isOnline } = useNetworkStore()
-    const isLocalFirstChecklistSpike = repositories.mode === 'local-first-checklist-spike'
     const isLocalFirstChecklistMode = repositories.mode === 'local-first-checklist-spike'
         || repositories.mode === 'local-first-checklist-dual-write'
         || repositories.mode === 'document-primary'
+        || repositories.mode === 'server-authority'
     const canApplyTemplates = repositories.mode === 'legacy-supabase'
         || repositories.mode === 'document-primary'
-    const canUseChecklistActions = (isOnline || isLocalFirstChecklistSpike) && !isOffline
+        || repositories.mode === 'server-authority'
+    const canUseChecklistActions = (isOnline || isLocalFirstChecklistMode) && !isOffline
 
     const [isLoading, setIsLoading] = useState(true)
     const [checklistId, setChecklistId] = useState<string | null>(null)
@@ -461,12 +459,6 @@ export default function ChecklistPage({
                 setTripOwner({ id: snapshot.trip.user_id, profiles: snapshot.trip.profiles, email: snapshot.trip.profiles?.email })
             }
 
-            // 이미 다운로드된 여행이라면 백그라운드에서 전체 데이터 동기화
-            const bundle = await DownloadService.getBundle(tripId!)
-            if (bundle) {
-                DownloadService.downloadTrip(tripId!)
-            }
-
             if (snapshot.trip) {
                 const pendingCount = snapshot.items.filter((i: any) => !i.is_checked).length
                 import('@/services/NotificationService').then(({ NotificationService }) => {
@@ -484,18 +476,20 @@ export default function ChecklistPage({
         if (isActive) {
             fetchChecklist()
             supabase.auth
-                .getUser()
-                .then(({ data }: { data: { user: any } }) => setCurrentUser(data.user))
+                .getSession()
+                .then(({ data }) => setCurrentUser(data.session?.user ?? null))
                 .catch(() => setCurrentUser(null))
         }
     }, [isActive, fetchChecklist])
 
     useEffect(() => {
         if (!tripId || !isLocalFirstChecklistMode) return
-        return subscribeToTripDocumentUpdates(tripId, () => {
+        let unsubscribe: (() => Promise<void>) | undefined
+        void subscribeWebProductResource(supabase, 'trip', tripId, () => {
             void fetchChecklist()
-        })
-    }, [fetchChecklist, isLocalFirstChecklistMode, tripId])
+        }).then((next) => { unsubscribe = next })
+        return () => { void unsubscribe?.() }
+    }, [fetchChecklist, isLocalFirstChecklistMode, supabase, tripId])
 
     const toggleItem = async (itemId: string, currentStatus: boolean) => {
         const item = items.find(i => i.id === itemId)
@@ -1214,12 +1208,6 @@ export default function ChecklistPage({
                             totalItems > 0 && <span className={css({ color: 'brand.primary', ml: '8px' })}>{progressPercent}%</span>
                         )}
                     </h2>
-                    <div className={css({ display: { base: 'none', sm: 'block' } })}>
-                        <P2PConnectionStatusBadge status={p2pStatus} />
-                    </div>
-                </div>
-                <div className={css({ display: { base: 'flex', sm: 'none' }, justifyContent: 'flex-start' })}>
-                    <P2PConnectionStatusBadge status={p2pStatus} />
                 </div>
 
                 {/* PC/모바일 분기 액션 버튼 및 필터 라인 */}

--- a/apps/web/app/trips/detail/TripClient.tsx
+++ b/apps/web/app/trips/detail/TripClient.tsx
@@ -9,7 +9,6 @@ import NewPlanModal from '@/components/trips/NewPlanModal'
 import CollaboratorModal from '@/components/trips/CollaboratorModal'
 import ShareModal from '@/components/trips/ShareModal'
 import PlanDetailModal from '@/components/trips/PlanDetailModal'
-import { collaboration } from '@/lib/collaboration'
 import PlanList from '@/components/trips/PlanList'
 import { useNetworkStore } from '@/stores/useNetworkStore'
 import { getCurrencyFromTimezone } from '@nexvoy/core'
@@ -18,11 +17,11 @@ import { CacheUtil } from '@/lib/cache'
 import { NotificationService } from '@/services/NotificationService'
 import { DownloadService } from '@/services/DownloadService'
 import { PlanPhotoStorageService } from '@/services/PlanPhotoStorageService'
-import { Download, CloudDownload, CloudCheck, Loader2 } from 'lucide-react'
 import TripDetailSkeleton from './TripDetailSkeleton'
-import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
-import { flushWebBackupQueue } from '@/lib/local-first/backupSyncService'
-import { subscribeToTripDocumentUpdates } from '@/lib/local-first/indexedDbStore'
+import {
+    createWebProductDocumentRepositories,
+    subscribeWebProductResource,
+} from '@/lib/local-first/repositoryFactory'
 import { materializePlanTimeline } from '@nexvoy/core/local-first/materialize'
 import {
     planTimelineItemToWebPlanRow,
@@ -102,8 +101,6 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
     const [timeDisplayMode, setTimeDisplayMode] = useState<'local' | 'kst' | 'both'>('local')
     const [userRole, setUserRole] = useState<'owner' | 'editor' | 'viewer' | null>(null)
     const { isOnline } = useNetworkStore()
-    const [isDownloaded, setIsDownloaded] = useState(false)
-    const [isDownloading, setIsDownloading] = useState(false)
 
     const [activeDropdown, setActiveDropdown] = useState<string | null>(null)
     const [editingPlan, setEditingPlan] = useState<any>(null)
@@ -194,7 +191,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             if (bundle?.trip) setTrip(bundle.trip)
             return
         }
-        const repositories = await createWebDocumentPrimaryRepositories(supabase)
+        const repositories = await createWebProductDocumentRepositories(supabase)
         const data = await repositories.trips.getTrip(tripId)
         if (data) setTrip(tripDetailToWebTripRow(data))
     }, [tripId, supabase, isOffline])
@@ -210,14 +207,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                 return
             }
 
-            // 2. 네트워크 확인
-            const { isOfflineMode } = useNetworkStore.getState()
-            if (!isOnline || isOfflineMode) {
-                setIsLoading(false)
-                return
-            }
-
-            const repositories = await createWebDocumentPrimaryRepositories(supabase)
+            const repositories = await createWebProductDocumentRepositories(supabase)
             const data = (await repositories.plans.listPlans(tripId)).map((plan) =>
                 planTimelineItemToWebPlanRow(tripId, plan),
             )
@@ -227,28 +217,24 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                 // 명시적 다운로드 정책에 따라 자동 저장은 제거하고 알림만 예약
                 NotificationService.scheduleOfflineReminders(data)
                 
-                // 이미 다운로드된 여행이라면 백그라운드에서 최신 데이터로 동기화
-                const bundle = await DownloadService.getBundle(tripId)
-                if (bundle) {
-                    DownloadService.downloadTrip(tripId)
-                }
             }
         } catch (err) {
             console.error('fetchPlans Error:', err)
         } finally {
             setIsLoading(false)
         }
-    }, [tripId, supabase, isOnline])
+    }, [tripId, supabase, isOffline])
 
     const fetchUserRole = useCallback(async () => {
         if (!tripId) return
-        const { data: { user } } = await supabase.auth.getUser()
+        const { data: { session } } = await supabase.auth.getSession()
+        const user = session?.user ?? await CacheUtil.getAuthUser()
         if (!user) {
             setUserRole(null)
             return
         }
 
-        const repositories = await createWebDocumentPrimaryRepositories(supabase)
+        const repositories = await createWebProductDocumentRepositories(supabase)
         const documentTrip = await repositories.trips.getTrip(tripId)
         if (documentTrip?.ownerId === user.id) {
             setUserRole('owner')
@@ -263,8 +249,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             return
         }
 
-        const { data } = await collaboration.getUserRole(tripId)
-        setUserRole(data as any)
+        setUserRole(null)
     }, [tripId, supabase])
 
     useEffect(() => {
@@ -277,31 +262,13 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
 
     useEffect(() => {
         if (!tripId || isOffline) return undefined
-        return subscribeToTripDocumentUpdates(tripId, () => {
+        let unsubscribe: (() => Promise<void>) | undefined
+        void subscribeWebProductResource(supabase, 'trip', tripId, () => {
             void fetchTrip()
             void fetchPlans()
-        })
-    }, [fetchPlans, fetchTrip, isOffline, tripId])
-
-    useEffect(() => {
-        if (!tripId || isOffline || !isOnline || (userRole !== 'owner' && userRole !== 'editor')) return
-
-        const flushPendingBackup = () => {
-            void flushWebBackupQueue({ supabase, documentId: tripId }).catch(() => undefined)
-        }
-
-        flushPendingBackup()
-
-        const handleVisibilityChange = () => {
-            if (document.visibilityState === 'visible') flushPendingBackup()
-        }
-        document.addEventListener('visibilitychange', handleVisibilityChange)
-
-        return () => {
-            document.removeEventListener('visibilitychange', handleVisibilityChange)
-        }
-    }, [tripId, isOffline, isOnline, supabase, userRole])
-
+        }).then((next) => { unsubscribe = next })
+        return () => { void unsubscribe?.() }
+    }, [fetchPlans, fetchTrip, isOffline, supabase, tripId])
 
     const handleDeletePlan = async (planId: string) => {
         if (!tripId) return
@@ -317,7 +284,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
         }
 
         try {
-            const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+            const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: userRole })
             await repositories.plans.deletePlan(tripId, planId)
             setActiveDropdown(null)
             fetchPlans()
@@ -335,7 +302,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             cur && cur.id === planId ? { ...cur, image_url: newImageUrl } : cur
         ))
         if (tripId && (userRole === 'owner' || userRole === 'editor')) {
-            createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+            createWebProductDocumentRepositories(supabase, { actorRole: userRole })
                 .then((repositories) => repositories.plans.updatePlan(tripId, {
                     planId,
                     patch: { imageUrl: newImageUrl },
@@ -369,7 +336,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
         // 디테일 모달이 열려 있으면 선택된 plan도 업데이트
         setSelectedPlanForDetail((prev: any) => prev && prev.id === planId ? { ...prev, is_visited: isVisited } : prev)
         try {
-            const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+            const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: userRole })
             await repositories.plans.updatePlan(tripId, {
                 planId,
                 patch: { isVisited },
@@ -389,7 +356,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
         if (userRole !== 'owner' && userRole !== 'editor') {
             throw new Error('일정을 수정할 권한이 없습니다.')
         }
-        const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+        const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: userRole })
         const planId = editPlanId ?? createLocalPlanId()
         const input = toDocumentPlanInput(planId, plan)
         const result = editPlanId
@@ -415,21 +382,6 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
     const handlePlanDetail = (plan: any) => {
         setSelectedPlanForDetail(plan)
         setIsDetailModalOpen(true)
-    }
-
-    const handleDownload = async () => {
-        if (!tripId || isDownloading) return
-        
-        setIsDownloading(true)
-        const success = await DownloadService.downloadTrip(tripId)
-        setIsDownloading(false)
-        
-        if (success) {
-            setIsDownloaded(true)
-            alert('여행 정보가 성공적으로 다운로드되었습니다. 오프라인에서도 확인할 수 있습니다!')
-        } else {
-            alert('다운로드에 실패했습니다. 네트워크 상태를 확인해 주세요.')
-        }
     }
 
     // 24시간 이내 가장 가까운 일정 계산
@@ -552,7 +504,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                     </div>
                     
                     {/* PC 전용 일정 추가 버튼 */}
-                    {(userRole === 'owner' || userRole === 'editor') && isOnline && !isOffline && (
+                    {(userRole === 'owner' || userRole === 'editor') && !isOffline && (
                         <button
                             onClick={() => { setEditingPlan(null); setIsModalOpen(true) }}
                              className={css({
@@ -576,7 +528,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
             ) : (!plans || plans.length === 0) ? (
                 <div className={css({ textAlign: 'center', py: '80px', color: 'brand.muted' })}>
                     <p className={css({ fontSize: '18px', fontWeight: '700', mb: '12px', color: 'brand.ink' })}>아직 등록된 여정이 없어요. 🗺️</p>
-                    {(userRole === 'owner' || userRole === 'editor') && isOnline && (
+                    {(userRole === 'owner' || userRole === 'editor') && (
                         <p className={css({ fontSize: '15px', color: 'brand.muted', lineHeight: '1.6' })}>새로운 일정을 추가해서 설레는 여정을 완성해 볼까요?</p>
                     )}
                 </div>
@@ -645,7 +597,7 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId, is
                 />
             )}
             {/* 모바일 전용 Sticky CTA (편집 권한 있을 때만) */}
-            {(userRole === 'owner' || userRole === 'editor') && isActive && !isModalOpen && isOnline && !isOffline && (
+            {(userRole === 'owner' || userRole === 'editor') && isActive && !isModalOpen && !isOffline && (
                 <button
                     onClick={() => { setEditingPlan(null); setIsModalOpen(true) }}
                     className={css({

--- a/apps/web/app/trips/detail/TripLayoutClient.tsx
+++ b/apps/web/app/trips/detail/TripLayoutClient.tsx
@@ -2,8 +2,7 @@
 
 import { createClient } from '@/lib/supabase/client'
 import { css } from 'styled-system/css'
-import Link from 'next/link'
-import { ArrowLeft, Calendar, ListChecks, MapPin } from 'lucide-react'
+import { Calendar, ListChecks, MapPin } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import TripHeaderActions from '@/components/trips/TripHeaderActions'
 import { useEffect, useState } from 'react'
@@ -15,24 +14,16 @@ import ChecklistClient from '../checklist/ChecklistClient'
 const RouteMapView = dynamic(() => import('@/components/trips/RouteMapView'), { ssr: false })
 import { useUIStore } from '@/stores/useUIStore'
 import { CacheUtil } from '@/lib/cache'
-import { collaboration } from '@/lib/collaboration'
 import { useNetworkStore } from '@/stores/useNetworkStore'
-import P2PConnectionStatusBadge from '@/components/trips/P2PConnectionStatusBadge'
-import type { P2PConnectionStatus } from '@/components/trips/P2PConnectionStatusBadge'
-import { useWebP2PDocumentConnection } from '@/lib/local-first/webP2PDocumentConnection'
-import { ensureWebDocumentKeyReadiness } from '@/lib/local-first/keyProvisioningService'
 import {
-    flushWebBackupQueue,
-    getWebBackupQueueSnapshot,
-    subscribeToWebBackupQueue,
-    type WebBackupQueueSnapshot,
-} from '@/lib/local-first/backupSyncService'
-import {
-    createWebDocumentPrimaryRepositories,
-    ensureWebTripDocumentRemoteBootstrap,
-} from '@/lib/local-first/documentPrimaryRepositories'
-import { tripDetailToWebMemberRows, tripDetailToWebTripRow } from '@/lib/local-first/tripReadModelAdapters'
+    createWebProductDocumentRepositories,
+    getWebProductSyncSnapshot,
+    subscribeWebProductResource,
+} from '@/lib/local-first/repositoryFactory'
+import { tripDetailToWebTripRow } from '@/lib/local-first/tripReadModelAdapters'
 import { createInvitationRepository } from '@nexvoy/core/supabase/invitationRepository'
+import type { AuthorityProductSyncSnapshot } from '@nexvoy/core'
+import AuthoritySyncStatusBadge from '@/components/trips/AuthoritySyncStatusBadge'
 
 export default function TripLayoutClient() {
     const searchParams = useSearchParams()
@@ -47,20 +38,16 @@ export default function TripLayoutClient() {
 
     const [trip, setTrip] = useState<any>(null)
     const [currentUser, setCurrentUser] = useState<any>(null)
-    const [members, setMembers] = useState<any[]>([])
-    const [backupQueue, setBackupQueue] = useState<WebBackupQueueSnapshot | null>(null)
+    const [syncSnapshot, setSyncSnapshot] = useState<AuthorityProductSyncSnapshot>({
+        status: 'synced',
+        pendingCount: 0,
+        lastError: null,
+    })
     const [loading, setLoading] = useState(true)
     const [activeTab, setActiveTab] = useState<'plans' | 'checklist' | 'map'>(initialTab)
     const { setMobileTitle } = useUIStore()
     const { isOnline } = useNetworkStore()
-    const p2pStatus = useWebP2PDocumentConnection({
-        enabled: Boolean(id && currentUser?.id && trip?.user_id && isOnline),
-        documentId: id,
-        currentUserId: currentUser?.id ?? null,
-        ownerId: trip?.user_id ?? null,
-        members,
-    })
-    const syncStatus = resolveVisibleSyncStatus(p2pStatus, backupQueue)
+    const syncStatus = syncSnapshot.status
 
     useEffect(() => {
         const urlTab = searchParams.get('tab')
@@ -108,7 +95,7 @@ export default function TripLayoutClient() {
                 }
                 setCurrentUser(currentUser)
                 
-                const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: 'viewer' })
+                const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: 'viewer' })
                 const documentTrip = await repositories.trips.getTrip(id)
 
                 if (!documentTrip) {
@@ -123,13 +110,6 @@ export default function TripLayoutClient() {
                     }
                 } else {
                     setTrip(tripDetailToWebTripRow(documentTrip))
-                    const documentMembers = tripDetailToWebMemberRows(documentTrip)
-                    if (documentMembers.length > 0) {
-                        setMembers(documentMembers)
-                    } else {
-                        const { data: memberRows } = await collaboration.getMembers(id)
-                        setMembers(memberRows ?? [])
-                    }
                 }
             } catch (err) {
                 console.error('Failed to fetch trip:', err)
@@ -141,86 +121,30 @@ export default function TripLayoutClient() {
     }, [id, supabase, router])
 
     useEffect(() => {
-        if (!id || !currentUser?.id || !trip?.user_id || !isOnline) return undefined
-
-        const role = resolveDocumentKeyReadinessRole({
-            currentUserId: currentUser.id,
-            ownerId: trip.user_id,
-            members,
-        })
+        if (!id || !currentUser?.id) return undefined
         let disposed = false
-        let running = false
-        const run = () => {
-            if (disposed || running) return
-            running = true
-            void (async () => {
-                if (role === 'owner') {
-                    await ensureWebTripDocumentRemoteBootstrap({
-                        supabase,
-                        tripId: id,
-                    })
-                }
-                await ensureWebDocumentKeyReadiness({
-                    supabase,
-                    documentId: id,
-                    role,
-                })
-                if (role === 'owner' || role === 'editor') {
-                    await flushWebBackupQueue({ supabase, documentId: id })
-                }
-                const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
-                await repositories.trips.getTrip(id)
-            })().catch((error) => {
-                const reason = error instanceof Error ? error.message : 'unknown'
-                console.warn('[document key readiness failed]', reason)
-            }).finally(() => {
-                running = false
-            })
+        let unsubscribe: (() => Promise<void>) | undefined
+        const load = async () => {
+            const [snapshot, repositories] = await Promise.all([
+                getWebProductSyncSnapshot(supabase, 'trip', id),
+                createWebProductDocumentRepositories(supabase, { actorRole: 'viewer' }),
+            ])
+            const detail = await repositories.trips.getTrip(id)
+            if (disposed) return
+            setSyncSnapshot(snapshot)
+            if (detail) {
+                setTrip(tripDetailToWebTripRow(detail))
+            }
         }
-
-        run()
-        if (role !== 'owner' && role !== 'editor') return () => { disposed = true }
-
-        const intervalId = window.setInterval(() => {
-            if (!disposed) run()
-        }, 10_000)
-        const handleVisibility = () => {
-            if (document.visibilityState === 'visible') run()
-        }
-        document.addEventListener('visibilitychange', handleVisibility)
-
+        void load().catch(() => undefined)
+        void subscribeWebProductResource(supabase, 'trip', id, () => {
+            void load().catch(() => undefined)
+        }).then((next) => { unsubscribe = next })
         return () => {
             disposed = true
-            window.clearInterval(intervalId)
-            document.removeEventListener('visibilitychange', handleVisibility)
+            void unsubscribe?.()
         }
-    }, [currentUser?.id, id, isOnline, members, supabase, trip?.user_id])
-
-    useEffect(() => {
-        if (!id || !currentUser?.id || !isOnline) {
-            setBackupQueue(null)
-            return undefined
-        }
-
-        let disposed = false
-        const load = () => {
-            void getWebBackupQueueSnapshot(id).then((snapshot) => {
-                if (!disposed) setBackupQueue(snapshot)
-            }).catch(() => {
-                if (!disposed) setBackupQueue(null)
-            })
-        }
-
-        load()
-        const unsubscribe = subscribeToWebBackupQueue(id, load)
-        const intervalId = window.setInterval(load, 5_000)
-
-        return () => {
-            disposed = true
-            unsubscribe()
-            window.clearInterval(intervalId)
-        }
-    }, [currentUser?.id, id, isOnline])
+    }, [currentUser?.id, id, isOnline, supabase])
 
     if (loading) {
         return <div className={css({ w: '100%', py: '40px', textAlign: 'center', color: '#888' })}>여행 정보를 불러오는 중...</div>
@@ -350,8 +274,16 @@ export default function TripLayoutClient() {
                     alignItems: 'center',
                     pr: '4px',
                 })}>
-                    <P2PConnectionStatusBadge status={syncStatus} />
+                    <AuthoritySyncStatusBadge status={syncStatus} detail={syncSnapshot.lastError} />
                 </div>
+            </div>
+
+            <div className={css({
+                display: { base: 'flex', sm: 'none' },
+                justifyContent: 'flex-end',
+                py: '8px',
+            })}>
+                <AuthoritySyncStatusBadge status={syncStatus} detail={syncSnapshot.lastError} />
             </div>
 
             {/* 하위 컨텐츠 전환 영역 (언마운트 하지 않고 display none으로 유지하여 상태 보존 및 즉각 전환) */}
@@ -360,7 +292,7 @@ export default function TripLayoutClient() {
                     <TripClient isActive={activeTab === 'plans'} />
                 </div>
                 <div style={{ display: activeTab === 'checklist' ? 'block' : 'none' }}>
-                    <ChecklistClient isActive={activeTab === 'checklist'} p2pStatus={p2pStatus} />
+                    <ChecklistClient isActive={activeTab === 'checklist'} />
                 </div>
                 <div style={{ display: activeTab === 'map' ? 'block' : 'none' }}>
                     <RouteMapView
@@ -372,31 +304,4 @@ export default function TripLayoutClient() {
             </div>
         </div>
     )
-}
-
-function resolveVisibleSyncStatus(
-    p2pStatus: P2PConnectionStatus,
-    backupQueue: WebBackupQueueSnapshot | null,
-): P2PConnectionStatus {
-    if (p2pStatus === 'connected' || p2pStatus === 'connecting') return p2pStatus
-    if (!backupQueue || backupQueue.pendingCount === 0) {
-        return backupQueue?.status === 'synced' ? 'backup_synced' : p2pStatus
-    }
-
-    if (backupQueue.lastError === 'key_unavailable') return 'backup_waiting_for_key'
-    if (backupQueue.status === 'failed') return 'backup_failed'
-    if (backupQueue.status === 'pending' || backupQueue.status === 'uploading') return 'backup_pending'
-    return p2pStatus
-}
-
-function resolveDocumentKeyReadinessRole(input: {
-    currentUserId: string
-    ownerId: string
-    members: Array<{ user_id?: string | null; role?: string | null; status?: string | null }>
-}): 'owner' | 'editor' | 'viewer' | null {
-    if (input.currentUserId === input.ownerId) return 'owner'
-    const member = input.members.find((candidate) => candidate.user_id === input.currentUserId)
-    if (!member || member.status !== 'accepted') return null
-    if (member.role === 'owner' || member.role === 'editor' || member.role === 'viewer') return member.role
-    return null
 }

--- a/apps/web/app/trips/new/page.tsx
+++ b/apps/web/app/trips/new/page.tsx
@@ -8,7 +8,7 @@ import { css } from 'styled-system/css'
 import { Plus, ArrowLeft, ChevronLeft, Minus } from 'lucide-react'
 import { useLoadScript, Autocomplete } from '@react-google-maps/api'
 import { CacheUtil } from '@/lib/cache'
-import { createWebTripDocument } from '@/lib/local-first/documentPrimaryRepositories'
+import { createWebProductTrip } from '@/lib/local-first/repositoryFactory'
 
 const libraries: ("places")[] = ["places"]
 
@@ -41,7 +41,8 @@ export default function NewTripPage() {
     useEffect(() => {
         async function checkAuth() {
             const supabase = createClient()
-            const { data: { user: networkUser } } = await supabase.auth.getUser()
+            const { data: { session } } = await supabase.auth.getSession()
+            const networkUser = session?.user
             const user = networkUser || await CacheUtil.getAuthUser()
             if (!user) {
                 router.push('/login')
@@ -69,7 +70,8 @@ export default function NewTripPage() {
         }
 
         const supabase = createClient()
-        const { data: { user: networkUser } } = await supabase.auth.getUser()
+        const { data: { session } } = await supabase.auth.getSession()
+        const networkUser = session?.user
         const user = networkUser || await CacheUtil.getAuthUser()
 
         if (!user) {
@@ -78,7 +80,7 @@ export default function NewTripPage() {
         }
 
         try {
-            const tripId = await createWebTripDocument({
+            const tripId = await createWebProductTrip({
                 supabase,
                 destination,
                 startDate,
@@ -166,7 +168,7 @@ export default function NewTripPage() {
                                             fontWeight: '600',
                                             color: '#2C3A47',
                                             _placeholder: { color: '#CCC', fontWeight: '400' },
-                                            _focus: { borderColor: '#2EC4B6', bg: 'white', boxShadow: '0 0 0 3px rgba(46, 196, 182, 0.1)' },
+                                            _focus: { borderColor: 'brand.primary', bg: 'white', boxShadow: '0 0 0 3px rgba(var(--colors-brand-primary-rgb), 0.1)' },
                                         })}
                                     />
                                 </PlacesAutocomplete>
@@ -176,15 +178,20 @@ export default function NewTripPage() {
                                     required
                                     value={destination}
                                     onChange={e => setDestination(e.target.value)}
-                                    placeholder="지도 로딩 중..."
-                                    disabled
+                                    placeholder="여행지를 입력하세요"
                                     className={css({
                                         w: '100%',
-                                        p: '14px',
-                                        border: '1px solid #ddd',
-                                        borderRadius: '12px',
+                                        p: '16px 18px',
+                                        border: '1px solid',
+                                        borderColor: 'brand.hairline',
+                                        borderRadius: '16px',
                                         outline: 'none',
-                                        bg: '#f1f1f1'
+                                        bg: 'bg.surfaceSoft',
+                                        fontSize: '16px',
+                                        fontWeight: '600',
+                                        color: 'brand.ink',
+                                        _placeholder: { color: 'brand.muted', fontWeight: '400' },
+                                        _focus: { borderColor: 'brand.primary', bg: 'white' },
                                     })}
                                 />
                             )}

--- a/apps/web/components/template/EditTemplateModal.tsx
+++ b/apps/web/components/template/EditTemplateModal.tsx
@@ -20,7 +20,7 @@ import {
     updateTemplateShareRole,
 } from '@nexvoy/core'
 import type { ChecklistCategory, ChecklistTemplateShareWithProfile } from '@nexvoy/types'
-import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import { createWebProductDocumentRepositories } from '@/lib/local-first/repositoryFactory'
 
 interface EditTemplateModalProps {
     isOpen: boolean
@@ -54,7 +54,7 @@ export default function EditTemplateModal({ isOpen, onClose, templateId, onSucce
         
         setFetching(true)
         try {
-            const repositories = await createWebDocumentPrimaryRepositories(supabase)
+            const repositories = await createWebProductDocumentRepositories(supabase)
             const data = await repositories.templates.getTemplate(templateId)
 
             if (data) {
@@ -120,7 +120,7 @@ export default function EditTemplateModal({ isOpen, onClose, templateId, onSucce
 
         setLoading(true)
         try {
-            const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: 'owner' })
+            const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: 'owner' })
             await repositories.templates.deleteTemplate(templateId)
             
             if (onSuccess) onSuccess()
@@ -154,7 +154,7 @@ export default function EditTemplateModal({ isOpen, onClose, templateId, onSucce
         setLoading(true)
 
         try {
-            const repositories = await createWebDocumentPrimaryRepositories(supabase, {
+            const repositories = await createWebProductDocumentRepositories(supabase, {
                 actorRole: canManageShares ? 'owner' : 'editor',
             })
             await repositories.templates.updateTemplate(templateId, { title: title.trim() })

--- a/apps/web/components/template/NewTemplateModal.tsx
+++ b/apps/web/components/template/NewTemplateModal.tsx
@@ -7,7 +7,7 @@ import { X, Sparkles } from 'lucide-react'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useRouter } from 'next/navigation'
 import TemplateForm, { TemplateItemInput } from './TemplateForm'
-import { createWebTemplateDocument } from '@/lib/local-first/documentPrimaryRepositories'
+import { createWebProductTemplate } from '@/lib/local-first/repositoryFactory'
 import {
     createChecklistCategory,
     deleteChecklistCategory,
@@ -100,7 +100,7 @@ export default function NewTemplateModal({ isOpen, onClose, onSuccess }: NewTemp
             const { data: { session } } = await supabase.auth.getSession()
             if (!session?.user) throw new Error('인증 정보가 없습니다.')
 
-            await createWebTemplateDocument({
+            await createWebProductTemplate({
                 supabase,
                 title: title.trim(),
                 items: validItems.map((item) => ({

--- a/apps/web/components/trips/AuthoritySyncStatusBadge.tsx
+++ b/apps/web/components/trips/AuthoritySyncStatusBadge.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { AlertTriangle, CheckCircle2, CloudOff, Loader2 } from 'lucide-react'
+import type { AuthorityProductSyncStatus } from '@nexvoy/core'
+import { css } from 'styled-system/css'
+
+const COPY: Record<AuthorityProductSyncStatus, string> = {
+  offline: '오프라인 저장',
+  pending: '저장 대기',
+  synced: '동기화 완료',
+  conflict: '확인 필요',
+  error: '저장 오류',
+}
+
+export default function AuthoritySyncStatusBadge({
+  status,
+  detail,
+}: {
+  status: AuthorityProductSyncStatus
+  detail?: string | null
+}) {
+  const isProblem = status === 'conflict' || status === 'error'
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      title={detail ? `${COPY[status]}: ${detail}` : COPY[status]}
+      className={css({
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        h: '32px',
+        px: '10px',
+        borderRadius: '8px',
+        border: '1px solid',
+        borderColor: isProblem ? '#FDE68A' : 'brand.hairline',
+        bg: isProblem ? '#FFFBEB' : 'white',
+        color: isProblem ? '#B45309' : status === 'synced' ? 'brand.primary' : 'brand.muted',
+        fontSize: '12px',
+        fontWeight: '700',
+        lineHeight: 1,
+        whiteSpace: 'nowrap',
+      })}
+    >
+      {status === 'pending' ? (
+        <Loader2 size={14} className={css({ animation: 'spin 1s linear infinite' })} />
+      ) : status === 'offline' ? (
+        <CloudOff size={14} />
+      ) : status === 'synced' ? (
+        <CheckCircle2 size={14} />
+      ) : (
+        <AlertTriangle size={14} />
+      )}
+      <span>{COPY[status]}</span>
+    </div>
+  )
+}

--- a/apps/web/components/trips/CollaboratorModal.tsx
+++ b/apps/web/components/trips/CollaboratorModal.tsx
@@ -18,6 +18,7 @@ import {
     createWebDocumentPrimaryRepositories,
     ensureWebTripDocumentRemoteBootstrap,
 } from '@/lib/local-first/documentPrimaryRepositories'
+import { isWebServerAuthorityEnabled } from '@/lib/local-first/repositoryFactory'
 
 interface CollaboratorModalProps {
     isOpen: boolean
@@ -151,10 +152,12 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
             const { data: { user } } = await supabase.auth.getUser()
             if (!user) throw new Error('로그인이 필요합니다.')
 
-            await ensureWebTripDocumentRemoteBootstrap({
-                supabase,
-                tripId,
-            })
+            if (!isWebServerAuthorityEnabled()) {
+                await ensureWebTripDocumentRemoteBootstrap({
+                    supabase,
+                    tripId,
+                })
+            }
 
             const result = await CollaborationService.createInvite({
                 documentId: tripId,
@@ -219,6 +222,7 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
     }
 
     const syncCollaboratorSnapshot = async (members: Collaborator[], actorRole: MemberRole | null) => {
+        if (isWebServerAuthorityEnabled()) return
         try {
             const repositories = await createWebDocumentPrimaryRepositories(supabase, {
                 actorRole,
@@ -234,6 +238,7 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
     }
 
     const upsertCollaboratorSnapshot = async (member: Collaborator) => {
+        if (isWebServerAuthorityEnabled()) return
         try {
             const repositories = await createWebDocumentPrimaryRepositories(supabase, {
                 actorRole: currentMemberRole ?? null,
@@ -247,6 +252,7 @@ export default function CollaboratorModal({ isOpen, onClose, tripId, tripTitle, 
     }
 
     const revokeCollaboratorSnapshot = async (memberId: string) => {
+        if (isWebServerAuthorityEnabled()) return
         try {
             const repositories = await createWebDocumentPrimaryRepositories(supabase, {
                 actorRole: currentMemberRole ?? null,

--- a/apps/web/components/trips/EditTripModal.tsx
+++ b/apps/web/components/trips/EditTripModal.tsx
@@ -8,6 +8,7 @@ import { useLoadScript, Autocomplete } from '@react-google-maps/api'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useScrollLock } from '@/hooks/useScrollLock'
 import { analytics } from '@/services/AnalyticsService'
+import { createWebProductDocumentRepositories } from '@/lib/local-first/repositoryFactory'
 
 const libraries: ("places")[] = ["places"]
 
@@ -116,18 +117,14 @@ export default function EditTripModal({ isOpen, onClose, onSuccess, trip }: Edit
         setError('')
 
         try {
-            const { error: updateError } = await supabase
-                .from('trips')
-                .update({
-                    destination,
-                    start_date: startDate,
-                    end_date: endDate,
-                    adults_count: adults,
-                    children_count: childrenCount,
-                })
-                .eq('id', trip.id)
-
-            if (updateError) throw updateError
+            const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: 'owner' })
+            await repositories.trips.updateTrip(trip.id, {
+                destination,
+                startDate,
+                endDate,
+                adultsCount: adults,
+                childrenCount,
+            })
 
             onSuccess({
                 destination,

--- a/apps/web/components/trips/NewPlanModal.tsx
+++ b/apps/web/components/trips/NewPlanModal.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback, type ComponentType, type ReactNode } from 'react'
-import { createClient } from '@/lib/supabase/client'
 import { css } from 'styled-system/css'
 import { X, MapPin, Clock, Calendar, Check, Search, ChevronRight, Loader2, Camera, Navigation, Map, Info, Compass, Bell } from 'lucide-react'
 import { useLoadScript, Autocomplete } from '@react-google-maps/api'
@@ -43,7 +42,7 @@ interface NewPlanModalProps {
      * 부모가 plans 리스트의 해당 항목 image_url을 패치할 때 사용.
      */
     onPlanImageUpdated?: (planId: string, imageUrl: string) => void
-    onSavePlan?: (input: {
+    onSavePlan: (input: {
         plan: PlanInsert
         editPlanId?: string
     }) => Promise<string>
@@ -75,7 +74,6 @@ export default function NewPlanModal({
     onPlanImageUpdated,
     onSavePlan,
 }: NewPlanModalProps) {
-    const supabase = createClient()
     const [step, setStep] = useState(1) // 1: 장소검색, 2: 상세입력
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState('')
@@ -318,7 +316,9 @@ export default function NewPlanModal({
         setError('')
 
         try {
-            const tzData = await LocationService.getTimezone(selectedPlace.lat, selectedPlace.lng)
+            const tzData = typeof navigator !== 'undefined' && !navigator.onLine
+                ? { timeZoneId: editData?.timezone_string || 'Asia/Seoul' }
+                : await LocationService.getTimezone(selectedPlace.lat, selectedPlace.lng)
 
             const startStr = `${visitDate}T${visitTime}:00`
             const startDateObj = new Date(startStr)
@@ -351,35 +351,16 @@ export default function NewPlanModal({
                 timezone_string: tzData.timeZoneId || 'Asia/Seoul'
             }
 
-            let savedPlanId: string | null = null
-            if (onSavePlan) {
-                savedPlanId = await onSavePlan({
-                    plan: planData,
-                    editPlanId: editData?.id,
-                })
-            } else if (editData?.id) {
-                const result = await supabase
-                    .from('plans')
-                    .update(planData)
-                    .eq('id', editData.id)
-                    .select('id')
-                    .single()
-                if (result.error) throw result.error
-                savedPlanId = (result.data as { id?: string } | null)?.id ?? editData.id
-            } else {
-                const result = await supabase
-                    .from('plans')
-                    .insert(planData)
-                    .select('id')
-                    .single()
-                if (result.error) throw result.error
-                savedPlanId = (result.data as { id?: string } | null)?.id ?? null
-            }
+            const savedPlanId = await onSavePlan({
+                plan: planData,
+                editPlanId: editData?.id,
+            })
 
             // 백그라운드 업로드 (fire-and-forget). photo_reference + placeId 모두 있을 때만 시도.
             // 모달 close 이전에 시작해야 try/catch/finally가 의도대로 동작한다.
             if (
                 savedPlanId &&
+                (typeof navigator === 'undefined' || navigator.onLine) &&
                 selectedPlace.photoReference &&
                 selectedPlace.googlePlaceId
             ) {
@@ -390,7 +371,7 @@ export default function NewPlanModal({
                             tripId,
                             placeId: selectedPlace.googlePlaceId,
                             photoReference: selectedPlace.photoReference,
-                            documentPrimary: Boolean(onSavePlan),
+                            documentPrimary: true,
                         },
                         (imageUrl) => {
                             // Zustand store가 plan-level에 없어, 부모에게 콜백으로 통지
@@ -492,7 +473,7 @@ export default function NewPlanModal({
                             </div>
 
                             <div className={css({ position: 'relative' })}>
-                                {isLoaded && (
+                                {isLoaded ? (
                                     <PlacesAutocomplete onLoad={(a) => setAutocomplete(a)} onPlaceChanged={onPlaceChanged}>
                                             <div className={css({ position: 'relative', width: '100%' })}>
                                                 <div className={css({ 
@@ -522,6 +503,32 @@ export default function NewPlanModal({
                                                 />
                                             </div>
                                     </PlacesAutocomplete>
+                                ) : (
+                                    <div className={css({ position: 'relative', width: '100%' })}>
+                                        <div className={css({
+                                            position: 'absolute', left: '18px', top: '50%', transform: 'translateY(-50%)',
+                                            color: 'brand.muted', zIndex: 10, pointerEvents: 'none',
+                                            display: 'flex', alignItems: 'center', justifyContent: 'center'
+                                        })}>
+                                            <Search size={20} />
+                                        </div>
+                                        <input
+                                            ref={searchInputRef}
+                                            type="text"
+                                            placeholder="장소 이름을 입력하세요"
+                                            value={inputValue}
+                                            onChange={(e) => setInputValue(e.target.value)}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter' && inputValue.trim()) handleContinueManual()
+                                            }}
+                                            className={css({
+                                                w: '100%', p: '18px 20px 18px 52px', bg: 'bg.softCotton', border: '1px solid', borderColor: 'brand.hairlineSoft',
+                                                borderRadius: '16px', fontSize: '16px', fontWeight: '600', outline: 'none',
+                                                transition: 'all 0.3s', _focus: { borderColor: 'brand.primary', bg: 'white' }
+                                            })}
+                                            autoFocus
+                                        />
+                                    </div>
                                 )}
 
                                 {inputValue.trim().length > 0 && (
@@ -582,10 +589,26 @@ export default function NewPlanModal({
                                         </div>
                                         <div className={css({ flex: 1, minW: 0 })}>
                                             <label className={css({ display: 'block', fontSize: '12px', fontWeight: '700', color: 'brand.muted', mb: '4px' })}>장소 이름</label>
-                                            <PlacesAutocomplete 
-                                                onLoad={(a) => setDetailAutocomplete(a)} 
-                                                onPlaceChanged={onDetailPlaceChanged}
-                                            >
+                                            {isLoaded ? (
+                                                <PlacesAutocomplete
+                                                    onLoad={(a) => setDetailAutocomplete(a)}
+                                                    onPlaceChanged={onDetailPlaceChanged}
+                                                >
+                                                    <input
+                                                        type="text"
+                                                        value={selectedPlace.name}
+                                                        onChange={e => setSelectedPlace({ ...selectedPlace, name: e.target.value })}
+                                                        placeholder="장소 이름을 입력하세요"
+                                                        className={css({
+                                                            w: '100%', fontSize: '16px', fontWeight: '800', color: 'brand.ink',
+                                                            border: 'none', bg: 'transparent', outline: 'none', p: 0,
+                                                            borderBottom: '1.5px solid transparent',
+                                                            transition: 'all 0.2s',
+                                                            _focus: { borderBottomColor: 'brand.primary' }
+                                                        })}
+                                                    />
+                                                </PlacesAutocomplete>
+                                            ) : (
                                                 <input
                                                     type="text"
                                                     value={selectedPlace.name}
@@ -599,7 +622,7 @@ export default function NewPlanModal({
                                                         _focus: { borderBottomColor: 'brand.primary' } 
                                                     })}
                                                 />
-                                            </PlacesAutocomplete>
+                                            )}
                                         </div>
                                     </div>
                                     <div className={css({ borderTop: '1px solid', borderColor: 'brand.hairlineSoft', pt: '12px' })}>

--- a/apps/web/components/trips/NewTripModal.tsx
+++ b/apps/web/components/trips/NewTripModal.tsx
@@ -8,7 +8,7 @@ import { useLoadScript, Autocomplete } from '@react-google-maps/api'
 import { useModalBackButton } from '@/hooks/useModalBackButton'
 import { useRouter } from 'next/navigation'
 import { analytics } from '@/services/AnalyticsService'
-import { createWebTripDocument } from '@/lib/local-first/documentPrimaryRepositories'
+import { createWebProductTrip } from '@/lib/local-first/repositoryFactory'
 
 const libraries: ("places")[] = ["places"]
 
@@ -106,13 +106,14 @@ export default function NewTripModal({ isOpen, onClose, onSuccess }: NewTripModa
         setError('')
 
         try {
-            const { data: { user } } = await supabase.auth.getUser()
+            const { data: { session } } = await supabase.auth.getSession()
+            const user = session?.user
             if (!user) {
                 router.push('/login')
                 return
             }
 
-            const tripId = await createWebTripDocument({
+            const tripId = await createWebProductTrip({
                 supabase,
                 destination,
                 startDate,
@@ -203,9 +204,18 @@ export default function NewTripModal({ isOpen, onClose, onSuccess }: NewTripModa
                                     />
                                 </PlacesAutocomplete>
                             ) : (
-                                <div className={css({ w: '100%', p: '18px 20px', bg: 'white', borderRadius: '8px', border: '1px solid', borderColor: 'brand.hairline', color: 'brand.muted', display: 'flex', alignItems: 'center', gap: '10px' })}>
-                                    <Loader2 size={18} className={css({ animation: 'spin 1.5s linear infinite' })} /> 지도 정보를 불러오는 중...
-                                </div>
+                                <input
+                                    type="text"
+                                    required
+                                    value={destination}
+                                    onChange={e => setDestination(e.target.value)}
+                                    placeholder="여행지를 입력하세요"
+                                    className={css({
+                                        w: '100%', p: '18px 20px', bg: 'white', border: '1px solid', borderColor: 'brand.hairline',
+                                        borderRadius: '8px', fontSize: '16px', fontWeight: '600', outline: 'none',
+                                        transition: 'all 0.3s', _focus: { borderColor: 'brand.primary', boxShadow: '0 0 0 5px rgba(var(--colors-brand-primary-rgb), 0.1)' }
+                                    })}
+                                />
                             )}
                         </div>
 

--- a/apps/web/components/trips/RouteMapView.tsx
+++ b/apps/web/components/trips/RouteMapView.tsx
@@ -13,7 +13,7 @@ import { PlanPhotoStorageService } from '@/services/PlanPhotoStorageService'
 import RouteMapInfoModal from '@/components/trips/RouteMapInfoModal'
 import PlanDetailModal from '@/components/trips/PlanDetailModal'
 import NewPlanModal from '@/components/trips/NewPlanModal'
-import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import { createWebProductDocumentRepositories } from '@/lib/local-first/repositoryFactory'
 import { materializePlanTimeline } from '@nexvoy/core/local-first/materialize'
 import { planTimelineItemToWebPlanRow } from '@/lib/local-first/tripReadModelAdapters'
 import type { CreatePlanMutationInput } from '@nexvoy/core/local-first/documentMutationWriter'
@@ -197,7 +197,7 @@ export default function RouteMapView({
         let cancelled = false
 
         const fetchData = async () => {
-            const repositories = await createWebDocumentPrimaryRepositories(supabase)
+            const repositories = await createWebProductDocumentRepositories(supabase)
             const [planRows, role] = await Promise.all([
                 repositories.plans.listPlans(tripId),
                 getDocumentPrimaryUserRole(supabase, tripId),
@@ -345,7 +345,7 @@ export default function RouteMapView({
                 if (!tripId || (userRole !== 'owner' && userRole !== 'editor')) {
                     throw new Error('일정을 수정할 권한이 없습니다.')
                 }
-                const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+                const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: userRole })
                 await repositories.plans.updatePlan(tripId, {
                     planId,
                     patch: { isVisited },
@@ -381,7 +381,7 @@ export default function RouteMapView({
     // plans 재패칭 (수정/삭제 후)
     const refetchPlans = useCallback(async () => {
         if (!tripId) return
-        const repositories = await createWebDocumentPrimaryRepositories(supabase)
+        const repositories = await createWebProductDocumentRepositories(supabase)
         const data = await repositories.plans.listPlans(tripId)
         setPlans(data.map((plan) => ({
             ...planTimelineItemToWebPlanRow(tripId, plan),
@@ -397,7 +397,7 @@ export default function RouteMapView({
         if (userRole !== 'owner' && userRole !== 'editor') {
             throw new Error('일정을 수정할 권한이 없습니다.')
         }
-        const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+        const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: userRole })
         const planId = editPlanId ?? createLocalPlanId()
         const input = toDocumentPlanInput(planId, plan)
         const result = editPlanId
@@ -438,7 +438,7 @@ export default function RouteMapView({
                 if (!tripId || (userRole !== 'owner' && userRole !== 'editor')) {
                     throw new Error('일정을 삭제할 권한이 없습니다.')
                 }
-                const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: userRole })
+                const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: userRole })
                 await repositories.plans.deletePlan(tripId, planId)
                 setPlans(prev => prev.filter(p => p.id !== planId))
                 setDetailPlan(null)
@@ -741,10 +741,11 @@ async function getDocumentPrimaryUserRole(
     supabase: ReturnType<typeof createClient>,
     tripId: string,
 ): Promise<'owner' | 'editor' | 'viewer' | null> {
-    const { data: { user } } = await supabase.auth.getUser()
+    const { data: { session } } = await supabase.auth.getSession()
+    const user = session?.user
     if (!user) return null
 
-    const repositories = await createWebDocumentPrimaryRepositories(supabase)
+    const repositories = await createWebProductDocumentRepositories(supabase)
     const documentTrip = await repositories.trips.getTrip(tripId)
     if (documentTrip?.ownerId === user.id) return 'owner'
 

--- a/apps/web/components/trips/TemplateModal.tsx
+++ b/apps/web/components/trips/TemplateModal.tsx
@@ -6,7 +6,7 @@ import { X, Copy, Loader2 } from 'lucide-react'
 import { useScrollLock } from '@/hooks/useScrollLock'
 import { analytics } from '@/services/AnalyticsService'
 import { createClient } from '@/lib/supabase/client'
-import { createWebDocumentPrimaryRepositories } from '@/lib/local-first/documentPrimaryRepositories'
+import { createWebProductDocumentRepositories } from '@/lib/local-first/repositoryFactory'
 
 interface TemplateModalProps {
     isOpen: boolean
@@ -33,7 +33,7 @@ export default function TemplateModal({ isOpen, onClose, checklistId, tripId, cu
             setLoading(true)
 
             if (currentUser?.id) {
-                const repositories = await createWebDocumentPrimaryRepositories(supabase)
+                const repositories = await createWebProductDocumentRepositories(supabase)
                 const summaries = await repositories.templates.listTemplates(currentUser.id)
                 setTemplates(summaries.map((template) => ({
                     id: template.id,
@@ -56,7 +56,7 @@ export default function TemplateModal({ isOpen, onClose, checklistId, tripId, cu
         setLoadingTemplateId(templateId)
 
         try {
-            const repositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: currentUserRole })
+            const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: currentUserRole })
             const template = await repositories.templates.getTemplate(templateId)
             if (!template) throw new Error('Template document was not found.')
             const result = await repositories.checklists.applyTemplate(

--- a/apps/web/components/trips/TripHeaderActions.tsx
+++ b/apps/web/components/trips/TripHeaderActions.tsx
@@ -4,12 +4,11 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { css } from 'styled-system/css'
-import { Calendar, Users, Pencil, Trash2, Wallet, Loader2, CloudDownload, CloudCheck } from 'lucide-react'
+import { Calendar, Users, Pencil, Trash2, Wallet, Loader2 } from 'lucide-react'
 import { getCurrencyFromTimezone, formatKRW, formatDate } from '@nexvoy/core'
 import { ExchangeService } from '@/services/ExternalApiService'
-import { DownloadService } from '@/services/DownloadService'
 import EditTripModal from './EditTripModal'
-import { useToastStore } from '@/stores/useToastStore'
+import { createWebProductDocumentRepositories } from '@/lib/local-first/repositoryFactory'
 
 interface TripHeaderActionsProps {
     trip: {
@@ -28,14 +27,11 @@ interface TripHeaderActionsProps {
 export default function TripHeaderActions({ trip, onUpdate, isOffline = false }: TripHeaderActionsProps) {
     const router = useRouter()
     const supabase = createClient()
-    const toast = useToastStore()
 
     const [isOwner, setIsOwner] = useState(false)
     const [showEditModal, setShowEditModal] = useState(false)
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
     const [deleting, setDeleting] = useState(false)
-    const [isDownloading, setIsDownloading] = useState(false)
-    const [isDownloaded, setIsDownloaded] = useState(false)
 
     // 총 비용 요약 상태
     interface CostSummary {
@@ -49,37 +45,13 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
     const end = formatDate(trip.end_date)
 
     useEffect(() => {
-        const checkStatus = async () => {
-            const downloaded = await DownloadService.isDownloaded(trip.id)
-            setIsDownloaded(downloaded)
-        }
-        checkStatus()
-    }, [trip.id])
-
-    const handleDownload = async () => {
-        if (isDownloading) return
-        setIsDownloading(true)
-        const loadingId = toast.loading('여행 정보를 다운로드하는 중입니다...')
-        try {
-            await DownloadService.downloadTrip(trip.id)
-            setIsDownloaded(true)
-            toast.removeToast(loadingId)
-            toast.success('여행 정보가 성공적으로 다운로드되었습니다. 이제 오프라인에서도 확인할 수 있습니다!')
-        } catch (error) {
-            console.error('Download failed:', error)
-            toast.removeToast(loadingId)
-            toast.error('다운로드에 실패했습니다. 네트워크 상태를 확인해 주세요.')
-        } finally {
-            setIsDownloading(false)
-        }
-    }
-    useEffect(() => {
         const checkOwner = async () => {
             if (isOffline) {
                 setIsOwner(false)
                 return
             }
-            const { data: { user } } = await supabase.auth.getUser()
+            const { data: { session } } = await supabase.auth.getSession()
+            const user = session?.user
             if (user && user.id === trip.user_id) {
                 setIsOwner(true)
             }
@@ -94,11 +66,8 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
                 setCostSummary({ totalKrw: 0, byCurrency: [], loading: false })
                 return
             }
-            const { data: plans } = await supabase
-                .from('plans')
-                .select('cost, timezone_string')
-                .eq('trip_id', trip.id)
-                .gt('cost', 0)
+            const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: 'viewer' })
+            const plans = (await repositories.plans.listPlans(trip.id)).filter((plan) => plan.cost > 0)
 
             if (!plans || plans.length === 0) {
                 setCostSummary({ totalKrw: 0, byCurrency: [], loading: false })
@@ -108,12 +77,12 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
             const byCode: Record<string, { code: string; symbol: string; total: number }> = {}
             const uniqueNonKrw = new Set<string>()
 
-            plans.forEach((p: any) => {
-                const currency = getCurrencyFromTimezone(p.timezone_string || 'Asia/Seoul')
+            plans.forEach((plan) => {
+                const currency = getCurrencyFromTimezone(plan.timezone || 'Asia/Seoul')
                 if (!byCode[currency.code]) {
                     byCode[currency.code] = { code: currency.code, symbol: currency.symbol, total: 0 }
                 }
-                byCode[currency.code].total += p.cost
+                byCode[currency.code].total += plan.cost
                 if (currency.code !== 'KRW') uniqueNonKrw.add(currency.code)
             })
 
@@ -155,14 +124,11 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
 
     const handleDelete = async () => {
         setDeleting(true)
-        const { error } = await supabase
-            .from('trips')
-            .delete()
-            .eq('id', trip.id)
-
-        if (!error) {
+        try {
+            const repositories = await createWebProductDocumentRepositories(supabase, { actorRole: 'owner' })
+            await repositories.trips.deleteTrip(trip.id)
             router.push('/')
-        } else {
+        } catch {
             setDeleting(false)
         }
     }
@@ -186,29 +152,6 @@ export default function TripHeaderActions({ trip, onUpdate, isOffline = false }:
 
                     {!isOffline && (
                         <div className={css({ display: 'flex', gap: '8px', flexShrink: 0 })}>
-                            <button
-                                onClick={handleDownload}
-                                disabled={isDownloading}
-                                className={css({
-                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                    p: '8px', bg: isDownloaded ? 'rgba(46, 196, 182, 0.05)' : 'white', 
-                                    color: isDownloaded ? 'brand.primary' : 'brand.muted', 
-                                    border: '1.5px solid', borderColor: isDownloaded ? 'brand.primary' : 'brand.border', 
-                                    borderRadius: '50%', cursor: 'pointer', transition: 'all 0.2s',
-                                    _hover: { bg: 'bg.softCotton', color: 'brand.primary', borderColor: 'brand.primary' },
-                                    _active: { transform: 'scale(0.92)' }
-                                })}
-                                title={isDownloaded ? "다운로드됨" : "오프라인 다운로드"}
-                            >
-                                {isDownloading ? (
-                                    <Loader2 size={18} className={css({ animation: 'spin 1s linear infinite' })} />
-                                ) : isDownloaded ? (
-                                    <CloudCheck size={18} />
-                                ) : (
-                                    <CloudDownload size={18} />
-                                )}
-                            </button>
-
                             {isOwner && (
                                 <>
                                     <button

--- a/apps/web/components/trips/TripSwitcherModal.tsx
+++ b/apps/web/components/trips/TripSwitcherModal.tsx
@@ -11,6 +11,7 @@ import { useSearchParams } from 'next/navigation'
 import { formatDate } from '@nexvoy/core'
 import { useScrollLock } from '@/hooks/useScrollLock'
 import { useBottomSheetDrag } from '@/hooks/useBottomSheetDrag'
+import { createWebRepositories, refreshWebProductList } from '@/lib/local-first/repositoryFactory'
 
 interface Trip {
     id: string
@@ -100,34 +101,16 @@ export default function TripSwitcherModal() {
             
 
             // 2. 네트워크 페칭
-            const { data: { user } } = await supabase.auth.getUser()
+            const { data: { session } } = await supabase.auth.getSession()
+            const user = session?.user
             if (!user) {
                 setLoading(false)
                 return
             }
 
-            const { data: memberTripData } = await supabase
-                .from('trip_members')
-                .select('trip_id')
-                .eq('user_id', user.id)
-                .eq('status', 'accepted')
-
-            const memberTripIds = memberTripData?.map((m: { trip_id: string }) => m.trip_id) || []
-
-            let query = supabase
-                .from('trips')
-                .select('*')
-
-            if (memberTripIds.length > 0) {
-                query = query.or(`user_id.eq.${user.id},id.in.(${memberTripIds.join(',')})`)
-            } else {
-                query = query.eq('user_id', user.id)
-            }
-
-            const { data: trips } = await query.order('start_date', { ascending: true })
-            if (trips) {
-                processTrips(trips as Trip[])
-            }
+            await refreshWebProductList(supabase, 'trip')
+            const trips = await createWebRepositories(supabase).trips.listTrips(user.id)
+            processTrips([...trips].sort((left, right) => left.start_date.localeCompare(right.start_date)))
             setLoading(false)
         }
 

--- a/apps/web/e2e/helpers/seed.ts
+++ b/apps/web/e2e/helpers/seed.ts
@@ -1,5 +1,7 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'node:crypto';
 import { assertLocalSupabaseUrl } from './supabase';
+import type { TestUser } from './supabase';
 
 /**
  * E2E 시드/정리/검증 헬퍼.
@@ -92,6 +94,74 @@ export async function seedTrip(
   }
 
   return data as SeededTrip;
+}
+
+export async function seedAuthorityTrip(
+  owner: TestUser,
+  overrides: TripOverrides = {},
+): Promise<SeededTrip> {
+  const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const anonKey = getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  assertLocalSupabaseUrl(url);
+  const client = createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: `Bearer ${owner.accessToken}` } },
+  });
+  const tripId = randomUUID();
+  const checklistId = randomUUID();
+  const createdAt = new Date().toISOString();
+  const payload = {
+    user_id: owner.id,
+    destination: overrides.destination ?? 'TASK-050 서버 권위 여행',
+    start_date: overrides.start_date ?? dateOffset(1),
+    end_date: overrides.end_date ?? dateOffset(2),
+    adults_count: overrides.adults_count ?? 1,
+    children_count: overrides.children_count ?? 0,
+  };
+  const commands = [
+    {
+      operation_id: randomUUID(),
+      entity_type: 'trip',
+      entity_id: tripId,
+      action: 'upsert',
+      payload,
+      created_at: createdAt,
+    },
+    {
+      operation_id: randomUUID(),
+      entity_type: 'checklist',
+      entity_id: checklistId,
+      action: 'upsert',
+      payload: { title: '준비물' },
+      created_at: new Date(Date.parse(createdAt) + 1).toISOString(),
+    },
+  ];
+
+  const { error } = await client.rpc('apply_trip_commands', {
+    p_trip_id: tripId,
+    p_commands: commands,
+    p_base_revision: 0,
+  });
+  if (error) throw new Error(`seedAuthorityTrip 실패: ${error.message}`);
+
+  return { id: tripId, ...payload };
+}
+
+export async function seedAuthorityDocumentMember(
+  documentId: string,
+  user: TestUser,
+  role: 'editor' | 'viewer',
+): Promise<void> {
+  const client = getServiceClient();
+  const { error } = await client.from('document_members').upsert({
+    document_id: documentId,
+    user_id: user.id,
+    invited_email: user.email,
+    role,
+    status: 'accepted',
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'document_id,user_id' });
+  if (error) throw new Error(`seedAuthorityDocumentMember 실패: ${error.message}`);
 }
 
 export interface SeededTripMember {
@@ -294,6 +364,15 @@ export async function cleanupTripsByUser(userId: string): Promise<void> {
 
   if (error) {
     throw new Error(`cleanupTripsByUser 실패: ${error.message}`);
+  }
+
+  const { error: documentError } = await client
+    .from('documents')
+    .delete()
+    .eq('owner_id', userId)
+    .eq('type', 'trip');
+  if (documentError) {
+    throw new Error(`cleanupTripsByUser document 정리 실패: ${documentError.message}`);
   }
 }
 

--- a/apps/web/e2e/local-first-product.spec.ts
+++ b/apps/web/e2e/local-first-product.spec.ts
@@ -7,7 +7,7 @@ import {
   seedTripMember,
 } from './helpers/seed';
 
-test.describe('Local-first document-primary product integration', () => {
+test.describe('Document-primary rollback integration', () => {
   test('owner/editor can edit plans while viewer stays read-only', async ({
     createAuthenticatedContextFor,
     multiUsers,
@@ -35,9 +35,9 @@ test.describe('Local-first document-primary product integration', () => {
       const editorPage = await editorContext.newPage();
       const viewerPage = await viewerContext.newPage();
 
-      await ownerPage.goto(`/trips/detail?id=${trip.id}&tab=plans&documentPrimary=1`);
-      await editorPage.goto(`/trips/detail?id=${trip.id}&tab=plans&documentPrimary=1`);
-      await viewerPage.goto(`/trips/detail?id=${trip.id}&tab=plans&documentPrimary=1`);
+      await ownerPage.goto(`/trips/detail?id=${trip.id}&tab=plans&serverAuthority=0&documentPrimary=1`);
+      await editorPage.goto(`/trips/detail?id=${trip.id}&tab=plans&serverAuthority=0&documentPrimary=1`);
+      await viewerPage.goto(`/trips/detail?id=${trip.id}&tab=plans&serverAuthority=0&documentPrimary=1`);
 
       await expect(ownerPage.getByText('TASK35 권한 검증', { exact: false })).toBeVisible({
         timeout: 15000,
@@ -71,7 +71,7 @@ test.describe('Local-first document-primary product integration', () => {
       await getOrCreateChecklist(trip.id);
 
       const page = await authenticatedContext.newPage();
-      await page.goto(`/trips/detail?id=${trip.id}&tab=checklist&documentPrimary=1`);
+      await page.goto(`/trips/detail?id=${trip.id}&tab=checklist&serverAuthority=0&documentPrimary=1`);
 
       const addToggleButton = page.getByRole('button', { name: '항목 추가' });
       await expect(addToggleButton).toBeVisible({ timeout: 15000 });

--- a/apps/web/e2e/server-authority-product.spec.ts
+++ b/apps/web/e2e/server-authority-product.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from './fixtures/auth';
+import {
+  cleanupTripsByUser,
+  getChecklistItemByName,
+  getOrCreateChecklist,
+  seedAuthorityDocumentMember,
+  seedAuthorityTrip,
+} from './helpers/seed';
+
+const LEGACY_PRODUCT_ENDPOINTS = [
+  'get_my_active_document_key',
+  'document_updates',
+  'document_snapshots',
+  'signaling:',
+];
+
+test.describe('TASK-050 Web server-authority product integration', () => {
+  test('offline outbox reconnects and an editor receives the canonical change', async ({
+    createAuthenticatedContextFor,
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id);
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-050 동기화 검증',
+    });
+    await seedAuthorityDocumentMember(trip.id, multiUsers.editor, 'editor');
+    const checklist = await getOrCreateChecklist(trip.id);
+
+    try {
+      const ownerContext = await createAuthenticatedContextFor(multiUsers.owner);
+      const editorContext = await createAuthenticatedContextFor(multiUsers.editor);
+      const ownerPage = await ownerContext.newPage();
+      const editorPage = await editorContext.newPage();
+      const legacyRequests: string[] = [];
+      for (const page of [ownerPage, editorPage]) {
+        page.on('request', (request) => {
+          if (LEGACY_PRODUCT_ENDPOINTS.some((part) => request.url().includes(part))) {
+            legacyRequests.push(request.url());
+          }
+        });
+      }
+
+      const detailUrl = `/trips/detail?id=${trip.id}&tab=checklist&serverAuthority=1`;
+      await ownerPage.goto(detailUrl);
+      await editorPage.goto(detailUrl);
+      await expect(ownerPage.getByText('TASK-050 동기화 검증', { exact: false })).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(editorPage.getByText('TASK-050 동기화 검증', { exact: false })).toBeVisible({
+        timeout: 15000,
+      });
+
+      await ownerContext.setOffline(true);
+      await ownerPage.getByRole('button', { name: '항목 추가' }).click();
+      const itemName = `오프라인-outbox-${Date.now()}`;
+      await ownerPage.getByPlaceholder('어떤 준비물인가요?').fill(itemName);
+      await ownerPage.getByRole('button', { name: '추가', exact: true }).click();
+      await expect(ownerPage.getByText(itemName)).toBeVisible({ timeout: 10000 });
+      await expect(ownerPage.getByText('오프라인 저장')).toBeVisible();
+      expect(await getChecklistItemByName(checklist.id, itemName)).toBeNull();
+
+      await ownerContext.setOffline(false);
+      await expect.poll(
+        () => getChecklistItemByName(checklist.id, itemName),
+        { timeout: 15000 },
+      ).not.toBeNull();
+      await expect(ownerPage.getByText('동기화 완료')).toBeVisible({ timeout: 15000 });
+      await expect(editorPage.getByText(itemName)).toBeVisible({ timeout: 15000 });
+      expect(legacyRequests).toEqual([]);
+    } finally {
+      await cleanupTripsByUser(multiUsers.owner.id);
+    }
+  });
+});

--- a/apps/web/lib/data/authorityChecklistRepository.ts
+++ b/apps/web/lib/data/authorityChecklistRepository.ts
@@ -1,0 +1,10 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { ChecklistRepository } from '@nexvoy/core/repositories/types'
+import { createWebChecklistRepository } from '@/lib/local-first/documentPrimaryChecklistRepository'
+import { createWebAuthorityDocumentRepositories } from './authorityProductRepositories'
+
+export function createWebAuthorityChecklistRepository(
+  supabase: SupabaseClient,
+): ChecklistRepository {
+  return createWebChecklistRepository(supabase, createWebAuthorityDocumentRepositories)
+}

--- a/apps/web/lib/data/authorityProductRepositories.ts
+++ b/apps/web/lib/data/authorityProductRepositories.ts
@@ -1,0 +1,1225 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database, Json } from '@nexvoy/types'
+import {
+  ServerAuthoritySyncCoordinator,
+  applyOptimisticAuthorityCommandsToBundle,
+  createServerAuthorityRepository,
+  materializeChecklists,
+  materializePlanTimeline,
+  materializeTripDetail,
+  materializeTripSummary,
+  type AuthorityCommand,
+  type AuthorityProductSyncSnapshot,
+  type AuthorityResourceType,
+  type CanonicalResourceBundle,
+  type DocumentMutationChangedEntity,
+  type DocumentMutationOperation,
+  type DocumentMutationResult,
+} from '@nexvoy/core'
+import type {
+  CreateChecklistItemMutationInput,
+  CreateChecklistMutationInput,
+  CreatePlanMutationInput,
+  ReplaceTemplateItemsMutationInput,
+  ToggleChecklistItemMutationInput,
+  UpdateChecklistItemMutationInput,
+  UpdatePlanMutationInput,
+  UpsertMemberMutationInput,
+  UpsertPlanUrlMutationInput,
+  UpsertTemplateShareMutationInput,
+} from '@nexvoy/core/local-first/documentMutationWriter'
+import type { TripDocumentV1 } from '@nexvoy/core/local-first/documentModel'
+import type { TemplateDocumentV1 } from '@nexvoy/core/local-first/templateDocument'
+import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
+import {
+  createInvitationRepository,
+  type DocumentCollaborator,
+} from '@nexvoy/core/supabase/invitationRepository'
+import { WebAuthorityIndexedDbStore, type WebAuthorityStoreChange } from '@/lib/server-authority/indexedDbStore'
+import {
+  subscribeWebAuthorityInvalidation,
+  type WebAuthorityInvalidationSubscription,
+} from '@/lib/server-authority/realtimeInvalidation'
+
+type Tables = Database['public']['Tables']
+type TableRow<TName extends keyof Tables> = Tables[TName]['Row']
+type TripRow = TableRow<'trips'>
+type PlanRow = TableRow<'plans'>
+type PlanUrlRow = TableRow<'plan_urls'>
+type ChecklistRow = TableRow<'checklists'>
+type ChecklistItemRow = TableRow<'checklist_items'>
+type ChecklistItemAssigneeRow = TableRow<'checklist_item_assignees'>
+type ChecklistItemUserCheckRow = TableRow<'checklist_item_user_checks'>
+type TemplateRow = TableRow<'checklist_templates'>
+type TemplateItemRow = TableRow<'checklist_template_items'>
+type TemplateShareRow = TableRow<'checklist_template_shares'>
+
+type ActorRole = 'owner' | 'editor' | 'viewer' | null
+const AUTHORITY_FLUSH_DEBOUNCE_MS = 1_000
+
+interface AuthorityRuntimeSubscription {
+  count: number
+  subscription: Promise<WebAuthorityInvalidationSubscription>
+}
+
+class WebAuthorityProductRuntime {
+  readonly store = new WebAuthorityIndexedDbStore()
+  readonly remote
+  readonly coordinator
+  private readonly watchedResources = new Map<string, AuthorityRuntimeSubscription>()
+  private readonly flushTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  constructor(private readonly supabase: SupabaseClient) {
+    this.remote = createServerAuthorityRepository(supabase)
+    this.coordinator = new ServerAuthoritySyncCoordinator({
+      repository: this.remote,
+      store: this.store,
+    })
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', () => { void this.flushCurrentAccount() })
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') void this.flushCurrentAccount()
+      })
+    }
+  }
+
+  async accountId(): Promise<string> {
+    const { data: sessionData } = await this.supabase.auth.getSession()
+    if (sessionData.session?.user) return sessionData.session.user.id
+    if (isBrowserOnline()) {
+      const { data, error } = await this.supabase.auth.getUser()
+      if (error) throw error
+      if (data.user) return data.user.id
+    }
+    throw new Error('인증 정보가 없습니다.')
+  }
+
+  async listLocal(resourceType: AuthorityResourceType): Promise<CanonicalResourceBundle[]> {
+    const accountId = await this.accountId()
+    this.kickFlush(accountId)
+    return this.store.listResources(accountId, resourceType)
+  }
+
+  async refreshList(resourceType: AuthorityResourceType): Promise<CanonicalResourceBundle[]> {
+    const accountId = await this.accountId()
+    if (!isBrowserOnline()) return this.store.listResources(accountId, resourceType)
+
+    await this.flushAccount(accountId)
+
+    const summaries = await this.remote.listMySummaries(resourceType)
+    const remoteIds = new Set(summaries.map((summary) => summary.resourceId))
+    for (const summary of summaries) {
+      const bundle = await this.coordinator.refreshResource(
+        accountId,
+        resourceType,
+        summary.resourceId,
+        summary.revision,
+      )
+      if (bundle) {
+        await this.cacheRole(accountId, bundle, normalizeActorRole(summary.role))
+      }
+    }
+
+    const local = await this.store.listResources(accountId, resourceType)
+    for (const bundle of local) {
+      if (remoteIds.has(bundle.resourceId)) continue
+      const sync = await this.store.getSyncSnapshot(accountId, resourceType, bundle.resourceId, true)
+      if (sync.status === 'synced') {
+        await this.store.deleteResource(accountId, resourceType, bundle.resourceId)
+      }
+    }
+    return this.store.listResources(accountId, resourceType)
+  }
+
+  async getBundle(
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<CanonicalResourceBundle | null> {
+    const accountId = await this.accountId()
+    const local = await this.store.getResource(accountId, resourceType, resourceId)
+    if (!isBrowserOnline()) return local
+    this.kickFlush(accountId)
+    if (!local) {
+      return this.coordinator.refreshResource(
+        accountId,
+        resourceType,
+        resourceId,
+        Number.MAX_SAFE_INTEGER,
+      )
+    }
+    void this.refreshResource(resourceType, resourceId).catch(() => undefined)
+    return local
+  }
+
+  async refreshResource(
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<CanonicalResourceBundle | null> {
+    const accountId = await this.accountId()
+    if (!isBrowserOnline()) return this.store.getResource(accountId, resourceType, resourceId)
+    const revision = await this.remote.getRevision(resourceType, resourceId)
+    return this.coordinator.refreshResource(accountId, resourceType, resourceId, revision)
+  }
+
+  async commit(
+    bundle: CanonicalResourceBundle,
+    commands: AuthorityCommand[],
+  ): Promise<CanonicalResourceBundle> {
+    const accountId = await this.accountId()
+    const now = new Date().toISOString()
+    const optimistic = applyOptimisticAuthorityCommandsToBundle(bundle, commands, now)
+    await this.store.commitOptimisticMutations({
+      accountId,
+      baseBundle: bundle,
+      bundle: optimistic,
+      commands,
+      now,
+    })
+    this.kickFlush(accountId)
+    return optimistic
+  }
+
+  async syncSnapshot(
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<AuthorityProductSyncSnapshot> {
+    return this.store.getSyncSnapshot(
+      await this.accountId(),
+      resourceType,
+      resourceId,
+      isBrowserOnline(),
+    )
+  }
+
+  async cacheRole(
+    accountId: string,
+    bundle: CanonicalResourceBundle,
+    role: ActorRole,
+  ): Promise<CanonicalResourceBundle> {
+    if (!role || bundle.data._role === role) return bundle
+    const withRole = { ...bundle, data: { ...bundle.data, _role: role } }
+    return await this.store.setResourceRole(
+      accountId,
+      bundle.resourceType,
+      bundle.resourceId,
+      role,
+    ) ?? withRole
+  }
+
+  async watch(
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<() => Promise<void>> {
+    if (!isBrowserOnline()) return async () => undefined
+    const accountId = await this.accountId()
+    const key = `${accountId}:${resourceType}:${resourceId}`
+    const active = this.watchedResources.get(key)
+    if (active) {
+      active.count += 1
+      return () => this.releaseWatch(key)
+    }
+
+    await this.flushAccount(accountId)
+    await this.refreshResource(resourceType, resourceId).catch(() => undefined)
+    const subscription = subscribeWebAuthorityInvalidation({
+      supabase: this.supabase,
+      accountId,
+      resourceType,
+      resourceId,
+      store: this.store,
+      coordinator: this.coordinator,
+    })
+    this.watchedResources.set(key, { count: 1, subscription })
+    try {
+      await subscription
+    } catch {
+      this.watchedResources.delete(key)
+      return async () => undefined
+    }
+    return () => this.releaseWatch(key)
+  }
+
+  subscribe(listener: (change: WebAuthorityStoreChange) => void): () => void {
+    return this.store.subscribe(listener)
+  }
+
+  private async releaseWatch(key: string): Promise<void> {
+    const active = this.watchedResources.get(key)
+    if (!active) return
+    active.count -= 1
+    if (active.count > 0) return
+    this.watchedResources.delete(key)
+    await (await active.subscription).unsubscribe()
+  }
+
+  private async flushCurrentAccount(): Promise<void> {
+    if (!isBrowserOnline()) return
+    try {
+      await this.flushAccount(await this.accountId())
+    } catch {
+      // Outbox classification persists retry/rejection details for the sync status UI.
+    }
+  }
+
+  private kickFlush(accountId: string): void {
+    if (!isBrowserOnline()) return
+    if (this.flushTimers.has(accountId)) return
+    const timer = setTimeout(() => {
+      this.flushTimers.delete(accountId)
+      void this.flushAccount(accountId).catch(() => undefined)
+    }, AUTHORITY_FLUSH_DEBOUNCE_MS)
+    this.flushTimers.set(accountId, timer)
+  }
+
+  private async flushAccount(accountId: string): Promise<void> {
+    if (!isBrowserOnline()) return
+    const pendingTimer = this.flushTimers.get(accountId)
+    if (pendingTimer) clearTimeout(pendingTimer)
+    this.flushTimers.delete(accountId)
+    const { data } = await this.supabase.auth.getSession()
+    if (data.session?.user.id !== accountId) {
+      const timer = this.retryTimers.get(accountId)
+      if (timer) clearTimeout(timer)
+      this.retryTimers.delete(accountId)
+      return
+    }
+    await this.coordinator.flush(accountId)
+    this.scheduleRetry(accountId, await this.store.getNextRetryAt(accountId))
+  }
+
+  private scheduleRetry(accountId: string, retryAt: string | null): void {
+    const current = this.retryTimers.get(accountId)
+    if (current) clearTimeout(current)
+    this.retryTimers.delete(accountId)
+    if (!retryAt || !isBrowserOnline()) return
+
+    const delay = Math.max(0, Date.parse(retryAt) - Date.now())
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(accountId)
+      void this.flushAccount(accountId).catch(() => undefined)
+    }, delay)
+    this.retryTimers.set(accountId, timer)
+  }
+}
+
+const runtimeByClient = new WeakMap<SupabaseClient, WebAuthorityProductRuntime>()
+
+function getRuntime(supabase: SupabaseClient): WebAuthorityProductRuntime {
+  const existing = runtimeByClient.get(supabase)
+  if (existing) return existing
+  const runtime = new WebAuthorityProductRuntime(supabase)
+  runtimeByClient.set(supabase, runtime)
+  return runtime
+}
+
+export async function createWebAuthorityDocumentRepositories(
+  supabase: SupabaseClient,
+  options: { actorRole?: ActorRole } = {},
+): Promise<DocumentPrimaryRepositoryBundle> {
+  const runtime = getRuntime(supabase)
+  const actorRole = options.actorRole ?? 'viewer'
+
+  const repositories: DocumentPrimaryRepositoryBundle = {
+    trips: {
+      async listTrips() {
+        const local = await runtime.listLocal('trip')
+        return local.flatMap((bundle) => {
+          const document = tripDocumentFromBundle(bundle, [])
+          return document && !asObject(bundle.data.trip).deleted_at
+            ? [materializeTripSummary(document)]
+            : []
+        })
+      },
+      async getTrip(tripId) {
+        const [bundle, collaborators, accountId] = await Promise.all([
+          runtime.getBundle('trip', tripId),
+          listTripCollaborators(supabase, tripId),
+          runtime.accountId(),
+        ])
+        const cachedBundle = bundle
+          ? await runtime.cacheRole(
+              accountId,
+              bundle,
+              resolveTripActorRole(bundle, collaborators, accountId),
+            )
+          : null
+        const members = cachedBundle
+          ? withCachedActorMember(cachedBundle, collaborators, accountId)
+          : collaborators
+        const document = cachedBundle ? tripDocumentFromBundle(cachedBundle, members) : null
+        return document
+          ? materializeTripDetail(document, { currentUserId: accountId })
+          : null
+      },
+      async getTripDocument(tripId) {
+        const [bundle, collaborators, accountId] = await Promise.all([
+          runtime.getBundle('trip', tripId),
+          listTripCollaborators(supabase, tripId),
+          runtime.accountId(),
+        ])
+        const cachedBundle = bundle
+          ? await runtime.cacheRole(
+              accountId,
+              bundle,
+              resolveTripActorRole(bundle, collaborators, accountId),
+            )
+          : null
+        return cachedBundle
+          ? tripDocumentFromBundle(
+              cachedBundle,
+              withCachedActorMember(cachedBundle, collaborators, accountId),
+            )
+          : null
+      },
+      async updateTrip(tripId, patch) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('trip', tripId, tripId, 'upsert', tripPatchPayload(patch))
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('trip.update', optimistic, [{ entityType: 'trip', entityId: tripId }])
+      },
+      async deleteTrip(tripId) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('trip', tripId, tripId, 'delete', {})
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('trip.delete', optimistic, [{ entityType: 'trip', entityId: tripId }])
+      },
+    },
+    plans: {
+      async listPlans(tripId) {
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        return planReadModels(bundle)
+      },
+      async createPlan(tripId, input) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('trip', tripId, input.id, 'upsert', planCreatePayload(input))
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('plan.create', optimistic, [{ entityType: 'plan', entityId: input.id }])
+      },
+      async updatePlan(tripId, input) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('trip', tripId, input.planId, 'upsert', planPatchPayload(input))
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('plan.update', optimistic, [{ entityType: 'plan', entityId: input.planId }])
+      },
+      async deletePlan(tripId, planId) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('trip', tripId, planId, 'delete', {})
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('plan.delete', optimistic, [{ entityType: 'plan', entityId: planId }])
+      },
+      async upsertPlanUrl(tripId, input) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('plan_url', tripId, input.id, 'upsert', {
+          plan_id: input.planId,
+          url: input.url,
+        })
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('planUrl.upsert', optimistic, [{ entityType: 'planUrl', entityId: input.id }])
+      },
+      async deletePlanUrl(tripId, planUrlId) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('plan_url', tripId, planUrlId, 'delete', {})
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('planUrl.delete', optimistic, [{ entityType: 'planUrl', entityId: planUrlId }])
+      },
+    },
+    checklists: {
+      async getChecklist(tripId) {
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        return checklistReadModels(bundle)
+      },
+      async createChecklist(tripId, input) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('checklist', tripId, input.id, 'upsert', { title: input.title })
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('checklist.create', optimistic, [{ entityType: 'checklist', entityId: input.id }])
+      },
+      async createItem(tripId, input) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const commands = checklistItemCommands(tripId, input.id, input, input.assigneeIds)
+        const optimistic = await runtime.commit(bundle, commands)
+        return tripMutationResult('checklistItem.create', optimistic, changedEntities(commands))
+      },
+      async updateItem(tripId, input) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const commands = checklistItemCommands(tripId, input.itemId, input.patch, input.assigneeIds)
+        const optimistic = await runtime.commit(bundle, commands)
+        return tripMutationResult('checklistItem.update', optimistic, changedEntities(commands))
+      },
+      async deleteItem(tripId, itemId) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = commandFor('checklist_item', tripId, itemId, 'delete', {})
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('checklistItem.delete', optimistic, [{ entityType: 'checklistItem', entityId: itemId }])
+      },
+      async toggleItem(tripId, input) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const command = input.currentUserId
+          ? commandFor('checklist_item_user_check', tripId, input.itemId, 'set', {
+              user_id: input.currentUserId,
+              checked: input.nextChecked,
+            })
+          : commandFor('checklist_item', tripId, input.itemId, 'upsert', {
+              is_checked: input.nextChecked,
+            })
+        const optimistic = await runtime.commit(bundle, [command])
+        return tripMutationResult('checklistItem.toggle', optimistic, changedEntities([command]))
+      },
+      async applyTemplate(tripId, checklistId, templateId, itemIds) {
+        assertWritable(actorRole)
+        const [bundle, templateBundle] = await Promise.all([
+          requireBundle(runtime, 'trip', tripId),
+          requireBundle(runtime, 'template', templateId),
+        ])
+        const existingNames = new Set(rows<ChecklistItemRow>(bundle, 'checklist_items').map((item) => item.item_name.trim()))
+        const templateItems = rows<TemplateItemRow>(templateBundle, 'items')
+          .filter((item) => !existingNames.has(item.item_name.trim()))
+        const commands = templateItems.map((item, index) => commandFor(
+          'checklist_item',
+          tripId,
+          itemIds[index] ?? createId(),
+          'upsert',
+          {
+            checklist_id: checklistId,
+            item_name: item.item_name,
+            category: item.category,
+            is_private: item.is_private,
+            assignment_type: 'anyone',
+            assigned_user_id: null,
+            source_template_name: asObject(templateBundle.data.template).title ?? null,
+            sort_key: item.sort_key,
+          },
+        ))
+        if (commands.length === 0) {
+          return tripMutationResult('checklistItem.applyTemplate', bundle, [])
+        }
+        const optimistic = await runtime.commit(bundle, commands)
+        return tripMutationResult('checklistItem.applyTemplate', optimistic, changedEntities(commands))
+      },
+    },
+    templates: {
+      async listTemplates() {
+        const local = await runtime.listLocal('template')
+        return local.flatMap((bundle) => {
+          const document = templateDocumentFromBundle(bundle)
+          if (!document || asObject(bundle.data.template).deleted_at) return []
+          return [templateSummary(document)]
+        })
+      },
+      async getTemplate(templateId) {
+        const [bundle, accountId] = await Promise.all([
+          runtime.getBundle('template', templateId),
+          runtime.accountId(),
+        ])
+        const document = bundle ? templateDocumentFromBundle(bundle, accountId) : null
+        return document ? templateDetail(document) : null
+      },
+      async getTemplateDocument(templateId) {
+        const [bundle, accountId] = await Promise.all([
+          runtime.getBundle('template', templateId),
+          runtime.accountId(),
+        ])
+        return bundle ? templateDocumentFromBundle(bundle, accountId) : null
+      },
+      async updateTemplate(templateId, patch) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'template', templateId)
+        const command = commandFor('template', templateId, templateId, 'upsert', {
+          ...(patch.title === undefined ? {} : { title: patch.title }),
+        })
+        const optimistic = await runtime.commit(bundle, [command])
+        return templateMutationResult('template.update', optimistic, [{ entityType: 'template', entityId: templateId }])
+      },
+      async deleteTemplate(templateId) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'template', templateId)
+        const command = commandFor('template', templateId, templateId, 'delete', {})
+        const optimistic = await runtime.commit(bundle, [command])
+        return templateMutationResult('template.delete', optimistic, [{ entityType: 'template', entityId: templateId }])
+      },
+      async replaceItems(templateId, input) {
+        assertWritable(actorRole)
+        const bundle = await requireBundle(runtime, 'template', templateId)
+        const nextIds = new Set(input.items.map((item) => item.id))
+        const commands: AuthorityCommand[] = rows<TemplateItemRow>(bundle, 'items')
+          .filter((item) => !nextIds.has(item.id))
+          .map((item) => commandFor('template_item', templateId, item.id, 'delete', {}))
+        input.items.forEach((item, index) => {
+          commands.push(commandFor('template_item', templateId, item.id, 'upsert', {
+            item_name: item.name,
+            category: item.categoryName,
+            is_private: item.isPrivate,
+            sort_key: String(index).padStart(8, '0'),
+          }))
+        })
+        if (commands.length === 0) return templateMutationResult('templateItem.replaceAll', bundle, [])
+        const optimistic = await runtime.commit(bundle, commands)
+        return templateMutationResult('templateItem.replaceAll', optimistic, changedEntities(commands))
+      },
+      async upsertShare(templateId, input) {
+        assertOwner(actorRole)
+        const bundle = await requireBundle(runtime, 'template', templateId)
+        const command = commandFor('template_share', templateId, input.share.id, 'upsert', {
+          shared_with_user_id: input.share.sharedWithUserId,
+          role: input.share.role,
+        })
+        const optimistic = await runtime.commit(bundle, [command])
+        return templateMutationResult('templateShare.upsert', optimistic, [{ entityType: 'templateShare', entityId: input.share.id }])
+      },
+      async removeShare(templateId, shareId) {
+        assertOwner(actorRole)
+        const bundle = await requireBundle(runtime, 'template', templateId)
+        const command = commandFor('template_share', templateId, shareId, 'delete', {})
+        const optimistic = await runtime.commit(bundle, [command])
+        return templateMutationResult('templateShare.remove', optimistic, [{ entityType: 'templateShare', entityId: shareId }])
+      },
+    },
+    members: {
+      async listMembers(tripId) {
+        const bundle = await requireBundle(runtime, 'trip', tripId)
+        const [collaborators, accountId] = await Promise.all([
+          listTripCollaborators(supabase, tripId),
+          runtime.accountId(),
+        ])
+        return materializeTripDetail(tripDocumentFromBundle(
+          bundle,
+          withCachedActorMember(bundle, collaborators, accountId),
+        ), {
+          currentUserId: accountId,
+        }).members
+      },
+      async upsertMember(tripId, input: UpsertMemberMutationInput) {
+        throw new Error(`Membership mutation for ${tripId}:${input.member.id} is handled by invitation authority.`)
+      },
+      async revokeMember(tripId, memberId) {
+        throw new Error(`Membership mutation for ${tripId}:${memberId} is handled by invitation authority.`)
+      },
+    },
+  }
+
+  return repositories
+}
+
+export async function createWebAuthorityTrip(input: {
+  supabase: SupabaseClient
+  destination: string
+  startDate: string
+  endDate: string
+  adultsCount: number
+  childrenCount: number
+}): Promise<string> {
+  const runtime = getRuntime(input.supabase)
+  const accountId = await runtime.accountId()
+  const tripId = createId()
+  const checklistId = createId()
+  const now = new Date().toISOString()
+  const bundle: CanonicalResourceBundle = {
+    resourceType: 'trip',
+    resourceId: tripId,
+    revision: 0,
+    serverUpdatedAt: now,
+    data: {
+      trip: null,
+      plans: [],
+      plan_urls: [],
+      checklists: [],
+      checklist_items: [],
+      checklist_item_assignees: [],
+      checklist_item_user_checks: [],
+      _role: 'owner',
+    },
+  }
+  await runtime.commit(bundle, [
+    commandFor('trip', tripId, tripId, 'upsert', {
+      user_id: accountId,
+      destination: input.destination,
+      start_date: input.startDate,
+      end_date: input.endDate,
+      adults_count: input.adultsCount,
+      children_count: input.childrenCount,
+    }, now),
+    commandFor('checklist', tripId, checklistId, 'upsert', { title: '준비물' }, addMilliseconds(now, 1)),
+  ])
+  return tripId
+}
+
+export async function createWebAuthorityTemplate(input: {
+  supabase: SupabaseClient
+  title: string
+  items: Array<{ item_name: string; category: string; is_private?: boolean }>
+}): Promise<string> {
+  const runtime = getRuntime(input.supabase)
+  const accountId = await runtime.accountId()
+  const templateId = createId()
+  const now = new Date().toISOString()
+  const bundle: CanonicalResourceBundle = {
+    resourceType: 'template',
+    resourceId: templateId,
+    revision: 0,
+    serverUpdatedAt: now,
+    data: { template: null, items: [], shares: [], _role: 'owner' },
+  }
+  const commands: AuthorityCommand[] = [commandFor('template', templateId, templateId, 'upsert', {
+    user_id: accountId,
+    title: input.title,
+  }, now)]
+  input.items.forEach((item, index) => commands.push(commandFor(
+    'template_item',
+    templateId,
+    createId(),
+    'upsert',
+    {
+      template_id: templateId,
+      item_name: item.item_name,
+      category: item.category,
+      is_private: item.is_private ?? false,
+      sort_key: String(index).padStart(8, '0'),
+    },
+    addMilliseconds(now, index + 1),
+  )))
+  await runtime.commit(bundle, commands)
+  return templateId
+}
+
+export async function subscribeWebAuthorityResource(
+  supabase: SupabaseClient,
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+  listener: () => void,
+): Promise<() => Promise<void>> {
+  const runtime = getRuntime(supabase)
+  const accountId = await runtime.accountId()
+  const unsubscribeStore = runtime.subscribe((change) => {
+    if (
+      change.accountId === accountId &&
+      (!change.resourceType || change.resourceType === resourceType) &&
+      (!change.resourceId || change.resourceId === resourceId)
+    ) listener()
+  })
+  const unwatch = await runtime.watch(resourceType, resourceId)
+  return async () => {
+    unsubscribeStore()
+    await unwatch()
+  }
+}
+
+export async function subscribeWebAuthorityAccount(
+  supabase: SupabaseClient,
+  resourceType: AuthorityResourceType,
+  listener: () => void,
+): Promise<() => void> {
+  const runtime = getRuntime(supabase)
+  const accountId = await runtime.accountId()
+  return runtime.subscribe((change) => {
+    if (change.accountId === accountId && (!change.resourceType || change.resourceType === resourceType)) {
+      listener()
+    }
+  })
+}
+
+export function getWebAuthoritySyncSnapshot(
+  supabase: SupabaseClient,
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+): Promise<AuthorityProductSyncSnapshot> {
+  return getRuntime(supabase).syncSnapshot(resourceType, resourceId)
+}
+
+export function refreshWebAuthorityList(
+  supabase: SupabaseClient,
+  resourceType: AuthorityResourceType,
+): Promise<CanonicalResourceBundle[]> {
+  return getRuntime(supabase).refreshList(resourceType)
+}
+
+function commandFor(
+  entityType: AuthorityCommand['entityType'],
+  resourceId: string,
+  entityId: string,
+  action: AuthorityCommand['action'],
+  payload: Record<string, Json | undefined>,
+  createdAt = new Date().toISOString(),
+): AuthorityCommand {
+  return {
+    operationId: createId(),
+    resourceId,
+    entityType,
+    entityId,
+    action,
+    payload,
+    createdAt,
+  } as AuthorityCommand
+}
+
+async function requireBundle(
+  runtime: WebAuthorityProductRuntime,
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+): Promise<CanonicalResourceBundle> {
+  const bundle = await runtime.getBundle(resourceType, resourceId)
+  if (!bundle) throw new Error(`${resourceType === 'trip' ? 'Trip' : 'Template'} was not found.`)
+  return bundle
+}
+
+function tripMutationResult(
+  operation: DocumentMutationOperation,
+  bundle: CanonicalResourceBundle,
+  entities: DocumentMutationChangedEntity[],
+): DocumentMutationResult<TripDocumentV1> {
+  return {
+    documentType: 'trip',
+    documentId: bundle.resourceId,
+    operation,
+    document: tripDocumentFromBundle(bundle, []),
+    update: new Uint8Array(),
+    changedEntities: entities,
+  }
+}
+
+function templateMutationResult(
+  operation: DocumentMutationOperation,
+  bundle: CanonicalResourceBundle,
+  entities: DocumentMutationChangedEntity[],
+): DocumentMutationResult<TemplateDocumentV1> {
+  return {
+    documentType: 'template',
+    documentId: bundle.resourceId,
+    operation,
+    document: templateDocumentFromBundle(bundle),
+    update: new Uint8Array(),
+    changedEntities: entities,
+  }
+}
+
+function changedEntities(commands: AuthorityCommand[]): DocumentMutationChangedEntity[] {
+  return commands.map((command) => ({
+    entityType: authorityEntityToDocumentEntity(command.entityType),
+    entityId: command.entityId,
+  }))
+}
+
+function authorityEntityToDocumentEntity(entityType: AuthorityCommand['entityType']): string {
+  return ({
+    trip: 'trip',
+    plan: 'plan',
+    plan_url: 'planUrl',
+    checklist: 'checklist',
+    checklist_item: 'checklistItem',
+    checklist_item_assignees: 'checklistItemAssignee',
+    checklist_item_user_check: 'checklistItemUserCheck',
+    template: 'template',
+    template_item: 'templateItem',
+    template_share: 'templateShare',
+  } as const)[entityType]
+}
+
+function tripDocumentFromBundle(
+  bundle: CanonicalResourceBundle,
+  collaborators: DocumentCollaborator[],
+): TripDocumentV1 {
+  const trip = asRow<TripRow>(bundle.data.trip, 'trip')
+  const planRows = rows<PlanRow>(bundle, 'plans')
+  const urlRows = rows<PlanUrlRow>(bundle, 'plan_urls')
+  const checklistRows = rows<ChecklistRow>(bundle, 'checklists')
+  const itemRows = rows<ChecklistItemRow>(bundle, 'checklist_items')
+  const assigneeRows = rows<ChecklistItemAssigneeRow>(bundle, 'checklist_item_assignees')
+  const checkRows = rows<ChecklistItemUserCheckRow>(bundle, 'checklist_item_user_checks')
+  return {
+    schemaVersion: 1,
+    trip: {
+      id: trip.id,
+      ownerId: trip.user_id,
+      destination: trip.destination,
+      startDate: trip.start_date,
+      endDate: trip.end_date,
+      adultsCount: trip.adults_count ?? 1,
+      childrenCount: trip.children_count ?? 0,
+      coverImageRef: trip.cover_image_ref,
+      bgColor: trip.bg_color,
+      createdAt: trip.created_at,
+      updatedAt: trip.updated_at,
+    },
+    plans: Object.fromEntries(planRows.map((plan) => [plan.id, {
+      id: plan.id,
+      title: plan.title,
+      location: plan.location,
+      address: plan.address,
+      coordinates: plan.location_lat === null || plan.location_lng === null
+        ? null
+        : { lat: plan.location_lat, lng: plan.location_lng },
+      googlePlaceId: plan.google_place_id,
+      imageUrl: plan.image_url,
+      photoReference: plan.photo_reference,
+      startDateTimeLocal: plan.start_datetime_local,
+      endDateTimeLocal: plan.end_datetime_local,
+      timezone: plan.timezone_string,
+      alarmMinutesBefore: plan.alarm_minutes_before,
+      alarmSentAt: plan.alarm_sent_at,
+      cost: plan.cost ?? 0,
+      memo: plan.memo,
+      isCompleted: false,
+      isVisited: plan.is_visited,
+      createdAt: plan.created_at,
+      updatedAt: plan.updated_at,
+    }])),
+    planOrder: planRows.map((plan) => plan.id),
+    planUrls: Object.fromEntries(urlRows.map((url) => [url.id, {
+      id: url.id,
+      planId: url.plan_id,
+      url: url.url,
+      createdAt: url.created_at,
+    }])),
+    checklists: Object.fromEntries(checklistRows.map((checklist) => [checklist.id, {
+      id: checklist.id,
+      title: checklist.title,
+      createdAt: checklist.created_at,
+    }])),
+    checklistItems: Object.fromEntries(itemRows.map((item) => [item.id, {
+      id: item.id,
+      checklistId: item.checklist_id,
+      name: item.item_name,
+      categoryName: item.category,
+      legacyIsChecked: item.is_checked,
+      isPrivate: item.is_private,
+      assignmentType: normalizeAssignmentType(item.assignment_type),
+      assignedUserId: item.assigned_user_id,
+      sourceTemplateName: item.source_template_name,
+      createdAt: item.created_at,
+      updatedAt: item.updated_at,
+    }])),
+    checklistCategories: {},
+    checklistItemAssignees: Object.fromEntries(assigneeRows.map((row) => [row.id, {
+      id: row.id,
+      itemId: row.item_id,
+      userId: row.user_id,
+      createdAt: row.created_at,
+    }])),
+    checklistItemUserChecks: Object.fromEntries(checkRows.map((row) => [row.id, {
+      id: row.id,
+      itemId: row.item_id,
+      userId: row.user_id,
+      createdAt: row.created_at,
+    }])),
+    members: Object.fromEntries(collaborators.map((member) => [member.memberId, {
+      id: member.memberId,
+      userId: member.userId,
+      invitedEmail: member.invitedEmail,
+      role: member.role,
+      status: member.status,
+      nickname: member.nickname,
+      email: member.email,
+      createdAt: member.createdAt,
+      updatedAt: member.updatedAt,
+    }])),
+    shares: {},
+    invitationLinks: {},
+    assets: {},
+    tombstones: {},
+    meta: {},
+  }
+}
+
+function templateDocumentFromBundle(
+  bundle: CanonicalResourceBundle,
+  currentUserId?: string,
+): TemplateDocumentV1 {
+  const template = asRow<TemplateRow>(bundle.data.template, 'template')
+  const itemRows = rows<TemplateItemRow>(bundle, 'items')
+  const shareRows = rows<TemplateShareRow>(bundle, 'shares')
+  const role = typeof bundle.data._role === 'string' ? bundle.data._role : null
+  const shares = Object.fromEntries(shareRows.map((share) => [share.id, {
+    id: share.id,
+    templateId: share.template_id,
+    sharedWithUserId: share.shared_with_user_id,
+    role: share.role === 'editor' ? 'editor' as const : 'viewer' as const,
+    createdBy: share.created_by,
+    createdAt: share.created_at,
+    updatedAt: share.updated_at,
+  }]))
+  if (
+    currentUserId &&
+    template.user_id !== currentUserId &&
+    (role === 'editor' || role === 'viewer') &&
+    !Object.values(shares).some((share) => share.sharedWithUserId === currentUserId)
+  ) {
+    shares[`cached:${currentUserId}`] = {
+      id: `cached:${currentUserId}`,
+      templateId: template.id,
+      sharedWithUserId: currentUserId,
+      role,
+      createdBy: template.user_id,
+      createdAt: template.created_at,
+      updatedAt: template.updated_at,
+    }
+  }
+  return {
+    schemaVersion: 1,
+    template: {
+      id: template.id,
+      ownerId: template.user_id,
+      title: template.title,
+      visibility: template.user_id === null ? 'public' : role === 'owner' ? 'private' : 'shared',
+      createdAt: template.created_at,
+      updatedAt: template.updated_at,
+    },
+    items: Object.fromEntries(itemRows.map((item, index) => [item.id, {
+      id: item.id,
+      templateId: item.template_id,
+      name: item.item_name,
+      categoryName: item.category,
+      isPrivate: item.is_private,
+      sortOrder: parseSortOrder(item.sort_key, index),
+      createdAt: item.created_at,
+      updatedAt: item.updated_at,
+    }])),
+    shares,
+    tombstones: {},
+    meta: {},
+  }
+}
+
+function planReadModels(bundle: CanonicalResourceBundle) {
+  return materializePlanTimeline(tripDocumentFromBundle(bundle, []))
+}
+
+function checklistReadModels(bundle: CanonicalResourceBundle) {
+  return materializeChecklists(tripDocumentFromBundle(bundle, []))
+}
+
+function templateSummary(document: TemplateDocumentV1) {
+  const items = Object.values(document.items).sort((left, right) => left.sortOrder - right.sortOrder)
+  return {
+    id: document.template.id,
+    ownerId: document.template.ownerId,
+    title: document.template.title,
+    visibility: document.template.visibility,
+    itemCount: items.length,
+    previewItems: items.slice(0, 3).map((item) => item.name),
+    updatedAt: document.template.updatedAt,
+  }
+}
+
+function templateDetail(document: TemplateDocumentV1) {
+  return {
+    ...templateSummary(document),
+    items: Object.values(document.items).sort((left, right) => left.sortOrder - right.sortOrder),
+    shares: Object.values(document.shares),
+  }
+}
+
+function planCreatePayload(input: CreatePlanMutationInput): Record<string, Json | undefined> {
+  return {
+    title: input.title,
+    location: input.location,
+    address: input.address,
+    location_lat: input.coordinates?.lat ?? null,
+    location_lng: input.coordinates?.lng ?? null,
+    google_place_id: input.googlePlaceId,
+    image_url: input.imageUrl,
+    photo_reference: input.photoReference,
+    start_datetime_local: input.startDateTimeLocal,
+    end_datetime_local: input.endDateTimeLocal,
+    timezone_string: input.timezone,
+    alarm_minutes_before: input.alarmMinutesBefore,
+    alarm_sent_at: input.alarmSentAt,
+    cost: input.cost,
+    memo: input.memo,
+    is_visited: input.isVisited,
+  }
+}
+
+function planPatchPayload(input: UpdatePlanMutationInput): Record<string, Json | undefined> {
+  const patch = input.patch
+  const payload: Record<string, Json | undefined> = {}
+  assign(payload, 'title', patch.title)
+  assign(payload, 'location', patch.location)
+  assign(payload, 'address', patch.address)
+  if (patch.coordinates !== undefined) {
+    payload.location_lat = patch.coordinates?.lat ?? null
+    payload.location_lng = patch.coordinates?.lng ?? null
+  }
+  assign(payload, 'google_place_id', patch.googlePlaceId)
+  assign(payload, 'image_url', patch.imageUrl)
+  assign(payload, 'photo_reference', patch.photoReference)
+  assign(payload, 'start_datetime_local', patch.startDateTimeLocal)
+  assign(payload, 'end_datetime_local', patch.endDateTimeLocal)
+  assign(payload, 'timezone_string', patch.timezone)
+  assign(payload, 'alarm_minutes_before', patch.alarmMinutesBefore)
+  assign(payload, 'alarm_sent_at', patch.alarmSentAt)
+  assign(payload, 'cost', patch.cost)
+  assign(payload, 'memo', patch.memo)
+  assign(payload, 'is_visited', patch.isVisited)
+  return payload
+}
+
+function tripPatchPayload(patch: Partial<TripDocumentV1['trip']>): Record<string, Json | undefined> {
+  const payload: Record<string, Json | undefined> = {}
+  assign(payload, 'destination', patch.destination)
+  assign(payload, 'start_date', patch.startDate)
+  assign(payload, 'end_date', patch.endDate)
+  assign(payload, 'adults_count', patch.adultsCount)
+  assign(payload, 'children_count', patch.childrenCount)
+  assign(payload, 'cover_image_ref', patch.coverImageRef)
+  assign(payload, 'bg_color', patch.bgColor)
+  return payload
+}
+
+function checklistItemCommands(
+  tripId: string,
+  itemId: string,
+  input: Partial<CreateChecklistItemMutationInput> | UpdateChecklistItemMutationInput['patch'],
+  assigneeIds?: string[],
+): AuthorityCommand[] {
+  const now = new Date().toISOString()
+  const payload: Record<string, Json | undefined> = {}
+  assign(payload, 'checklist_id', 'checklistId' in input ? input.checklistId : undefined)
+  assign(payload, 'item_name', 'name' in input ? input.name : undefined)
+  assign(payload, 'category', 'categoryName' in input ? input.categoryName : undefined)
+  assign(payload, 'is_checked', 'legacyIsChecked' in input ? input.legacyIsChecked : undefined)
+  assign(payload, 'is_private', 'isPrivate' in input ? input.isPrivate : undefined)
+  assign(payload, 'assignment_type', 'assignmentType' in input ? input.assignmentType : undefined)
+  assign(payload, 'assigned_user_id', 'assignedUserId' in input ? input.assignedUserId : undefined)
+  assign(payload, 'source_template_name', 'sourceTemplateName' in input ? input.sourceTemplateName : undefined)
+  const commands: AuthorityCommand[] = [commandFor('checklist_item', tripId, itemId, 'upsert', payload, now)]
+  if (assigneeIds) {
+    commands.push(commandFor('checklist_item_assignees', tripId, itemId, 'set', {
+      user_ids: assigneeIds,
+    }, addMilliseconds(now, 1)))
+  }
+  return commands
+}
+
+async function listTripCollaborators(
+  supabase: SupabaseClient,
+  tripId: string,
+): Promise<DocumentCollaborator[]> {
+  if (!isBrowserOnline()) return []
+  try {
+    return await createInvitationRepository(supabase).listDocumentCollaborators(tripId)
+  } catch {
+    return []
+  }
+}
+
+function withCachedActorMember(
+  bundle: CanonicalResourceBundle,
+  collaborators: DocumentCollaborator[],
+  accountId: string,
+): DocumentCollaborator[] {
+  if (collaborators.some((member) => member.userId === accountId)) return collaborators
+  const trip = asRow<TripRow>(bundle.data.trip, 'trip')
+  const cachedRole = typeof bundle.data._role === 'string' ? bundle.data._role : null
+  const role = trip.user_id === accountId
+    ? 'owner'
+    : cachedRole === 'editor' || cachedRole === 'viewer'
+      ? cachedRole
+      : null
+  if (!role) return collaborators
+  return [...collaborators, {
+    memberId: `cached:${accountId}`,
+    userId: accountId,
+    invitedEmail: null,
+    nickname: null,
+    email: null,
+    role,
+    status: 'accepted',
+    createdAt: trip.created_at,
+    updatedAt: trip.updated_at,
+  }]
+}
+
+function resolveTripActorRole(
+  bundle: CanonicalResourceBundle,
+  collaborators: DocumentCollaborator[],
+  accountId: string,
+): ActorRole {
+  const trip = asRow<TripRow>(bundle.data.trip, 'trip')
+  if (trip.user_id === accountId) return 'owner'
+  const collaborator = collaborators.find((member) =>
+    member.userId === accountId && member.status === 'accepted',
+  )
+  if (collaborator?.role === 'editor' || collaborator?.role === 'viewer') {
+    return collaborator.role
+  }
+  const cachedRole = bundle.data._role
+  return cachedRole === 'owner' || cachedRole === 'editor' || cachedRole === 'viewer'
+    ? cachedRole
+    : null
+}
+
+function rows<TRow>(bundle: CanonicalResourceBundle, key: string): TRow[] {
+  const value = bundle.data[key]
+  return Array.isArray(value) ? value as TRow[] : []
+}
+
+function asRow<TRow>(value: Json | undefined, label: string): TRow {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Authority ${label} row is unavailable.`)
+  }
+  return value as TRow
+}
+
+function asObject(value: Json | undefined): Record<string, Json | undefined> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, Json | undefined>
+}
+
+function assign(
+  target: Record<string, Json | undefined>,
+  key: string,
+  value: Json | undefined,
+): void {
+  if (value !== undefined) target[key] = value
+}
+
+function normalizeAssignmentType(value: string): 'anyone' | 'specific' | 'everyone' {
+  return value === 'specific' || value === 'everyone' ? value : 'anyone'
+}
+
+function parseSortOrder(value: string | null, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function addMilliseconds(value: string, milliseconds: number): string {
+  return new Date(Date.parse(value) + milliseconds).toISOString()
+}
+
+function assertWritable(role: ActorRole): void {
+  if (role !== 'owner' && role !== 'editor') throw new Error('수정 권한이 없습니다.')
+}
+
+function normalizeActorRole(role: string): ActorRole {
+  return role === 'owner' || role === 'editor' || role === 'viewer' ? role : null
+}
+
+function assertOwner(role: ActorRole): void {
+  if (role !== 'owner') throw new Error('소유자 권한이 필요합니다.')
+}
+
+function isBrowserOnline(): boolean {
+  return typeof navigator === 'undefined' || navigator.onLine
+}
+
+function createId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (character) => {
+    const random = Math.floor(Math.random() * 16)
+    const value = character === 'x' ? random : (random & 0x3) | 0x8
+    return value.toString(16)
+  })
+}

--- a/apps/web/lib/data/authorityTripRepository.ts
+++ b/apps/web/lib/data/authorityTripRepository.ts
@@ -1,0 +1,124 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { TripRepository } from '@nexvoy/core/repositories/types'
+import type { Trip } from '@nexvoy/types'
+import {
+  createWebAuthorityDocumentRepositories,
+  createWebAuthorityTrip,
+} from './authorityProductRepositories'
+
+export function createWebAuthorityTripRepository(supabase: SupabaseClient): TripRepository {
+  return {
+    async listTrips(userId) {
+      const repositories = await createWebAuthorityDocumentRepositories(supabase)
+      const summaries = await repositories.trips.listTrips(userId)
+      return summaries.map((summary) => toTripRow(summary, summary.updatedAt))
+    },
+    async getTrip(tripId) {
+      const repositories = await createWebAuthorityDocumentRepositories(supabase)
+      const detail = await repositories.trips.getTrip(tripId)
+      return detail ? toTripRow(detail, detail.updatedAt) : null
+    },
+    async getTripDocument(tripId) {
+      return (await createWebAuthorityDocumentRepositories(supabase)).trips.getTripDocument(tripId)
+    },
+    async getTripWithPlans(tripId) {
+      const repositories = await createWebAuthorityDocumentRepositories(supabase)
+      const [trip, plans] = await Promise.all([
+        repositories.trips.getTrip(tripId),
+        repositories.plans.listPlans(tripId),
+      ])
+      if (!trip) throw new Error('Trip was not found.')
+      return {
+        trip: toTripRow(trip, trip.updatedAt),
+        plans: plans.map((plan) => ({
+          id: plan.id,
+          trip_id: tripId,
+          title: plan.title,
+          location: plan.location,
+          address: plan.address,
+          lat: plan.coordinates?.lat ?? null,
+          lng: plan.coordinates?.lng ?? null,
+          location_lat: plan.coordinates?.lat ?? null,
+          location_lng: plan.coordinates?.lng ?? null,
+          start_datetime_local: plan.startDateTimeLocal,
+          end_datetime_local: plan.endDateTimeLocal,
+          timezone_string: plan.timezone,
+          alarm_minutes_before: plan.alarmMinutesBefore,
+          alarm_sent_at: plan.alarmSentAt,
+          cost: plan.cost,
+          memo: plan.memo,
+          image_url: plan.imageUrl,
+          photo_reference: plan.photoReference,
+          google_place_id: plan.googlePlaceId,
+          is_completed: plan.isCompleted,
+          is_visited: plan.isVisited,
+          visit_date: null,
+          visit_time: null,
+          created_at: trip.updatedAt,
+          updated_at: trip.updatedAt,
+        })),
+      }
+    },
+    async createTrip(input) {
+      const id = await createWebAuthorityTrip({
+        supabase,
+        destination: input.destination,
+        startDate: input.start_date,
+        endDate: input.end_date,
+        adultsCount: input.adults_count,
+        childrenCount: input.children_count,
+      })
+      const trip = await this.getTrip(id)
+      if (!trip) throw new Error('Created trip was not found in the local authority cache.')
+      return trip
+    },
+    async updateTrip(tripId, input) {
+      const repositories = await createWebAuthorityDocumentRepositories(supabase, { actorRole: 'owner' })
+      const result = await repositories.trips.updateTrip(tripId, {
+        destination: input.destination,
+        startDate: input.start_date,
+        endDate: input.end_date,
+        adultsCount: input.adults_count,
+        childrenCount: input.children_count,
+      })
+      return toTripRow({
+        id: result.document.trip.id,
+        ownerId: result.document.trip.ownerId,
+        destination: result.document.trip.destination,
+        startDate: result.document.trip.startDate,
+        endDate: result.document.trip.endDate,
+        adultsCount: result.document.trip.adultsCount,
+        childrenCount: result.document.trip.childrenCount,
+      }, result.document.trip.updatedAt)
+    },
+    async deleteTrip(tripId) {
+      const repositories = await createWebAuthorityDocumentRepositories(supabase, { actorRole: 'owner' })
+      await repositories.trips.deleteTrip(tripId)
+    },
+  }
+}
+
+function toTripRow(
+  input: {
+    id: string
+    ownerId: string
+    destination: string
+    startDate: string
+    endDate: string
+    adultsCount: number
+    childrenCount: number
+  },
+  updatedAt: string,
+): Trip {
+  return {
+    id: input.id,
+    user_id: input.ownerId,
+    destination: input.destination,
+    start_date: input.startDate,
+    end_date: input.endDate,
+    adults_count: input.adultsCount,
+    children_count: input.childrenCount,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+  }
+}

--- a/apps/web/lib/local-first/documentPrimaryChecklistRepository.ts
+++ b/apps/web/lib/local-first/documentPrimaryChecklistRepository.ts
@@ -21,12 +21,21 @@ import type {
 import type { TripDocumentV1 } from '@nexvoy/core/local-first/documentModel'
 import { createWebDocumentPrimaryRepositories } from './documentPrimaryRepositories'
 
+export type WebDocumentRepositoryFactory = typeof createWebDocumentPrimaryRepositories
+
 export function createWebDocumentPrimaryChecklistRepository(
   supabase: SupabaseClient,
 ): ChecklistRepository {
+  return createWebChecklistRepository(supabase, createWebDocumentPrimaryRepositories)
+}
+
+export function createWebChecklistRepository(
+  supabase: SupabaseClient,
+  createRepositories: WebDocumentRepositoryFactory,
+): ChecklistRepository {
   return {
     getChecklist: async (tripId) => {
-      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const repositories = await createRepositories(supabase)
       const [trip, checklists] = await Promise.all([
         repositories.trips.getTrip(tripId),
         repositories.checklists.getChecklist(tripId),
@@ -35,11 +44,11 @@ export function createWebDocumentPrimaryChecklistRepository(
       return toChecklistSnapshot(trip, checklists)
     },
     createItem: async (checklistId, input) => {
-      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const repositories = await createRepositories(supabase)
       const tripId = await resolveTripIdForChecklist(repositories, checklistId)
       if (!tripId) throw new Error('Checklist document was not found.')
       const role = await resolveCurrentTripRole(supabase, repositories, tripId)
-      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      const writeRepositories = await createRepositories(supabase, { actorRole: role })
       const itemId = createEntityId('checklist-item')
       const result = await writeRepositories.checklists.createItem(tripId, {
         id: itemId,
@@ -56,11 +65,11 @@ export function createWebDocumentPrimaryChecklistRepository(
       return toMutationResult(result.document, itemId)
     },
     updateItem: async (itemId, input) => {
-      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const repositories = await createRepositories(supabase)
       const resolved = await resolveTripAndItem(repositories, itemId)
       if (!resolved) throw new Error('Checklist item document was not found.')
       const role = await resolveCurrentTripRole(supabase, repositories, resolved.tripId)
-      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      const writeRepositories = await createRepositories(supabase, { actorRole: role })
       const result = await writeRepositories.checklists.updateItem(resolved.tripId, {
         itemId,
         patch: {
@@ -76,30 +85,30 @@ export function createWebDocumentPrimaryChecklistRepository(
       return toMutationResult(result.document, itemId)
     },
     deleteItem: async (itemId) => {
-      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const repositories = await createRepositories(supabase)
       const resolved = await resolveTripAndItem(repositories, itemId)
       if (!resolved) throw new Error('Checklist item document was not found.')
       const role = await resolveCurrentTripRole(supabase, repositories, resolved.tripId)
-      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      const writeRepositories = await createRepositories(supabase, { actorRole: role })
       await writeRepositories.checklists.deleteItem(resolved.tripId, itemId)
     },
     toggleItem: async (itemId, isChecked) => {
-      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const repositories = await createRepositories(supabase)
       const resolved = await resolveTripAndItem(repositories, itemId)
       if (!resolved) throw new Error('Checklist item document was not found.')
       const role = await resolveCurrentTripRole(supabase, repositories, resolved.tripId)
-      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      const writeRepositories = await createRepositories(supabase, { actorRole: role })
       await writeRepositories.checklists.toggleItem(resolved.tripId, {
         itemId,
         nextChecked: isChecked,
       })
     },
     toggleItemForUser: async (input) => {
-      const repositories = await createWebDocumentPrimaryRepositories(supabase)
+      const repositories = await createRepositories(supabase)
       const resolved = await resolveTripAndItem(repositories, input.item.id)
       if (!resolved) throw new Error('Checklist item document was not found.')
       const role = await resolveCurrentTripRole(supabase, repositories, resolved.tripId)
-      const writeRepositories = await createWebDocumentPrimaryRepositories(supabase, { actorRole: role })
+      const writeRepositories = await createRepositories(supabase, { actorRole: role })
       const result = await writeRepositories.checklists.toggleItem(resolved.tripId, {
         itemId: input.item.id,
         nextChecked: input.nextChecked,
@@ -233,8 +242,8 @@ async function resolveCurrentTripRole(
   repositories: Awaited<ReturnType<typeof createWebDocumentPrimaryRepositories>>,
   tripId: string,
 ): Promise<'owner' | 'editor' | 'viewer' | null> {
-  const { data } = await supabase.auth.getUser()
-  const userId = data.user?.id
+  const { data } = await supabase.auth.getSession()
+  const userId = data.session?.user.id
   if (!userId) return null
   const document = await repositories.trips.getTripDocument(tripId)
   if (!document) return null

--- a/apps/web/lib/local-first/repositoryFactory.ts
+++ b/apps/web/lib/local-first/repositoryFactory.ts
@@ -7,8 +7,27 @@ import type { ChecklistRepository, TripRepository } from '@nexvoy/core/repositor
 import { createWebDualWriteChecklistRepository } from './dualWriteChecklistRepository'
 import { createWebLocalFirstChecklistRepository } from './localFirstChecklistRepository'
 import { createWebDocumentPrimaryChecklistRepository } from './documentPrimaryChecklistRepository'
+import {
+  createWebAuthorityDocumentRepositories,
+  createWebAuthorityTemplate,
+  createWebAuthorityTrip,
+  getWebAuthoritySyncSnapshot,
+  refreshWebAuthorityList,
+  subscribeWebAuthorityAccount,
+  subscribeWebAuthorityResource,
+} from '@/lib/data/authorityProductRepositories'
+import { createWebAuthorityChecklistRepository } from '@/lib/data/authorityChecklistRepository'
+import { createWebAuthorityTripRepository } from '@/lib/data/authorityTripRepository'
+import {
+  createWebDocumentPrimaryRepositories,
+  createWebTemplateDocument,
+  createWebTripDocument,
+} from './documentPrimaryRepositories'
+import type { AuthorityProductSyncSnapshot, AuthorityResourceType } from '@nexvoy/core'
+import type { DocumentPrimaryRepositoryBundle } from '@nexvoy/core/repositories/documentPrimaryRepository'
 
 export type WebRepositoryMode =
+  | 'server-authority'
   | 'legacy-supabase'
   | 'document-primary'
   | 'local-first-checklist-spike'
@@ -27,6 +46,12 @@ export function createWebRepositories(
   const legacyRepositories: LegacyRepositories = createSupabaseLegacyRepositories(supabase)
 
   switch (mode) {
+    case 'server-authority':
+      return {
+        mode,
+        trips: createWebAuthorityTripRepository(supabase),
+        checklists: createWebAuthorityChecklistRepository(supabase),
+      }
     case 'local-first-checklist-dual-write':
       return {
         ...legacyRepositories,
@@ -59,6 +84,26 @@ export function createWebRepositories(
 }
 
 export function resolveWebRepositoryMode(): WebRepositoryMode {
+  if (process.env.NEXT_PUBLIC_WEB_SERVER_AUTHORITY === '1') return 'server-authority'
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('serverAuthority') === '1') {
+      window.localStorage.removeItem('onvoy.webServerAuthorityDisabled')
+      return 'server-authority'
+    }
+    if (params.get('serverAuthority') === '0') {
+      window.localStorage.setItem('onvoy.webServerAuthorityDisabled', '1')
+    }
+    if (
+      process.env.NEXT_PUBLIC_WEB_SERVER_AUTHORITY !== '0' &&
+      window.localStorage.getItem('onvoy.webServerAuthorityDisabled') !== '1'
+    ) {
+      return 'server-authority'
+    }
+  } else if (process.env.NEXT_PUBLIC_WEB_SERVER_AUTHORITY !== '0') {
+    return 'server-authority'
+  }
+
   if (process.env.NEXT_PUBLIC_LOCAL_FIRST_CHECKLIST_DUAL_WRITE === '1') {
     return 'local-first-checklist-dual-write'
   }
@@ -106,4 +151,78 @@ export function resolveWebRepositoryMode(): WebRepositoryMode {
   return window.localStorage.getItem('onvoy.localFirstChecklistSpike') === '1'
     ? 'local-first-checklist-spike'
     : 'legacy-supabase'
+}
+
+export function isWebServerAuthorityEnabled(): boolean {
+  return resolveWebRepositoryMode() === 'server-authority'
+}
+
+export async function createWebProductDocumentRepositories(
+  supabase: SupabaseClient,
+  options: { actorRole?: 'owner' | 'editor' | 'viewer' | null } = {},
+): Promise<DocumentPrimaryRepositoryBundle> {
+  return isWebServerAuthorityEnabled()
+    ? createWebAuthorityDocumentRepositories(supabase, options)
+    : createWebDocumentPrimaryRepositories(supabase, options)
+}
+
+export function createWebProductTrip(input: {
+  supabase: SupabaseClient
+  destination: string
+  startDate: string
+  endDate: string
+  adultsCount: number
+  childrenCount: number
+}): Promise<string> {
+  return isWebServerAuthorityEnabled()
+    ? createWebAuthorityTrip(input)
+    : createWebTripDocument(input)
+}
+
+export function createWebProductTemplate(input: {
+  supabase: SupabaseClient
+  title: string
+  items: Array<{ item_name: string; category: string; is_private?: boolean }>
+}): Promise<string> {
+  return isWebServerAuthorityEnabled()
+    ? createWebAuthorityTemplate(input)
+    : createWebTemplateDocument(input)
+}
+
+export async function subscribeWebProductResource(
+  supabase: SupabaseClient,
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+  listener: () => void,
+): Promise<() => Promise<void>> {
+  if (!isWebServerAuthorityEnabled()) return async () => undefined
+  return subscribeWebAuthorityResource(supabase, resourceType, resourceId, listener)
+}
+
+export async function subscribeWebProductAccount(
+  supabase: SupabaseClient,
+  resourceType: AuthorityResourceType,
+  listener: () => void,
+): Promise<() => void> {
+  if (!isWebServerAuthorityEnabled()) return () => undefined
+  return subscribeWebAuthorityAccount(supabase, resourceType, listener)
+}
+
+export function refreshWebProductList(
+  supabase: SupabaseClient,
+  resourceType: AuthorityResourceType,
+): Promise<unknown> {
+  if (!isWebServerAuthorityEnabled()) return Promise.resolve([])
+  return refreshWebAuthorityList(supabase, resourceType)
+}
+
+export function getWebProductSyncSnapshot(
+  supabase: SupabaseClient,
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+): Promise<AuthorityProductSyncSnapshot> {
+  if (!isWebServerAuthorityEnabled()) {
+    return Promise.resolve({ status: 'synced', pendingCount: 0, lastError: null })
+  }
+  return getWebAuthoritySyncSnapshot(supabase, resourceType, resourceId)
 }

--- a/apps/web/lib/server-authority/__tests__/indexedDbStore.test.ts
+++ b/apps/web/lib/server-authority/__tests__/indexedDbStore.test.ts
@@ -32,14 +32,14 @@ function bundle(destination: string, revision = 0): CanonicalResourceBundle {
   }
 }
 
-function command(operationId: string): AuthorityCommand {
+function command(operationId: string, destination = '전주'): AuthorityCommand {
   return {
     operationId,
     resourceId: tripId,
     entityType: 'trip',
     entityId: tripId,
     action: 'upsert',
-    payload: { destination: '전주' },
+    payload: { destination },
     createdAt: now,
   }
 }
@@ -57,6 +57,38 @@ async function run(): Promise<void> {
   assert.equal((await store.getResource('account-a', 'trip', tripId))?.data.trip !== undefined, true)
   assert.equal(await store.getResource('account-b', 'trip', tripId), null)
   assert.equal((await store.listReadyOutbox('account-a', now, 10)).length, 1)
+
+  const batchOperations = [
+    command('48000000-0000-0000-0000-000000000021'),
+    command('48000000-0000-0000-0000-000000000022'),
+  ]
+  await store.commitOptimisticMutations({
+    accountId: 'account-batch',
+    bundle: bundle('batch trip'),
+    commands: batchOperations,
+    now,
+  })
+  assert.equal((await store.listReadyOutbox('account-batch', now, 10)).length, 2)
+  assert.equal((await store.listResources('account-batch', 'trip')).length, 1)
+  assert.deepEqual(await store.getSyncSnapshot('account-batch', 'trip', tripId, true), {
+    status: 'pending',
+    pendingCount: 2,
+    lastError: null,
+  })
+  await store.markRejected(
+    'account-batch',
+    [batchOperations[0].operationId],
+    'authority_trip_forbidden',
+    now,
+  )
+  assert.equal(
+    (await store.getSyncSnapshot('account-batch', 'trip', tripId, true)).status,
+    'error',
+  )
+  assert.equal(
+    (await store.getSyncSnapshot('account-batch', 'trip', tripId, false)).status,
+    'error',
+  )
 
   await store.commitOptimisticMutation({
     accountId: 'account-a',
@@ -88,12 +120,13 @@ async function run(): Promise<void> {
     (await store.listReadyOutbox('account-a', '2026-07-17T01:03:00.000Z', 10))[0]?.status,
     'retryable',
   )
+  assert.equal(await store.getNextRetryAt('account-a'), '2026-07-17T01:03:00.000Z')
 
   const secondOperation = '48000000-0000-0000-0000-000000000013'
   await store.commitOptimisticMutation({
     accountId: 'account-a',
     bundle: bundle('전주 후속 변경'),
-    command: command(secondOperation),
+    command: command(secondOperation, '전주 후속 변경'),
     now: '2026-07-17T01:03:30.000Z',
   })
 
@@ -125,11 +158,31 @@ async function run(): Promise<void> {
   assert.equal(rebased[0]?.operationId, secondOperation)
   assert.equal(rebased[0]?.baseRevision, 1)
   assert.equal((await store.getResource('account-a', 'trip', tripId))?.revision, 1)
+  assert.equal(
+    ((await store.getResource('account-a', 'trip', tripId))?.data.trip as { destination?: string })
+      .destination,
+    '전주 후속 변경',
+  )
+
+  await store.putResource('account-role', {
+    ...bundle('role cache', 1),
+    data: { ...bundle('role cache', 1).data, _role: 'editor' },
+  })
+  await store.putResource('account-role', bundle('remote without role', 2))
+  assert.equal(
+    (await store.getResource('account-role', 'trip', tripId))?.data._role,
+    'editor',
+  )
 
   await store.putResource('account-a', {
     ...bundle('newer canonical', 3),
     serverUpdatedAt: '2026-07-17T01:05:00.000Z',
   })
+  assert.equal(
+    ((await store.getResource('account-a', 'trip', tripId))?.data.trip as { destination?: string })
+      .destination,
+    '전주 후속 변경',
+  )
   await store.applyAcknowledgement(
     'account-a',
     {
@@ -141,6 +194,11 @@ async function run(): Promise<void> {
     '2026-07-17T01:05:30.000Z',
   )
   assert.equal((await store.getResource('account-a', 'trip', tripId))?.revision, 3)
+  assert.equal(
+    ((await store.getResource('account-a', 'trip', tripId))?.data.trip as { destination?: string })
+      .destination,
+    'newer canonical',
+  )
   assert.equal((await store.listReadyOutbox('account-a', now, 10)).length, 0)
 
   await assert.rejects(

--- a/apps/web/lib/server-authority/indexedDbStore.ts
+++ b/apps/web/lib/server-authority/indexedDbStore.ts
@@ -1,12 +1,15 @@
 import {
   applyCanonicalChangesToBundle,
+  applyOptimisticAuthorityCommandsToBundle,
   type AuthorityApplyResult,
   type AuthorityLocalStore,
   type AuthorityOutboxRecord,
   type AuthorityOutboxStatus,
+  type AuthorityProductSyncSnapshot,
   type AuthorityResourceType,
   type CanonicalResourceBundle,
   type CommitOptimisticAuthorityMutationInput,
+  type CommitOptimisticAuthorityMutationsInput,
 } from '@nexvoy/core'
 
 export const WEB_AUTHORITY_DB_NAME = 'onvoy-server-authority'
@@ -23,6 +26,7 @@ interface StoredAuthorityResource {
   resourceType: AuthorityResourceType
   resourceId: string
   bundle: CanonicalResourceBundle
+  canonicalBundle?: CanonicalResourceBundle
   updatedAt: string
 }
 
@@ -30,6 +34,16 @@ interface WebAuthorityIndexedDbOptions {
   indexedDB?: IDBFactory
   databaseName?: string
 }
+
+export interface WebAuthorityStoreChange {
+  accountId: string
+  resourceType?: AuthorityResourceType
+  resourceId?: string
+}
+
+type WebAuthorityStoreListener = (change: WebAuthorityStoreChange) => void
+
+const storeListeners = new Map<string, Set<WebAuthorityStoreListener>>()
 
 export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
   private readonly indexedDB: IDBFactory
@@ -59,20 +73,64 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
 
   async putResource(accountId: string, bundle: CanonicalResourceBundle): Promise<void> {
     const database = await this.open()
-    const transaction = database.transaction(RESOURCE_STORE, 'readwrite')
+    const transaction = database.transaction([RESOURCE_STORE, OUTBOX_STORE], 'readwrite')
     const store = transaction.objectStore(RESOURCE_STORE)
+    const outbox = transaction.objectStore(OUTBOX_STORE)
     const id = resourceKey(accountId, bundle.resourceType, bundle.resourceId)
     const existing = await requestValue<StoredAuthorityResource | undefined>(store.get(id))
-    if (!existing || shouldReplaceResource(existing.bundle, bundle)) {
-      store.put(toStoredResource(accountId, bundle))
+    const currentCanonical = existing?.canonicalBundle ?? existing?.bundle
+    const candidate = existing ? preserveLocalMetadata(existing.bundle, bundle) : bundle
+    if (!currentCanonical || shouldReplaceResource(currentCanonical, candidate)) {
+      const remaining = await requestValue<AuthorityOutboxRecord[]>(
+        outbox.index(ACCOUNT_RESOURCE_INDEX).getAll([
+          accountId,
+          bundle.resourceType,
+          bundle.resourceId,
+        ]),
+      )
+      const optimisticCommands = remaining
+        .filter((row) =>
+          row.status === 'pending' || row.status === 'sending' || row.status === 'retryable',
+        )
+        .sort(compareOutbox)
+        .map((row) => row.command)
+      const projected = optimisticCommands.length > 0
+        ? {
+            ...applyOptimisticAuthorityCommandsToBundle(
+              candidate,
+              optimisticCommands,
+              candidate.serverUpdatedAt,
+            ),
+            serverUpdatedAt: candidate.serverUpdatedAt,
+          }
+        : candidate
+      store.put(toStoredResource(accountId, projected, candidate.serverUpdatedAt, candidate))
     }
     await transactionComplete(transaction)
+    emitStoreChange(this.databaseName, {
+      accountId,
+      resourceType: bundle.resourceType,
+      resourceId: bundle.resourceId,
+    })
   }
 
   async commitOptimisticMutation(
     input: CommitOptimisticAuthorityMutationInput,
   ): Promise<void> {
-    validateMutation(input)
+    await this.commitOptimisticMutations({
+      accountId: input.accountId,
+      baseBundle: input.baseBundle,
+      bundle: input.bundle,
+      commands: [input.command],
+      now: input.now,
+    })
+  }
+
+  async commitOptimisticMutations(
+    input: CommitOptimisticAuthorityMutationsInput,
+  ): Promise<void> {
+    if (input.commands.length === 0) throw new Error('Authority mutation batch is empty.')
+    input.commands.forEach((command) => validateMutation({ ...input, command }))
     const database = await this.open()
     const transaction = database.transaction([RESOURCE_STORE, OUTBOX_STORE], 'readwrite')
     const resources = transaction.objectStore(RESOURCE_STORE)
@@ -85,43 +143,153 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
     const currentResource = await requestValue<StoredAuthorityResource | undefined>(
       resources.get(resourceId),
     )
-    const existing = await requestValue<AuthorityOutboxRecord | undefined>(
-      outbox.get(input.command.operationId),
-    )
-
-    if (existing) {
-      if (
-        existing.accountId !== input.accountId ||
-        JSON.stringify(existing.command) !== JSON.stringify(input.command)
-      ) {
-        transaction.abort()
-        throw new Error('Authority operation id is already used by another mutation.')
-      }
-      await transactionComplete(transaction)
-      return
-    }
-
     if (currentResource && input.bundle.revision < currentResource.bundle.revision) {
       transaction.abort()
       throw new Error('Optimistic mutation is based on a stale authority revision.')
     }
 
-    resources.put(toStoredResource(input.accountId, input.bundle, input.now))
-    outbox.put({
-      operationId: input.command.operationId,
+    const canonicalBundle = currentResource?.canonicalBundle
+      ?? currentResource?.bundle
+      ?? input.baseBundle
+      ?? input.bundle
+    resources.put(toStoredResource(input.accountId, input.bundle, input.now, canonicalBundle))
+    for (const command of input.commands) {
+      const existing = await requestValue<AuthorityOutboxRecord | undefined>(
+        outbox.get(command.operationId),
+      )
+      if (existing) {
+        if (
+          existing.accountId !== input.accountId ||
+          JSON.stringify(existing.command) !== JSON.stringify(command)
+        ) {
+          transaction.abort()
+          throw new Error('Authority operation id is already used by another mutation.')
+        }
+        continue
+      }
+      outbox.put({
+        operationId: command.operationId,
+        accountId: input.accountId,
+        resourceType: input.bundle.resourceType,
+        resourceId: input.bundle.resourceId,
+        baseRevision: input.bundle.revision,
+        command,
+        status: 'pending',
+        attempts: 0,
+        nextAttemptAt: null,
+        lastError: null,
+        createdAt: command.createdAt,
+        updatedAt: input.now,
+      } satisfies AuthorityOutboxRecord)
+    }
+    await transactionComplete(transaction)
+    emitStoreChange(this.databaseName, {
       accountId: input.accountId,
       resourceType: input.bundle.resourceType,
       resourceId: input.bundle.resourceId,
-      baseRevision: input.bundle.revision,
-      command: input.command,
-      status: 'pending',
-      attempts: 0,
-      nextAttemptAt: null,
-      lastError: null,
-      createdAt: input.command.createdAt,
-      updatedAt: input.now,
-    } satisfies AuthorityOutboxRecord)
+    })
+  }
+
+  async listResources(
+    accountId: string,
+    resourceType?: AuthorityResourceType,
+  ): Promise<CanonicalResourceBundle[]> {
+    const database = await this.open()
+    const transaction = database.transaction(RESOURCE_STORE, 'readonly')
+    const rows = await requestValue<StoredAuthorityResource[]>(
+      transaction.objectStore(RESOURCE_STORE).index(ACCOUNT_INDEX).getAll(accountId),
+    )
     await transactionComplete(transaction)
+    return rows
+      .filter((row) => !resourceType || row.resourceType === resourceType)
+      .map((row) => row.bundle)
+      .sort((left, right) => right.serverUpdatedAt.localeCompare(left.serverUpdatedAt))
+  }
+
+  async deleteResource(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<void> {
+    const database = await this.open()
+    const transaction = database.transaction(RESOURCE_STORE, 'readwrite')
+    transaction.objectStore(RESOURCE_STORE).delete(resourceKey(accountId, resourceType, resourceId))
+    await transactionComplete(transaction)
+    emitStoreChange(this.databaseName, { accountId, resourceType, resourceId })
+  }
+
+  async getSyncSnapshot(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+    online = typeof navigator === 'undefined' || navigator.onLine,
+  ): Promise<AuthorityProductSyncSnapshot> {
+    const rows = (await this.listAccountOutbox(accountId)).filter(
+      (row) => row.resourceType === resourceType && row.resourceId === resourceId,
+    )
+    const conflict = rows.find((row) => row.status === 'conflict')
+    const rejected = rows.find((row) => row.status === 'rejected')
+    const pending = rows.filter((row) =>
+      row.status === 'pending' || row.status === 'sending' || row.status === 'retryable',
+    )
+    if (conflict) {
+      return { status: 'conflict', pendingCount: rows.length, lastError: conflict.lastError }
+    }
+    if (rejected) {
+      return { status: 'error', pendingCount: rows.length, lastError: rejected.lastError }
+    }
+    if (!online) {
+      return { status: 'offline', pendingCount: pending.length, lastError: null }
+    }
+    return {
+      status: pending.length > 0 ? 'pending' : 'synced',
+      pendingCount: pending.length,
+      lastError: pending.find((row) => row.lastError)?.lastError ?? null,
+    }
+  }
+
+  subscribe(listener: WebAuthorityStoreListener): () => void {
+    const listeners = storeListeners.get(this.databaseName) ?? new Set<WebAuthorityStoreListener>()
+    listeners.add(listener)
+    storeListeners.set(this.databaseName, listeners)
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) storeListeners.delete(this.databaseName)
+    }
+  }
+
+  async setResourceRole(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+    role: string,
+  ): Promise<CanonicalResourceBundle | null> {
+    const database = await this.open()
+    const transaction = database.transaction(RESOURCE_STORE, 'readwrite')
+    const resources = transaction.objectStore(RESOURCE_STORE)
+    const id = resourceKey(accountId, resourceType, resourceId)
+    const row = await requestValue<StoredAuthorityResource | undefined>(resources.get(id))
+    if (!row) {
+      await transactionComplete(transaction)
+      return null
+    }
+
+    const bundle = { ...row.bundle, data: { ...row.bundle.data, _role: role } }
+    const canonical = row.canonicalBundle
+      ? { ...row.canonicalBundle, data: { ...row.canonicalBundle.data, _role: role } }
+      : undefined
+    resources.put({ ...row, bundle, canonicalBundle: canonical })
+    await transactionComplete(transaction)
+    emitStoreChange(this.databaseName, { accountId, resourceType, resourceId })
+    return bundle
+  }
+
+  async getNextRetryAt(accountId: string): Promise<string | null> {
+    const retryAt = (await this.listAccountOutbox(accountId))
+      .filter((row) => row.status === 'retryable' && row.nextAttemptAt)
+      .map((row) => row.nextAttemptAt as string)
+      .sort()[0]
+    return retryAt ?? null
   }
 
   async listReadyOutbox(
@@ -159,18 +327,24 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
     const id = resourceKey(accountId, result.resourceType, result.resourceId)
     const existing = await requestValue<StoredAuthorityResource | undefined>(resources.get(id))
 
-    let effectiveRevision = existing?.bundle.revision ?? 0
-    if (result.bundle && (!existing || shouldReplaceResource(existing.bundle, result.bundle))) {
-      resources.put(toStoredResource(accountId, result.bundle, now))
-      effectiveRevision = result.bundle.revision
-    } else if (existing && result.revision >= existing.bundle.revision) {
-      const canonical = applyCanonicalChangesToBundle(existing.bundle, result, now)
-      resources.put(toStoredResource(accountId, canonical, now))
-      effectiveRevision = canonical.revision
-    } else if (!existing) {
+    const existingCanonical = existing?.canonicalBundle ?? existing?.bundle ?? null
+    let canonicalBundle = existingCanonical
+    const resultBundle = result.bundle && existing
+      ? preserveLocalMetadata(existing.bundle, result.bundle)
+      : result.bundle
+    if (resultBundle && (!existingCanonical || shouldReplaceResource(existingCanonical, resultBundle))) {
+      canonicalBundle = resultBundle
+    } else if (existingCanonical && result.revision >= existingCanonical.revision) {
+      canonicalBundle = applyCanonicalChangesToBundle(existingCanonical, result, now)
+    } else if (!existingCanonical) {
       transaction.abort()
       throw new Error('Cannot acknowledge authority commands without a local resource cache.')
     }
+    if (!canonicalBundle) {
+      transaction.abort()
+      throw new Error('Canonical authority state is unavailable after acknowledgement.')
+    }
+    const effectiveRevision = canonicalBundle.revision
 
     for (const operationId of result.acknowledgedOperationIds) {
       const row = await requestValue<AuthorityOutboxRecord | undefined>(outbox.get(operationId))
@@ -192,7 +366,22 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
         outbox.put({ ...row, baseRevision: effectiveRevision, updatedAt: now })
       }
     }
+    const optimisticCommands = remaining
+      .filter((row) =>
+        row.status === 'pending' || row.status === 'sending' || row.status === 'retryable',
+      )
+      .sort(compareOutbox)
+      .map((row) => row.command)
+    const projection = optimisticCommands.length > 0
+      ? applyOptimisticAuthorityCommandsToBundle(canonicalBundle, optimisticCommands, now)
+      : canonicalBundle
+    resources.put(toStoredResource(accountId, projection, now, canonicalBundle))
     await transactionComplete(transaction)
+    emitStoreChange(this.databaseName, {
+      accountId,
+      resourceType: result.resourceType,
+      resourceId: result.resourceId,
+    })
   }
 
   async markRetryable(
@@ -238,7 +427,12 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
     const resources = transaction.objectStore(RESOURCE_STORE)
     const outbox = transaction.objectStore(OUTBOX_STORE)
 
-    if (bundle) resources.put(toStoredResource(accountId, bundle, now))
+    if (bundle) {
+      const id = resourceKey(accountId, bundle.resourceType, bundle.resourceId)
+      const existing = await requestValue<StoredAuthorityResource | undefined>(resources.get(id))
+      const canonicalBundle = existing ? preserveLocalMetadata(existing.bundle, bundle) : bundle
+      resources.put(toStoredResource(accountId, canonicalBundle, now, canonicalBundle))
+    }
     for (const operationId of operationIds) {
       const row = await requestValue<AuthorityOutboxRecord | undefined>(outbox.get(operationId))
       if (row?.accountId === accountId) {
@@ -252,6 +446,7 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
       }
     }
     await transactionComplete(transaction)
+    emitStoreChange(this.databaseName, { accountId })
   }
 
   async recoverStaleSending(
@@ -331,6 +526,7 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
     }
 
     await transactionComplete(transaction)
+    emitStoreChange(this.databaseName, { accountId })
   }
 
   close(): void {
@@ -368,6 +564,7 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
       if (row?.accountId === accountId) outbox.put(transform(row))
     }
     await transactionComplete(transaction)
+    emitStoreChange(this.databaseName, { accountId })
   }
 }
 
@@ -435,6 +632,7 @@ function toStoredResource(
   accountId: string,
   bundle: CanonicalResourceBundle,
   updatedAt = bundle.serverUpdatedAt,
+  canonicalBundle: CanonicalResourceBundle = bundle,
 ): StoredAuthorityResource {
   return {
     id: resourceKey(accountId, bundle.resourceType, bundle.resourceId),
@@ -442,6 +640,7 @@ function toStoredResource(
     resourceType: bundle.resourceType,
     resourceId: bundle.resourceId,
     bundle,
+    canonicalBundle,
     updatedAt,
   }
 }
@@ -455,6 +654,15 @@ function shouldReplaceResource(
     (candidate.revision === current.revision &&
       candidate.serverUpdatedAt >= current.serverUpdatedAt)
   )
+}
+
+function preserveLocalMetadata(
+  current: CanonicalResourceBundle,
+  candidate: CanonicalResourceBundle,
+): CanonicalResourceBundle {
+  const role = current.data._role
+  if (candidate.data._role !== undefined || role === undefined) return candidate
+  return { ...candidate, data: { ...candidate.data, _role: role } }
 }
 
 function validateMutation(input: CommitOptimisticAuthorityMutationInput): void {
@@ -475,4 +683,8 @@ function compareOutbox(left: AuthorityOutboxRecord, right: AuthorityOutboxRecord
 
 function normalizePromotedStatus(status: AuthorityOutboxStatus): AuthorityOutboxStatus {
   return status === 'sending' ? 'retryable' : status
+}
+
+function emitStoreChange(databaseName: string, change: WebAuthorityStoreChange): void {
+  storeListeners.get(databaseName)?.forEach((listener) => listener(change))
 }

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -27,6 +27,16 @@
 - Realtime은 private resource topic에 1KB 미만 invalidation만 보낸다. 연속 revision은 entity RPC, gap/reconnect는 full bundle로 복구한다.
 - 이번 단계는 기반 구현이다. 현재 Web 제품 화면은 TASK-050에서 이 repository와 sync session으로 전환한다.
 
+## 2026-07-17 TASK-050 구현 완료
+
+- Web 여행, 일정, 준비물, 템플릿과 프로필 파생 조회를 server-authority repository로 전환했다.
+- IndexedDB canonical cache와 optimistic projection을 분리하고 local mutation과 outbox append를 원자 처리한다.
+- online/foreground/retry flush와 Realtime revision invalidation으로 다른 Web 계정의 화면을 canonical row에 수렴시킨다.
+- 제품 경로에서 Yjs update, WebRTC signaling, document key, encrypted backup 호출을 제거했다.
+- 상세 화면은 오프라인 저장, 저장 대기, 동기화 완료, 충돌, 저장 오류를 구분해 표시한다.
+- 기능 플래그로 document-primary 경로를 롤백 경로로 유지한다. 실제 legacy runtime 삭제는 TASK-055 범위다.
+- 단위 테스트, typecheck, Web/Mobile build와 Playwright discovery는 통과했다. 다중 사용자 E2E 실제 실행은 로컬 Supabase 환경이 필요하다.
+
 2026-07-16 초대 흐름 재점검:
 
 - 이메일 초대와 기존 로그인 후 Accept UI가 서로 다른 registry를 사용하고 있음을 확인했다.

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -118,7 +118,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-047-shared-offline-sync-core.md` | 완료 | 공통 domain command, Repository, outbox, conflict/retry core |
 | `TASK-048-web-indexeddb-cache-outbox.md` | 완료 | Web account-scoped IndexedDB cache와 transactional outbox |
 | `TASK-049-realtime-invalidation-and-revision-recovery.md` | 완료 | private Broadcast invalidation과 Web revision gap 복구 |
-| `TASK-050-web-server-authority-product-cutover.md` | 대기 | Web 전체 기능 server-authority 제품 경로 전환 |
+| `TASK-050-web-server-authority-product-cutover.md` | 구현 완료 | Web 전체 기능 server-authority 전환, 로컬 Supabase E2E 실행 대기 |
 | `TASK-051-mobile-sqlite-cache-outbox.md` | 대기 | Mobile SQLite cache/outbox와 Realtime adapter |
 | `TASK-052-mobile-server-authority-product-cutover.md` | 대기 | Mobile 전체 기능 server-authority 제품 경로 전환 |
 | `TASK-053-membership-invitation-without-document-keys.md` | 대기 | document key 없는 membership/invitation/role/revoke |
@@ -215,7 +215,7 @@ rotating room secret 보안 하드닝을 완료했다.
 - [x] `TASK-047-shared-offline-sync-core.md`: 공통 command/repository/outbox/conflict core
 - [x] `TASK-048-web-indexeddb-cache-outbox.md`: Web IndexedDB cache/outbox adapter
 - [x] `TASK-049-realtime-invalidation-and-revision-recovery.md`: Realtime invalidation과 Web revision recovery
-- [ ] `TASK-050-web-server-authority-product-cutover.md`: Web 전체 제품 경로 전환
+- [x] `TASK-050-web-server-authority-product-cutover.md`: Web 전체 제품 경로 전환 (로컬 Supabase E2E 실행 대기)
 - [ ] `TASK-051-mobile-sqlite-cache-outbox.md`: Mobile SQLite cache/outbox와 Realtime adapter
 - [ ] `TASK-052-mobile-server-authority-product-cutover.md`: Mobile 전체 제품 경로 전환
 - [ ] `TASK-053-membership-invitation-without-document-keys.md`: keyless membership/invitation 전환

--- a/docs/refactor/tasks/TASK-050-web-server-authority-product-cutover.md
+++ b/docs/refactor/tasks/TASK-050-web-server-authority-product-cutover.md
@@ -1,6 +1,8 @@
 # TASK-050: Web Server-Authority Product Cutover
 
-- 상태: 대기
+- 상태: 구현 완료 (로컬 Supabase 통합 E2E 실행 대기)
+- Issue: [#354](https://github.com/ysjee141/nexvoy-frontend/issues/354)
+- Pull Request: [#355](https://github.com/ysjee141/nexvoy-frontend/pull/355)
 
 ## 목적
 
@@ -75,3 +77,26 @@ Web의 여행, 일정, 준비물, 템플릿 제품 경로를 server-authority Re
 - Web 핵심 기능이 신규 Repository/cache/outbox/RPC 경로에서 동작한다.
 - Web 제품 mutation이 full Yjs update를 생성하거나 P2P/backup에 publish하지 않는다.
 - offline, cross-account collaboration, refresh가 데이터 유실 없이 검증된다.
+
+## 구현 결과
+
+- 여행, 일정, 준비물, 템플릿 및 프로필 파생 조회를 server-authority repository로 전환했다.
+- `onvoy-server-authority` IndexedDB가 canonical bundle과 optimistic projection을 분리하고 mutation과 outbox를 한 transaction에 저장한다.
+- 1초 debounce, 재시도 시각 예약, foreground/online flush, Realtime revision invalidation을 제품 runtime에 연결했다.
+- 여행 상세에 오프라인 저장, 저장 대기, 동기화 완료, 충돌, 저장 오류 상태를 표시한다.
+- 기본값은 신규 경로이며 `NEXT_PUBLIC_WEB_SERVER_AUTHORITY=0` 또는 `?serverAuthority=0`으로 기존 document-primary 경로를 사용할 수 있다.
+- 신규 migration은 없으며 TASK-046/049의 RPC와 Realtime 계약을 사용한다.
+
+## 검증 결과
+
+- `pnpm --filter nexvoy-web test:authority`
+- `pnpm --filter @nexvoy/core test`
+- `pnpm typecheck`
+- `pnpm build:packages`
+- `pnpm build`
+- `pnpm build:mobile`
+- `pnpm --filter nexvoy-web exec playwright test --list`
+
+위 검증은 통과했다. `server-authority-product.spec.ts`는 offline outbox, reconnect flush, editor Realtime 수신,
+legacy key/backup/signaling 호출 부재를 검증한다. 실제 실행은 `.env.test.local`이 원격 DEV를 가리켜 destructive cleanup
+안전장치가 중단했으며, 로컬 Supabase 환경에서 후속 실행해야 한다.

--- a/packages/core/src/sync/__tests__/serverAuthoritySync.test.ts
+++ b/packages/core/src/sync/__tests__/serverAuthoritySync.test.ts
@@ -10,6 +10,7 @@ import {
   decideAuthorityInvalidation,
   parseAuthorityInvalidation,
 } from '../serverAuthorityInvalidation'
+import { applyOptimisticAuthorityCommandsToBundle } from '../serverAuthorityMaterialize'
 import type {
   AuthorityApplyResult,
   AuthorityLocalStore,
@@ -70,6 +71,8 @@ class FakeStore implements AuthorityLocalStore {
   }
 
   async commitOptimisticMutation(): Promise<void> {}
+
+  async commitOptimisticMutations(): Promise<void> {}
 
   async listReadyOutbox(): Promise<AuthorityOutboxRecord[]> {
     return this.records.filter((item) => item.status === 'pending' || item.status === 'retryable')
@@ -166,6 +169,36 @@ function repositoryWith(
 }
 
 async function run(): Promise<void> {
+  const optimisticTripId = '10000000-0000-0000-0000-000000000099'
+  const optimistic = applyOptimisticAuthorityCommandsToBundle({
+    resourceType: 'trip',
+    resourceId: optimisticTripId,
+    revision: 0,
+    serverUpdatedAt: now,
+    data: { trip: null, checklists: [], checklist_item_assignees: [] },
+  }, [
+    {
+      operationId: '00000000-0000-0000-0000-000000000091',
+      resourceId: optimisticTripId,
+      entityType: 'trip',
+      entityId: optimisticTripId,
+      action: 'upsert',
+      payload: { destination: '전주', user_id: 'account-1' },
+      createdAt: now,
+    },
+    {
+      operationId: '00000000-0000-0000-0000-000000000092',
+      resourceId: optimisticTripId,
+      entityType: 'checklist',
+      entityId: '10000000-0000-0000-0000-000000000098',
+      action: 'upsert',
+      payload: { title: '준비물' },
+      createdAt: now,
+    },
+  ], now)
+  assert.equal((optimistic.data.trip as { destination?: string }).destination, '전주')
+  assert.equal((optimistic.data.checklists as Array<{ title?: string }>)[0]?.title, '준비물')
+
   const invalidation = parseAuthorityInvalidation({
     resource_type: 'trip',
     resource_id: '10000000-0000-0000-0000-000000000001',

--- a/packages/core/src/sync/serverAuthorityMaterialize.ts
+++ b/packages/core/src/sync/serverAuthorityMaterialize.ts
@@ -1,5 +1,6 @@
 import type { Json } from '@nexvoy/types'
 import type {
+  AuthorityCommand,
   AuthorityApplyResult,
   CanonicalAuthorityChange,
   CanonicalResourceBundle,
@@ -35,6 +36,109 @@ export function applyCanonicalChangesToBundle(
     revision: result.revision,
     serverUpdatedAt: result.serverUpdatedAt ?? fallbackUpdatedAt,
     data,
+  }
+}
+
+export function applyOptimisticAuthorityCommandsToBundle(
+  current: CanonicalResourceBundle,
+  commands: AuthorityCommand[],
+  now: string,
+): CanonicalResourceBundle {
+  const data = cloneJsonObject(current.data)
+  for (const command of commands) {
+    if (
+      command.resourceId !== current.resourceId ||
+      (command.entityType.startsWith('template') ? 'template' : 'trip') !== current.resourceType
+    ) {
+      throw new Error('Optimistic authority command does not match the resource bundle.')
+    }
+    applyOptimisticCommand(data, command, now)
+  }
+  return { ...current, serverUpdatedAt: now, data }
+}
+
+function applyOptimisticCommand(data: JsonObject, command: AuthorityCommand, now: string): void {
+  const payload = asObject(command.payload)
+  if (command.entityType === 'trip' || command.entityType === 'template') {
+    const existing = asObject(data[command.entityType])
+    data[command.entityType] = command.action === 'delete'
+      ? { ...existing, deleted_at: now, updated_at: now }
+      : optimisticRow(existing, payload, command.entityId, now)
+    return
+  }
+
+  if (command.entityType === 'checklist_item_assignees') {
+    const userIds = jsonArray(payload.user_ids).filter((value): value is string => typeof value === 'string')
+    const existing = jsonArray(data.checklist_item_assignees).filter(
+      (item) => stringValue(asObject(item).item_id) !== command.entityId,
+    )
+    data.checklist_item_assignees = [
+      ...existing,
+      ...userIds.map((userId) => ({
+        id: `${command.entityId}:${userId}`,
+        item_id: command.entityId,
+        user_id: userId,
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        version: 0,
+      })),
+    ]
+    return
+  }
+
+  if (command.entityType === 'checklist_item_user_check') {
+    const userId = stringValue(payload.user_id)
+    const existing = jsonArray(data.checklist_item_user_checks).filter((item) => {
+      const row = asObject(item)
+      return !(
+        stringValue(row.item_id) === command.entityId &&
+        stringValue(row.user_id) === userId
+      )
+    })
+    if (userId && payload.checked === true) {
+      existing.push({
+        id: `${command.entityId}:${userId}`,
+        item_id: command.entityId,
+        user_id: userId,
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+        version: 0,
+      })
+    }
+    data.checklist_item_user_checks = existing
+    return
+  }
+
+  const collectionKey = collectionKeyByEntity[command.entityType]
+  const rows = jsonArray(data[collectionKey])
+  const index = rows.findIndex((item) => stringValue(asObject(item).id) === command.entityId)
+  if (command.action === 'delete') {
+    if (index >= 0) rows.splice(index, 1)
+  } else {
+    const existing = index >= 0 ? asObject(rows[index]) : {}
+    const row = optimisticRow(existing, payload, command.entityId, now)
+    if (index >= 0) rows[index] = row
+    else rows.push(row)
+  }
+  data[collectionKey] = rows
+}
+
+function optimisticRow(
+  existing: JsonObject,
+  payload: JsonObject,
+  id: string,
+  now: string,
+): JsonObject {
+  return {
+    ...existing,
+    ...payload,
+    id,
+    created_at: existing.created_at ?? now,
+    updated_at: now,
+    deleted_at: null,
+    version: existing.version ?? 0,
   }
 }
 

--- a/packages/core/src/sync/serverAuthorityTypes.ts
+++ b/packages/core/src/sync/serverAuthorityTypes.ts
@@ -144,9 +144,31 @@ export interface AuthorityOutboxRecord {
 
 export interface CommitOptimisticAuthorityMutationInput {
   accountId: string
+  baseBundle?: CanonicalResourceBundle
   bundle: CanonicalResourceBundle
   command: AuthorityCommand
   now: string
+}
+
+export interface CommitOptimisticAuthorityMutationsInput {
+  accountId: string
+  baseBundle?: CanonicalResourceBundle
+  bundle: CanonicalResourceBundle
+  commands: AuthorityCommand[]
+  now: string
+}
+
+export type AuthorityProductSyncStatus =
+  | 'offline'
+  | 'pending'
+  | 'synced'
+  | 'conflict'
+  | 'error'
+
+export interface AuthorityProductSyncSnapshot {
+  status: AuthorityProductSyncStatus
+  pendingCount: number
+  lastError: string | null
 }
 
 export interface AuthorityLocalStore {
@@ -157,6 +179,7 @@ export interface AuthorityLocalStore {
   ): Promise<CanonicalResourceBundle | null>
   putResource(accountId: string, bundle: CanonicalResourceBundle): Promise<void>
   commitOptimisticMutation(input: CommitOptimisticAuthorityMutationInput): Promise<void>
+  commitOptimisticMutations(input: CommitOptimisticAuthorityMutationsInput): Promise<void>
   listReadyOutbox(accountId: string, now: string, limit: number): Promise<AuthorityOutboxRecord[]>
   markSending(accountId: string, operationIds: string[], now: string): Promise<void>
   applyAcknowledgement(

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,65 @@
+# Walkthrough: TASK-050 Web Server-Authority Product Cutover
+
+## Summary
+
+Web의 여행, 일정, 준비물, 템플릿 제품 경로를 Supabase normalized row authority로 전환했다. 화면은 계정별
+IndexedDB cache를 먼저 읽고, 수정은 optimistic projection과 durable outbox에 원자 기록한다. 서버 반영은
+authenticated batch RPC로 수행하며 Realtime은 revision invalidation만 전달한다.
+
+```mermaid
+flowchart LR
+    UI["Web product UI"] --> CACHE["IndexedDB optimistic projection"]
+    UI --> OUTBOX["Transactional outbox"]
+    OUTBOX --> RPC["Authenticated command RPC"]
+    RPC --> ROWS["Normalized canonical rows"]
+    ROWS --> RT["Revision invalidation"]
+    RT --> REFRESH["Delta or full bundle refresh"]
+    REFRESH --> CANON["IndexedDB canonical bundle"]
+    CANON --> CACHE
+```
+
+## Artifacts
+
+- GitHub Issue [#354](https://github.com/ysjee141/nexvoy-frontend/issues/354)
+- Pull Request [#355](https://github.com/ysjee141/nexvoy-frontend/pull/355)
+- 브랜치: `codex/task-050-web-authority-cutover`
+- `apps/web/lib/data/authorityProductRepositories.ts`
+- `apps/web/lib/server-authority/indexedDbStore.ts`
+- `apps/web/components/trips/AuthoritySyncStatusBadge.tsx`
+- `apps/web/e2e/server-authority-product.spec.ts`
+
+## Key Changes
+
+- authority mode를 Web 기본 repository로 지정하고 환경 변수 또는 query flag로 document-primary 롤백을 유지했다.
+- 여행 생성은 client UUID의 trip과 기본 준비물 checklist command를 한 local transaction에 기록한다.
+- 여행·일정·URL·준비물·개인 체크·담당자·템플릿·공유 command를 optimistic materializer와 RPC에 연결했다.
+- canonical bundle과 optimistic projection을 분리해 remote refresh나 out-of-order ack가 미전송 변경을 덮지 않도록 했다.
+- outbox는 1초 debounce, 정확한 retry 시각, online/foreground trigger, 계정 세션 일치 검사를 사용한다.
+- active resource는 private Realtime invalidation을 구독하고 revision gap이면 full bundle로 복구한다.
+- 여행 상세에 오프라인 저장, 저장 대기, 동기화 완료, 충돌, 저장 오류 상태를 표시한다.
+- 신규 제품 경로는 document key, encrypted backup, Yjs update, WebRTC signaling을 호출하지 않는다.
+
+## Verification
+
+| 검증 | 결과 |
+| --- | --- |
+| `pnpm --filter nexvoy-web test:authority` | PASS |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm typecheck` | PASS |
+| `pnpm build:packages` | PASS |
+| `pnpm build` | PASS |
+| `pnpm build:mobile` | PASS |
+| `pnpm --filter nexvoy-web exec playwright test --list` | PASS, 14 tests |
+| TASK-050 Playwright 실제 실행 | BLOCKED, 원격 DEV cleanup 방지 안전장치 |
+
+## Remaining Work
+
+- 로컬 Supabase에 TASK-046/049 migration을 적용하고 TASK-050 다중 사용자 E2E를 실제 실행한다.
+- Mobile SQLite/cache/outbox와 제품 전환은 TASK-051/052에서 진행한다.
+- invitation의 document key 의존 제거, asset 전송, legacy runtime 삭제는 TASK-053~055 범위다.
+
+---
+
 # Walkthrough: TASK-046~049 Server Authority Sync Foundation
 
 ## Summary


### PR DESCRIPTION
# feat(TASK-050): cut over Web product flows to server authority

## Summary

- switch Web trip, plan, checklist, and template flows to cache-first server authority repositories
- persist optimistic projections and durable outbox commands atomically in account-scoped IndexedDB
- connect debounced/retry flush, Realtime revision recovery, sync status UI, and rollback flag
- add authority unit coverage and an offline/cross-account Playwright scenario

## Verification

- `pnpm --filter nexvoy-web test:authority`
- `pnpm --filter @nexvoy/core test`
- `pnpm typecheck`
- `pnpm build:packages`
- `pnpm build`
- `pnpm build:mobile`
- `pnpm --filter nexvoy-web exec playwright test --list`

The targeted Playwright run is intentionally blocked because `.env.test.local` points to remote DEV and the test cleanup guard only permits local Supabase.

Closes #354
