### PR TITLE
fix(TASK-050): recover malformed plan commands

### DIFF
--- a/apps/web/app/api/places/photo/store/route.ts
+++ b/apps/web/app/api/places/photo/store/route.ts
@@ -100,7 +100,8 @@ export async function POST(request: NextRequest) {
 
         // 3) 멤버십 검증
         //    Legacy row plan은 plans row로 trip 소속을 확인한다.
-        //    Document-primary plan은 plans row가 없을 수 있으므로 trip-level owner/editor 권한만 확인한다.
+        //    Local-first/server-authority plan은 plans row가 아직 보이지 않을 수 있으므로
+        //    trip-level owner/editor 권한만 확인한다.
         if (!isDocumentPrimary) {
             const { data: planRow, error: planLookupError } = await supabase
                 .from('plans')
@@ -120,22 +121,36 @@ export async function POST(request: NextRequest) {
             }
         }
 
-        // 소유자 또는 멤버(편집자) 권한 검증.
-        // 두 보조 함수를 RPC 호출하여 OR 조건을 평가한다.
-        const [ownerResp, editorResp] = await Promise.all([
-            supabase.rpc('check_is_trip_owner', { _trip_id: tripId, _user_id: user.id }),
-            supabase.rpc('check_is_trip_editor', { _trip_id: tripId, _user_id: user.id }),
-        ])
-        if (ownerResp.error) {
-            console.error('[places/photo/store] check_is_trip_owner failed:', ownerResp.error.message)
-        }
-        if (editorResp.error) {
-            console.error('[places/photo/store] check_is_trip_editor failed:', editorResp.error.message)
-        }
-        const isOwner = ownerResp.data === true
-        const isEditor = editorResp.data === true
-        if (!isOwner && !isEditor) {
-            return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+        if (isDocumentPrimary) {
+            const authorityWrite = await supabase.rpc('check_can_write_authority_trip', {
+                p_trip_id: tripId,
+                p_user_id: user.id,
+            })
+            if (authorityWrite.error) {
+                console.error(
+                    '[places/photo/store] check_can_write_authority_trip failed:',
+                    authorityWrite.error.message
+                )
+                return NextResponse.json({ error: 'Permission lookup failed' }, { status: 500 })
+            }
+            if (authorityWrite.data !== true) {
+                return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+            }
+        } else {
+            // Legacy rows use trip owner/trip_members editor authority.
+            const [ownerResp, editorResp] = await Promise.all([
+                supabase.rpc('check_is_trip_owner', { _trip_id: tripId, _user_id: user.id }),
+                supabase.rpc('check_is_trip_editor', { _trip_id: tripId, _user_id: user.id }),
+            ])
+            if (ownerResp.error) {
+                console.error('[places/photo/store] check_is_trip_owner failed:', ownerResp.error.message)
+            }
+            if (editorResp.error) {
+                console.error('[places/photo/store] check_is_trip_editor failed:', editorResp.error.message)
+            }
+            if (ownerResp.data !== true && editorResp.data !== true) {
+                return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+            }
         }
 
         // 4) Google Maps API Key (서버 보유)

--- a/apps/web/e2e/helpers/seed.ts
+++ b/apps/web/e2e/helpers/seed.ts
@@ -332,6 +332,23 @@ export async function getChecklistItemByName(
   return (data as { id: string; is_checked: boolean } | null) ?? null;
 }
 
+export async function getPlanByTitle(
+  tripId: string,
+  title: string,
+): Promise<{ id: string; title: string } | null> {
+  const client = getServiceClient();
+  const { data, error } = await client
+    .from('plans')
+    .select('id, title')
+    .eq('trip_id', tripId)
+    .eq('title', title)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(`getPlanByTitle 실패: ${error.message}`);
+  return (data as { id: string; title: string } | null) ?? null;
+}
+
 /**
  * 검증용 단일 항목 조회.
  */

--- a/apps/web/e2e/server-authority-product.spec.ts
+++ b/apps/web/e2e/server-authority-product.spec.ts
@@ -3,6 +3,7 @@ import {
   cleanupTripsByUser,
   getChecklistItemByName,
   getOrCreateChecklist,
+  getPlanByTitle,
   seedAuthorityDocumentMember,
   seedAuthorityTrip,
 } from './helpers/seed';
@@ -69,6 +70,46 @@ test.describe('TASK-050 Web server-authority product integration', () => {
       expect(legacyRequests).toEqual([]);
     } finally {
       await cleanupTripsByUser(multiUsers.owner.id);
+    }
+  });
+
+  test('plan creation keeps the trip root intact and reaches the canonical server', async ({
+    authenticatedContext,
+    testUser,
+  }) => {
+    await cleanupTripsByUser(testUser.id);
+    const trip = await seedAuthorityTrip(testUser, {
+      destination: 'TASK-050 일정 명령 검증',
+    });
+
+    try {
+      const page = await authenticatedContext.newPage();
+      await page.goto(`/trips/detail?id=${trip.id}&tab=plans&serverAuthority=1`);
+      await expect(page.getByText('TASK-050 일정 명령 검증', { exact: false })).toBeVisible({
+        timeout: 15000,
+      });
+
+      await page.getByRole('button', { name: '일정 추가' }).click();
+      const placeName = `명령 분류 장소 ${Date.now()}`;
+      await page.getByPlaceholder(/레스토랑|장소 이름/).fill(placeName);
+      await page.getByRole('button', { name: /계속하기/ }).click();
+
+      const planTitle = `plan-command-${Date.now()}`;
+      await page.getByPlaceholder('예: 근사한 저녁 식사, 박물관 투어').fill(planTitle);
+      await page.locator('input[type="date"]').fill(trip.start_date);
+      await page.locator('input[type="time"]').fill('10:00');
+      await page.getByRole('button', { name: '일정 추가하기' }).click();
+
+      await expect(page.getByText(planTitle)).toBeVisible({ timeout: 10000 });
+      await expect.poll(
+        () => getPlanByTitle(trip.id, planTitle),
+        { timeout: 15000 },
+      ).not.toBeNull();
+      await expect(page.getByText('TASK-050 일정 명령 검증', { exact: false })).toBeVisible();
+      await expect(page.getByText('동기화 완료')).toBeVisible({ timeout: 15000 });
+      await page.close();
+    } finally {
+      await cleanupTripsByUser(testUser.id);
     }
   });
 });

--- a/apps/web/hooks/useImageRecovery.ts
+++ b/apps/web/hooks/useImageRecovery.ts
@@ -59,6 +59,9 @@ export function useImageRecovery(): UseImageRecoveryReturn {
                     tripId,
                     placeId,
                     photoReference,
+                    // Product plans are local-first/server-authority records and may be
+                    // recovered before their relational row is visible to direct RLS reads.
+                    documentPrimary: true,
                 })
 
                 if (result.ok) {

--- a/apps/web/lib/data/authorityProductRepositories.ts
+++ b/apps/web/lib/data/authorityProductRepositories.ts
@@ -69,6 +69,7 @@ class WebAuthorityProductRuntime {
   private readonly watchedResources = new Map<string, AuthorityRuntimeSubscription>()
   private readonly flushTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  private readonly accountRepairPromises = new Map<string, Promise<void>>()
 
   constructor(private readonly supabase: SupabaseClient) {
     this.remote = createServerAuthorityRepository(supabase)
@@ -86,13 +87,29 @@ class WebAuthorityProductRuntime {
 
   async accountId(): Promise<string> {
     const { data: sessionData } = await this.supabase.auth.getSession()
-    if (sessionData.session?.user) return sessionData.session.user.id
+    if (sessionData.session?.user) return this.prepareAccount(sessionData.session.user.id)
     if (isBrowserOnline()) {
       const { data, error } = await this.supabase.auth.getUser()
       if (error) throw error
-      if (data.user) return data.user.id
+      if (data.user) return this.prepareAccount(data.user.id)
     }
     throw new Error('인증 정보가 없습니다.')
+  }
+
+  private async prepareAccount(accountId: string): Promise<string> {
+    let repair = this.accountRepairPromises.get(accountId)
+    if (!repair) {
+      repair = this.store
+        .repairMislabeledPlanCommands(accountId, new Date().toISOString())
+        .then(() => undefined)
+        .catch((error: unknown) => {
+          this.accountRepairPromises.delete(accountId)
+          throw error
+        })
+      this.accountRepairPromises.set(accountId, repair)
+    }
+    await repair
+    return accountId
   }
 
   async listLocal(resourceType: AuthorityResourceType): Promise<CanonicalResourceBundle[]> {
@@ -395,21 +412,21 @@ export async function createWebAuthorityDocumentRepositories(
       async createPlan(tripId, input) {
         assertWritable(actorRole)
         const bundle = await requireBundle(runtime, 'trip', tripId)
-        const command = commandFor('trip', tripId, input.id, 'upsert', planCreatePayload(input))
+        const command = commandFor('plan', tripId, input.id, 'upsert', planCreatePayload(input))
         const optimistic = await runtime.commit(bundle, [command])
         return tripMutationResult('plan.create', optimistic, [{ entityType: 'plan', entityId: input.id }])
       },
       async updatePlan(tripId, input) {
         assertWritable(actorRole)
         const bundle = await requireBundle(runtime, 'trip', tripId)
-        const command = commandFor('trip', tripId, input.planId, 'upsert', planPatchPayload(input))
+        const command = commandFor('plan', tripId, input.planId, 'upsert', planPatchPayload(input))
         const optimistic = await runtime.commit(bundle, [command])
         return tripMutationResult('plan.update', optimistic, [{ entityType: 'plan', entityId: input.planId }])
       },
       async deletePlan(tripId, planId) {
         assertWritable(actorRole)
         const bundle = await requireBundle(runtime, 'trip', tripId)
-        const command = commandFor('trip', tripId, planId, 'delete', {})
+        const command = commandFor('plan', tripId, planId, 'delete', {})
         const optimistic = await runtime.commit(bundle, [command])
         return tripMutationResult('plan.delete', optimistic, [{ entityType: 'plan', entityId: planId }])
       },
@@ -753,6 +770,12 @@ function commandFor(
   payload: Record<string, Json | undefined>,
   createdAt = new Date().toISOString(),
 ): AuthorityCommand {
+  if (
+    (entityType === 'trip' || entityType === 'template') &&
+    entityId !== resourceId
+  ) {
+    throw new Error('Authority root command must target its resource id.')
+  }
   return {
     operationId: createId(),
     resourceId,

--- a/apps/web/lib/server-authority/__tests__/indexedDbStore.test.ts
+++ b/apps/web/lib/server-authority/__tests__/indexedDbStore.test.ts
@@ -90,6 +90,94 @@ async function run(): Promise<void> {
     'error',
   )
 
+  const planId = '48000000-0000-0000-0000-000000000099'
+  const repairBase: CanonicalResourceBundle = {
+    resourceType: 'trip',
+    resourceId: tripId,
+    revision: 0,
+    serverUpdatedAt: now,
+    data: { trip: null, plans: [], checklists: [], _role: 'owner' },
+  }
+  const repairCommands: AuthorityCommand[] = [
+    command('48000000-0000-0000-0000-000000000031', '전주 복구'),
+    {
+      operationId: '48000000-0000-0000-0000-000000000032',
+      resourceId: tripId,
+      entityType: 'checklist',
+      entityId: '48000000-0000-0000-0000-000000000098',
+      action: 'upsert',
+      payload: { title: '준비물' },
+      createdAt: now,
+    },
+    {
+      operationId: '48000000-0000-0000-0000-000000000033',
+      resourceId: tripId,
+      entityType: 'trip',
+      entityId: planId,
+      action: 'upsert',
+      payload: { title: '한옥마을 산책', start_datetime_local: '2026-07-17T10:00:00' },
+      createdAt: now,
+    },
+  ]
+  const corruptedProjection: CanonicalResourceBundle = {
+    ...repairBase,
+    data: {
+      ...repairBase.data,
+      trip: {
+        id: planId,
+        title: '한옥마을 산책',
+        start_datetime_local: '2026-07-17T10:00:00',
+      },
+      checklists: [{
+        id: '48000000-0000-0000-0000-000000000098',
+        title: '준비물',
+      }],
+    },
+  }
+  await store.commitOptimisticMutations({
+    accountId: 'account-repair',
+    baseBundle: repairBase,
+    bundle: corruptedProjection,
+    commands: repairCommands,
+    now,
+  })
+  await store.markRejected(
+    'account-repair',
+    repairCommands.map((item) => item.operationId),
+    '22023',
+    now,
+  )
+  assert.equal(
+    ((await store.getResource('account-repair', 'trip', tripId))?.data.trip as { id?: string }).id,
+    planId,
+  )
+
+  assert.equal(
+    await store.repairMislabeledPlanCommands(
+      'account-repair',
+      '2026-07-17T01:00:01.000Z',
+    ),
+    1,
+  )
+  const repairedRows = await store.listReadyOutbox('account-repair', now, 10)
+  assert.deepEqual(repairedRows.map((row) => row.command.entityType), [
+    'trip',
+    'checklist',
+    'plan',
+  ])
+  assert.equal(
+    ((await store.getResource('account-repair', 'trip', tripId))?.data.trip as { id?: string }).id,
+    tripId,
+  )
+  assert.equal(
+    ((await store.getResource('account-repair', 'trip', tripId))?.data.plans as Array<{ id?: string }>)[0]?.id,
+    planId,
+  )
+  assert.equal(
+    (await store.getSyncSnapshot('account-repair', 'trip', tripId, true)).status,
+    'pending',
+  )
+
   await store.commitOptimisticMutation({
     accountId: 'account-a',
     bundle: bundle('전주'),

--- a/apps/web/lib/server-authority/indexedDbStore.ts
+++ b/apps/web/lib/server-authority/indexedDbStore.ts
@@ -2,6 +2,7 @@ import {
   applyCanonicalChangesToBundle,
   applyOptimisticAuthorityCommandsToBundle,
   type AuthorityApplyResult,
+  type AuthorityCommand,
   type AuthorityLocalStore,
   type AuthorityOutboxRecord,
   type AuthorityOutboxStatus,
@@ -472,6 +473,87 @@ export class WebAuthorityIndexedDbStore implements AuthorityLocalStore {
     return rows.length
   }
 
+  async repairMislabeledPlanCommands(accountId: string, now: string): Promise<number> {
+    const database = await this.open()
+    const transaction = database.transaction([RESOURCE_STORE, OUTBOX_STORE], 'readwrite')
+    const resources = transaction.objectStore(RESOURCE_STORE)
+    const outbox = transaction.objectStore(OUTBOX_STORE)
+    const accountRows = await requestValue<AuthorityOutboxRecord[]>(
+      outbox.index(ACCOUNT_INDEX).getAll(accountId),
+    )
+    const malformed = accountRows.filter(isMislabeledPlanCommand)
+    if (malformed.length === 0) {
+      await transactionComplete(transaction)
+      return 0
+    }
+
+    const affectedResources = new Map<string, AuthorityOutboxRecord[]>()
+    for (const row of malformed) {
+      const key = resourceKey(accountId, row.resourceType, row.resourceId)
+      affectedResources.set(
+        key,
+        accountRows.filter((candidate) =>
+          candidate.resourceType === row.resourceType && candidate.resourceId === row.resourceId,
+        ),
+      )
+    }
+
+    const repairedChanges: WebAuthorityStoreChange[] = []
+    let repairedCount = 0
+    for (const [key, rows] of affectedResources) {
+      const stored = await requestValue<StoredAuthorityResource | undefined>(resources.get(key))
+      if (!stored?.canonicalBundle) continue
+
+      const malformedBaseRevisions = new Set(
+        rows.filter(isMislabeledPlanCommand).map((row) => row.baseRevision),
+      )
+      const repairedRows = rows.map((row) => {
+        const mislabeled = isMislabeledPlanCommand(row)
+        const rejectedWithBatch =
+          row.status === 'rejected' &&
+          row.lastError === '22023' &&
+          malformedBaseRevisions.has(row.baseRevision)
+        if (!mislabeled && !rejectedWithBatch) return row
+        if (mislabeled) repairedCount += 1
+        const repairedRow: AuthorityOutboxRecord = {
+          ...row,
+          command: mislabeled
+            ? { ...row.command, entityType: 'plan' as const }
+            : row.command,
+          status: 'pending' as const,
+          attempts: 0,
+          nextAttemptAt: null,
+          lastError: null,
+          updatedAt: now,
+        }
+        return repairedRow
+      })
+      const optimisticCommands = repairedRows
+        .filter((row) =>
+          row.status === 'pending' || row.status === 'sending' || row.status === 'retryable',
+        )
+        .sort(compareOutbox)
+        .map((row) => row.command)
+      const projected = applyOptimisticAuthorityCommandsToBundle(
+        stored.canonicalBundle,
+        optimisticCommands,
+        now,
+      )
+
+      repairedRows.forEach((row) => outbox.put(row))
+      resources.put(toStoredResource(accountId, projected, now, stored.canonicalBundle))
+      repairedChanges.push({
+        accountId,
+        resourceType: stored.resourceType,
+        resourceId: stored.resourceId,
+      })
+    }
+
+    await transactionComplete(transaction)
+    repairedChanges.forEach((change) => emitStoreChange(this.databaseName, change))
+    return repairedCount
+  }
+
   async promoteGuestAccount(
     guestAccountId: string,
     accountId: string,
@@ -610,6 +692,19 @@ function requestValue<T>(request: IDBRequest<T>): Promise<T> {
     request.onsuccess = () => resolve(request.result)
     request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed.'))
   })
+}
+
+function isMislabeledPlanCommand(
+  row: AuthorityOutboxRecord,
+): row is AuthorityOutboxRecord & {
+  command: Extract<AuthorityCommand, { entityType: 'trip' }>
+} {
+  return (
+    row.resourceType === 'trip' &&
+    row.command.entityType === 'trip' &&
+    row.command.resourceId === row.resourceId &&
+    row.command.entityId !== row.resourceId
+  )
 }
 
 function transactionComplete(transaction: IDBTransaction): Promise<void> {

--- a/packages/core/src/sync/__tests__/serverAuthoritySync.test.ts
+++ b/packages/core/src/sync/__tests__/serverAuthoritySync.test.ts
@@ -175,7 +175,7 @@ async function run(): Promise<void> {
     resourceId: optimisticTripId,
     revision: 0,
     serverUpdatedAt: now,
-    data: { trip: null, checklists: [], checklist_item_assignees: [] },
+    data: { trip: null, plans: [], checklists: [], checklist_item_assignees: [] },
   }, [
     {
       operationId: '00000000-0000-0000-0000-000000000091',
@@ -195,9 +195,31 @@ async function run(): Promise<void> {
       payload: { title: '준비물' },
       createdAt: now,
     },
+    {
+      operationId: '00000000-0000-0000-0000-000000000093',
+      resourceId: optimisticTripId,
+      entityType: 'plan',
+      entityId: '10000000-0000-0000-0000-000000000097',
+      action: 'upsert',
+      payload: { title: '한옥마을 산책' },
+      createdAt: now,
+    },
   ], now)
   assert.equal((optimistic.data.trip as { destination?: string }).destination, '전주')
   assert.equal((optimistic.data.checklists as Array<{ title?: string }>)[0]?.title, '준비물')
+  assert.equal((optimistic.data.plans as Array<{ title?: string }>)[0]?.title, '한옥마을 산책')
+  assert.throws(
+    () => applyOptimisticAuthorityCommandsToBundle(optimistic, [{
+      operationId: '00000000-0000-0000-0000-000000000094',
+      resourceId: optimisticTripId,
+      entityType: 'trip',
+      entityId: '10000000-0000-0000-0000-000000000096',
+      action: 'upsert',
+      payload: { title: '잘못 분류된 일정' },
+      createdAt: now,
+    }], now),
+    /root command must target its resource id/,
+  )
 
   const invalidation = parseAuthorityInvalidation({
     resource_type: 'trip',

--- a/packages/core/src/sync/serverAuthorityMaterialize.ts
+++ b/packages/core/src/sync/serverAuthorityMaterialize.ts
@@ -52,6 +52,12 @@ export function applyOptimisticAuthorityCommandsToBundle(
     ) {
       throw new Error('Optimistic authority command does not match the resource bundle.')
     }
+    if (
+      (command.entityType === 'trip' || command.entityType === 'template') &&
+      command.entityId !== command.resourceId
+    ) {
+      throw new Error('Optimistic authority root command must target its resource id.')
+    }
     applyOptimisticCommand(data, command, now)
   }
   return { ...current, serverUpdatedAt: now, data }

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,50 @@
+# Walkthrough: TASK-050 Plan Command Recovery
+
+## Summary
+
+TASK-050 Web 전환 후 일정 명령이 `plan` 대신 `trip`으로 생성되어 optimistic trip root를 덮어쓰고,
+신규 여행의 첫 server batch 전체를 `22023`으로 rollback하던 결함을 수정했다. 기존 브라우저에 이미 거절된
+배치는 canonical base에서 자동 재구축해 여행·준비물·일정을 함께 재전송한다.
+
+## Artifacts
+
+- GitHub Issue [#356](https://github.com/ysjee141/nexvoy-frontend/issues/356)
+- Pull Request [#357](https://github.com/ysjee141/nexvoy-frontend/pull/357)
+- 브랜치: `codex/fix-task050-plan-command`
+- `apps/web/lib/data/authorityProductRepositories.ts`
+- `apps/web/lib/server-authority/indexedDbStore.ts`
+- `packages/core/src/sync/serverAuthorityMaterialize.ts`
+- `apps/web/e2e/server-authority-product.spec.ts`
+
+## Key Changes
+
+- 일정 create/update/delete command를 `entityType: plan`으로 교정했다.
+- trip/template root command가 resource ID와 다른 entity ID를 대상으로 하면 즉시 거부한다.
+- 기존 오분류 command와 같은 `22023` 거절 batch를 pending으로 되돌리고 canonical bundle에서 projection을 재구축한다.
+- 서버 권위 일정 이미지 복구는 direct plan RLS 조회 대신 document owner/editor write 권한을 사용한다.
+- 일정 생성 후 trip root 유지, canonical plan 반영, IndexedDB 거절 batch 복구 회귀 테스트를 추가했다.
+
+## Verification
+
+| 검증 | 결과 |
+| --- | --- |
+| `pnpm --filter nexvoy-web test:authority` | PASS |
+| `pnpm --filter @nexvoy/core test` | PASS |
+| `pnpm --filter nexvoy-web exec tsc --noEmit --pretty false` | PASS |
+| `pnpm typecheck` | PASS |
+| `pnpm build` | PASS |
+| `pnpm build:mobile` | PASS |
+| `pnpm --filter nexvoy-web exec playwright test --list` | PASS, 15 tests |
+| 일정 생성 Playwright 실제 실행 | BLOCKED, 원격 DEV cleanup 방지 안전장치 |
+| 기존 실패 draft 브라우저 복구 | PASS, 일정 1개 및 `동기화 완료` 확인 |
+
+## Rollback
+
+plan command 교정만 되돌리면 데이터 손상 결함이 재발하므로 부분 rollback은 허용하지 않는다. 전체 rollback 시
+runtime의 local repair 호출, IndexedDB repair 함수, root 불변식, 이미지 권한 분기를 함께 제거한다. DB migration은 없다.
+
+---
+
 # Walkthrough: TASK-050 Web Server-Authority Product Cutover
 
 ## Summary


### PR DESCRIPTION
## Summary
- classify plan create/update/delete commands as `plan` instead of `trip`
- repair existing `22023` rejected IndexedDB batches from their canonical base and retry atomically
- enforce root-command ID invariants and use document authority for plan photo recovery
- add IndexedDB/Core regression coverage and a canonical plan E2E scenario

Closes #356

## Verification
- `pnpm --filter nexvoy-web test:authority`
- `pnpm --filter @nexvoy/core test`
- `pnpm --filter nexvoy-web exec tsc --noEmit --pretty false`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:mobile`
- `pnpm --filter nexvoy-web exec playwright test --list`
- DEV browser: affected draft restored with one plan and `동기화 완료`

## Limitation
The targeted Playwright run is blocked by the existing local-Supabase-only cleanup guard because `.env.test.local` targets remote DEV.