### PR TITLE
feat(TASK-051): add mobile SQLite authority cache

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -24,6 +24,7 @@ module.exports = () => {
     ...(config.plugins ?? []),
     'expo-background-task',
     'expo-build-properties',
+    'expo-sqlite',
     'react-native-quick-crypto',
   ]
 

--- a/apps/mobile/app/profile/withdrawal.tsx
+++ b/apps/mobile/app/profile/withdrawal.tsx
@@ -27,6 +27,7 @@ import { deleteUser } from '@nexvoy/core'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/lib/auth-context'
 import { cancelAllLocalNotifications } from '@/lib/notifications'
+import { purgeMobileAuthorityAccount } from '@/lib/data/server-authority/syncService'
 import { colors, fontSizes, fontWeights, radii, spacing } from '@/theme'
 
 const CONFIRM_KEYWORD = '탈퇴'
@@ -107,7 +108,11 @@ export default function WithdrawalScreen() {
         // 탈퇴 본 작업은 서버 delete_user RPC가 최종 책임을 가진다.
       }
       await deleteUser(supabase)
-      await signOut()
+      try {
+        if (session?.user.id) await purgeMobileAuthorityAccount(session.user.id)
+      } finally {
+        await signOut()
+      }
       // auth gate 가 세션 소멸을 감지해 자동 리다이렉트하지만,
       // 명시적으로 로그인 화면으로 이동시켜 잔여 상태를 정리한다.
       router.replace('/(auth)/login')

--- a/apps/mobile/lib/auth-context.tsx
+++ b/apps/mobile/lib/auth-context.tsx
@@ -24,6 +24,14 @@ import {
   registerMobileProvisioningBackgroundTask,
   unregisterMobileProvisioningBackgroundTask,
 } from './local-first/provisioningBackgroundTask'
+import {
+  registerMobileAuthorityBackgroundTask,
+  unregisterMobileAuthorityBackgroundTask,
+} from './data/server-authority/backgroundTask'
+import {
+  startMobileAuthoritySync,
+  stopMobileAuthoritySync,
+} from './data/server-authority/syncService'
 
 interface AuthContextValue {
   session: Session | null
@@ -73,18 +81,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (isLoading) return
-    if (session) {
+    const accountId = session?.user.id
+    if (accountId) {
       setMobileBackgroundWorkPaused(false)
       void registerMobileProvisioningBackgroundTask()
+      void registerMobileAuthorityBackgroundTask()
+      void startMobileAuthoritySync(accountId)
       return
     }
     setMobileBackgroundWorkPaused(true)
     void unregisterMobileProvisioningBackgroundTask()
-  }, [isLoading, session])
+    void unregisterMobileAuthorityBackgroundTask()
+    void stopMobileAuthoritySync()
+  }, [isLoading, session?.user.id])
 
   const signOut = async () => {
     setMobileBackgroundWorkPaused(true)
-    await unregisterMobileProvisioningBackgroundTask()
+    await Promise.all([
+      unregisterMobileProvisioningBackgroundTask(),
+      unregisterMobileAuthorityBackgroundTask(),
+      stopMobileAuthoritySync(),
+    ])
     try {
       await cancelAllLocalNotifications()
     } catch {

--- a/apps/mobile/lib/data/server-authority/__tests__/sqliteStore.test.ts
+++ b/apps/mobile/lib/data/server-authority/__tests__/sqliteStore.test.ts
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  applyOptimisticAuthorityCommandsToBundle,
+  type AuthorityCommand,
+  type AuthorityOutboxRecord,
+  type AuthorityResourceType,
+  type CanonicalResourceBundle,
+} from '@nexvoy/core'
+import type {
+  MobileAuthorityDatabase,
+  MobileAuthorityDatabaseTransaction,
+  MobileAuthoritySyncState,
+  StoredMobileAuthorityResource,
+} from '../database'
+import { MobileAuthoritySqliteStore } from '../sqliteStore'
+
+const ACCOUNT_A = 'account-a'
+const ACCOUNT_B = 'account-b'
+const TRIP_ID = 'trip-1'
+const T0 = '2026-07-17T00:00:00.000Z'
+const T1 = '2026-07-17T00:01:00.000Z'
+const T2 = '2026-07-17T00:02:00.000Z'
+
+test('optimistic resource and outbox append commit atomically', async () => {
+  const database = new FakeMobileAuthorityDatabase()
+  const store = new MobileAuthoritySqliteStore(database)
+  const base = tripBundle(1, T0)
+  const command = planCommand('operation-1', 'plan-1', T1)
+  const optimistic = applyOptimisticAuthorityCommandsToBundle(base, [command], T1)
+
+  await store.commitOptimisticMutation({
+    accountId: ACCOUNT_A,
+    baseBundle: base,
+    bundle: optimistic,
+    command,
+    now: T1,
+  })
+
+  assert.equal(database.transactionCount, 1)
+  assert.deepEqual(await store.getResource(ACCOUNT_A, 'trip', TRIP_ID), optimistic)
+  assert.deepEqual((await store.listReadyOutbox(ACCOUNT_A, T1, 10))[0]?.command, command)
+})
+
+test('transaction rollback prevents a resource-only optimistic write', async () => {
+  const database = new FakeMobileAuthorityDatabase()
+  const store = new MobileAuthoritySqliteStore(database)
+  const base = tripBundle(1, T0)
+  const command = planCommand('operation-1', 'plan-1', T1)
+  database.failNextOutboxWrite = true
+
+  await assert.rejects(
+    store.commitOptimisticMutation({
+      accountId: ACCOUNT_A,
+      baseBundle: base,
+      bundle: applyOptimisticAuthorityCommandsToBundle(base, [command], T1),
+      command,
+      now: T1,
+    }),
+    /simulated outbox failure/,
+  )
+
+  assert.equal(await store.getResource(ACCOUNT_A, 'trip', TRIP_ID), null)
+  assert.deepEqual(await store.listReadyOutbox(ACCOUNT_A, T1, 10), [])
+})
+
+test('canonical acknowledgement removes acked commands and rebases pending projection', async () => {
+  const database = new FakeMobileAuthorityDatabase()
+  const store = new MobileAuthoritySqliteStore(database)
+  const base = tripBundle(1, T0)
+  const first = planCommand('operation-1', 'plan-1', T1)
+  const second = planCommand('operation-2', 'plan-2', T2)
+  const optimistic = applyOptimisticAuthorityCommandsToBundle(base, [first, second], T2)
+
+  await store.commitOptimisticMutations({
+    accountId: ACCOUNT_A,
+    baseBundle: base,
+    bundle: optimistic,
+    commands: [first, second],
+    now: T2,
+  })
+  await store.markSending(ACCOUNT_A, [first.operationId], T2)
+  await store.applyAcknowledgement(
+    ACCOUNT_A,
+    {
+      status: 'applied',
+      resourceType: 'trip',
+      resourceId: TRIP_ID,
+      revision: 2,
+      serverUpdatedAt: T2,
+      acknowledgedOperationIds: [first.operationId],
+      changes: [{
+        operationId: first.operationId,
+        entityType: 'plan',
+        entityId: first.entityId,
+        action: 'upsert',
+        row: { id: first.entityId, title: 'canonical', version: 1, updated_at: T2 },
+      }],
+    },
+    T2,
+  )
+
+  const outbox = await store.listReadyOutbox(ACCOUNT_A, T2, 10)
+  assert.equal(outbox.length, 1)
+  assert.equal(outbox[0]?.operationId, second.operationId)
+  assert.equal(outbox[0]?.baseRevision, 2)
+  const bundle = await store.getResource(ACCOUNT_A, 'trip', TRIP_ID)
+  assert.equal(bundle?.revision, 2)
+  assert.deepEqual(
+    (bundle?.data.plans as Array<{ id: string }>).map((plan) => plan.id).sort(),
+    ['plan-1', 'plan-2'],
+  )
+})
+
+test('account namespaces stay isolated and purge removes only the selected account', async () => {
+  const database = new FakeMobileAuthorityDatabase()
+  const store = new MobileAuthoritySqliteStore(database)
+  await store.putResource(ACCOUNT_A, tripBundle(1, T0))
+  await store.putResource(ACCOUNT_B, tripBundle(2, T1))
+
+  await store.purgeAccount(ACCOUNT_A)
+
+  assert.equal(await store.getResource(ACCOUNT_A, 'trip', TRIP_ID), null)
+  assert.equal((await store.getResource(ACCOUNT_B, 'trip', TRIP_ID))?.revision, 2)
+})
+
+test('guest promotion moves cache and recovers interrupted sending work', async () => {
+  const database = new FakeMobileAuthorityDatabase()
+  const store = new MobileAuthoritySqliteStore(database)
+  const guestId = 'guest:device-1'
+  const base = tripBundle(1, T0)
+  const command = planCommand('operation-guest', 'plan-guest', T1)
+  await store.commitOptimisticMutation({
+    accountId: guestId,
+    baseBundle: base,
+    bundle: applyOptimisticAuthorityCommandsToBundle(base, [command], T1),
+    command,
+    now: T1,
+  })
+  await store.markSending(guestId, [command.operationId], T1)
+
+  await store.promoteGuestAccount(guestId, ACCOUNT_A, T2)
+  assert.equal((await store.listReadyOutbox(ACCOUNT_A, T2, 10))[0]?.status, 'retryable')
+  await store.markSending(ACCOUNT_A, [command.operationId], T1)
+  const recovered = await store.recoverStaleSending(ACCOUNT_A, T2, T2)
+
+  assert.equal(recovered, 1)
+  assert.equal(await store.getResource(guestId, 'trip', TRIP_ID), null)
+  assert.ok(await store.getResource(ACCOUNT_A, 'trip', TRIP_ID))
+  assert.equal((await store.listReadyOutbox(ACCOUNT_A, T2, 10))[0]?.status, 'retryable')
+})
+
+function tripBundle(revision: number, updatedAt: string): CanonicalResourceBundle {
+  return {
+    resourceType: 'trip',
+    resourceId: TRIP_ID,
+    revision,
+    serverUpdatedAt: updatedAt,
+    data: {
+      _role: 'owner',
+      trip: { id: TRIP_ID, destination: 'Seoul', version: revision },
+      plans: [],
+    },
+  }
+}
+
+function planCommand(operationId: string, entityId: string, createdAt: string): AuthorityCommand {
+  return {
+    operationId,
+    resourceId: TRIP_ID,
+    entityType: 'plan',
+    entityId,
+    action: 'upsert',
+    payload: { title: entityId },
+    createdAt,
+  }
+}
+
+class FakeMobileAuthorityDatabase
+implements MobileAuthorityDatabase, MobileAuthorityDatabaseTransaction {
+  private resources = new Map<string, StoredMobileAuthorityResource>()
+  private outbox = new Map<string, AuthorityOutboxRecord>()
+  private syncStates = new Map<string, MobileAuthoritySyncState>()
+  transactionCount = 0
+  failNextOutboxWrite = false
+
+  async transaction<T>(
+    task: (transaction: MobileAuthorityDatabaseTransaction) => Promise<T>,
+  ): Promise<T> {
+    this.transactionCount += 1
+    const snapshot = {
+      resources: cloneMap(this.resources),
+      outbox: cloneMap(this.outbox),
+      syncStates: cloneMap(this.syncStates),
+    }
+    try {
+      return await task(this)
+    } catch (error) {
+      this.resources = snapshot.resources
+      this.outbox = snapshot.outbox
+      this.syncStates = snapshot.syncStates
+      throw error
+    }
+  }
+
+  async getResource(accountId: string, resourceType: AuthorityResourceType, resourceId: string) {
+    return cloneValue(this.resources.get(resourceKey(accountId, resourceType, resourceId)) ?? null)
+  }
+
+  async listResources(accountId: string, resourceType?: AuthorityResourceType) {
+    return [...this.resources.values()]
+      .filter((row) => row.accountId === accountId && (!resourceType || row.resourceType === resourceType))
+      .map(cloneValue)
+  }
+
+  async putResource(resource: StoredMobileAuthorityResource) {
+    this.resources.set(
+      resourceKey(resource.accountId, resource.resourceType, resource.resourceId),
+      cloneValue(resource),
+    )
+  }
+
+  async deleteResource(accountId: string, resourceType: AuthorityResourceType, resourceId: string) {
+    this.resources.delete(resourceKey(accountId, resourceType, resourceId))
+    for (const [operationId, row] of this.outbox) {
+      if (row.accountId === accountId && row.resourceType === resourceType && row.resourceId === resourceId) {
+        this.outbox.delete(operationId)
+      }
+    }
+    this.syncStates.delete(resourceKey(accountId, resourceType, resourceId))
+  }
+
+  async getOutbox(operationId: string) {
+    return cloneValue(this.outbox.get(operationId) ?? null)
+  }
+
+  async listOutbox(accountId: string, resourceType?: AuthorityResourceType, resourceId?: string) {
+    return [...this.outbox.values()]
+      .filter((row) =>
+        row.accountId === accountId &&
+        (!resourceType || row.resourceType === resourceType) &&
+        (!resourceId || row.resourceId === resourceId),
+      )
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+      .map(cloneValue)
+  }
+
+  async putOutbox(record: AuthorityOutboxRecord) {
+    if (this.failNextOutboxWrite) {
+      this.failNextOutboxWrite = false
+      throw new Error('simulated outbox failure')
+    }
+    this.outbox.set(record.operationId, cloneValue(record))
+  }
+
+  async deleteOutbox(operationId: string) {
+    this.outbox.delete(operationId)
+  }
+
+  async getSyncState(accountId: string, resourceType: AuthorityResourceType, resourceId: string) {
+    return cloneValue(this.syncStates.get(resourceKey(accountId, resourceType, resourceId)) ?? null)
+  }
+
+  async listSyncStates(accountId: string) {
+    return [...this.syncStates.values()]
+      .filter((state) => state.accountId === accountId)
+      .map(cloneValue)
+  }
+
+  async putSyncState(state: MobileAuthoritySyncState) {
+    this.syncStates.set(
+      resourceKey(state.accountId, state.resourceType, state.resourceId),
+      cloneValue(state),
+    )
+  }
+
+  async deleteAccount(accountId: string) {
+    for (const row of await this.listResources(accountId)) {
+      await this.deleteResource(accountId, row.resourceType, row.resourceId)
+    }
+  }
+
+  async close() {}
+}
+
+function resourceKey(
+  accountId: string,
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+): string {
+  return `${accountId}:${resourceType}:${resourceId}`
+}
+
+function cloneMap<T>(source: Map<string, T>): Map<string, T> {
+  return new Map([...source].map(([key, value]) => [key, cloneValue(value)]))
+}
+
+function cloneValue<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}

--- a/apps/mobile/lib/data/server-authority/backgroundTask.ts
+++ b/apps/mobile/lib/data/server-authority/backgroundTask.ts
@@ -1,0 +1,77 @@
+import { Platform } from 'react-native'
+import * as BackgroundTask from 'expo-background-task'
+import * as TaskManager from 'expo-task-manager'
+import {
+  defineMobileBackgroundWorker,
+  isMobileBackgroundWorkPaused,
+  runExclusiveMobileBackgroundWork,
+} from '@/lib/backgroundTaskCoordinator'
+import { supabase } from '@/lib/supabase'
+import { flushMobileAuthorityAccount } from './syncService'
+
+export const MOBILE_AUTHORITY_BACKGROUND_TASK_NAME = 'onvoy.mobile.authority.background'
+
+const authorityWorker = defineMobileBackgroundWorker({
+  name: MOBILE_AUTHORITY_BACKGROUND_TASK_NAME,
+  minimumInterval: 15,
+  run: async () => {
+    if (isMobileBackgroundWorkPaused()) return
+    const { data } = await supabase.auth.getSession()
+    const accountId = data.session?.user.id
+    if (!accountId) return
+    await runExclusiveMobileBackgroundWork(
+      MOBILE_AUTHORITY_BACKGROUND_TASK_NAME,
+      () => flushMobileAuthorityAccount(accountId),
+      () => null,
+    )
+  },
+})
+
+if (!TaskManager.isTaskDefined(MOBILE_AUTHORITY_BACKGROUND_TASK_NAME)) {
+  TaskManager.defineTask(MOBILE_AUTHORITY_BACKGROUND_TASK_NAME, async ({ error }) => {
+    if (!error) {
+      try {
+        await authorityWorker.run()
+      } catch {
+        // Background execution is best effort; foreground recovery remains authoritative.
+      }
+    }
+    return BackgroundTask.BackgroundTaskResult.Success
+  })
+}
+
+export async function registerMobileAuthorityBackgroundTask(): Promise<boolean> {
+  if (!isSupportedNativePlatform()) return false
+  try {
+    if (!await TaskManager.isAvailableAsync()) return false
+    if (await BackgroundTask.getStatusAsync() !== BackgroundTask.BackgroundTaskStatus.Available) {
+      return false
+    }
+    if (await TaskManager.isTaskRegisteredAsync(MOBILE_AUTHORITY_BACKGROUND_TASK_NAME)) {
+      return true
+    }
+    await BackgroundTask.registerTaskAsync(MOBILE_AUTHORITY_BACKGROUND_TASK_NAME, {
+      minimumInterval: authorityWorker.minimumInterval,
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function unregisterMobileAuthorityBackgroundTask(): Promise<boolean> {
+  if (!isSupportedNativePlatform()) return false
+  try {
+    if (!await TaskManager.isTaskRegisteredAsync(MOBILE_AUTHORITY_BACKGROUND_TASK_NAME)) {
+      return true
+    }
+    await BackgroundTask.unregisterTaskAsync(MOBILE_AUTHORITY_BACKGROUND_TASK_NAME)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isSupportedNativePlatform(): boolean {
+  return Platform.OS === 'android' || Platform.OS === 'ios'
+}

--- a/apps/mobile/lib/data/server-authority/database.ts
+++ b/apps/mobile/lib/data/server-authority/database.ts
@@ -1,0 +1,69 @@
+import type {
+  AuthorityOutboxRecord,
+  AuthorityResourceType,
+  CanonicalResourceBundle,
+} from '@nexvoy/core'
+
+export interface StoredMobileAuthorityResource {
+  accountId: string
+  resourceType: AuthorityResourceType
+  resourceId: string
+  bundle: CanonicalResourceBundle
+  canonicalBundle: CanonicalResourceBundle
+  updatedAt: string
+}
+
+export interface MobileAuthoritySyncState {
+  accountId: string
+  resourceType: AuthorityResourceType
+  resourceId: string
+  lastSeenRevision: number
+  lastReconciledRevision: number
+  lastRefreshedAt: string | null
+  lastError: string | null
+  updatedAt: string
+}
+
+export interface MobileAuthorityDatabaseReader {
+  getResource(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<StoredMobileAuthorityResource | null>
+  listResources(
+    accountId: string,
+    resourceType?: AuthorityResourceType,
+  ): Promise<StoredMobileAuthorityResource[]>
+  getOutbox(operationId: string): Promise<AuthorityOutboxRecord | null>
+  listOutbox(
+    accountId: string,
+    resourceType?: AuthorityResourceType,
+    resourceId?: string,
+  ): Promise<AuthorityOutboxRecord[]>
+  getSyncState(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<MobileAuthoritySyncState | null>
+  listSyncStates(accountId: string): Promise<MobileAuthoritySyncState[]>
+}
+
+export interface MobileAuthorityDatabaseTransaction extends MobileAuthorityDatabaseReader {
+  putResource(resource: StoredMobileAuthorityResource): Promise<void>
+  deleteResource(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<void>
+  putOutbox(record: AuthorityOutboxRecord): Promise<void>
+  deleteOutbox(operationId: string): Promise<void>
+  putSyncState(state: MobileAuthoritySyncState): Promise<void>
+  deleteAccount(accountId: string): Promise<void>
+}
+
+export interface MobileAuthorityDatabase extends MobileAuthorityDatabaseReader {
+  transaction<T>(
+    task: (transaction: MobileAuthorityDatabaseTransaction) => Promise<T>,
+  ): Promise<T>
+  close(): Promise<void>
+}

--- a/apps/mobile/lib/data/server-authority/realtimeInvalidation.ts
+++ b/apps/mobile/lib/data/server-authority/realtimeInvalidation.ts
@@ -1,0 +1,156 @@
+import {
+  AUTHORITY_INVALIDATION_EVENT,
+  decideAuthorityInvalidation,
+  parseAuthorityInvalidation,
+  type AuthorityLocalStore,
+  type AuthorityResourceType,
+  type ServerAuthoritySyncCoordinator,
+} from '@nexvoy/core'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type MobileAuthorityRealtimeMetric =
+  | {
+      name: 'authority_invalidation_received' | 'authority_invalidation_ignored'
+      resourceType: AuthorityResourceType
+      resourceId: string
+      revision: number
+    }
+  | {
+      name: 'authority_invalidation_gap' | 'authority_reconnect_refresh'
+      resourceType: AuthorityResourceType
+      resourceId: string
+      localRevision: number
+      remoteRevision: number
+    }
+
+export interface MobileAuthorityInvalidationSubscription {
+  topic: string
+  unsubscribe(): Promise<void>
+}
+
+interface SubscribeMobileAuthorityInvalidationInput {
+  supabase: SupabaseClient
+  accountId: string
+  resourceType: AuthorityResourceType
+  resourceId: string
+  store: AuthorityLocalStore
+  coordinator: ServerAuthoritySyncCoordinator
+  onMetric?: (metric: MobileAuthorityRealtimeMetric) => void
+  onError?: (error: unknown) => void
+}
+
+export async function subscribeMobileAuthorityInvalidation(
+  input: SubscribeMobileAuthorityInvalidationInput,
+): Promise<MobileAuthorityInvalidationSubscription> {
+  const topic = `${input.resourceType}:${input.resourceId}`
+  const channel = input.supabase.channel(topic, {
+    config: { private: true, broadcast: { self: false, ack: false } },
+  })
+  let reconciliation = Promise.resolve()
+  let subscribedOnce = false
+
+  const forceRefresh = async (isReconnect: boolean): Promise<void> => {
+    const local = await input.store.getResource(
+      input.accountId,
+      input.resourceType,
+      input.resourceId,
+    )
+    const remote = await input.coordinator.refreshResource(
+      input.accountId,
+      input.resourceType,
+      input.resourceId,
+      Number.MAX_SAFE_INTEGER,
+    )
+    if (isReconnect && remote) {
+      input.onMetric?.({
+        name: 'authority_reconnect_refresh',
+        resourceType: input.resourceType,
+        resourceId: input.resourceId,
+        localRevision: local?.revision ?? 0,
+        remoteRevision: remote.revision,
+      })
+    }
+  }
+
+  channel.on(
+    'broadcast',
+    { event: AUTHORITY_INVALIDATION_EVENT },
+    ({ payload }: { payload: unknown }) => {
+      reconciliation = reconciliation
+        .then(async () => {
+          const invalidation = parseAuthorityInvalidation(payload)
+          if (
+            !invalidation ||
+            invalidation.resourceType !== input.resourceType ||
+            invalidation.resourceId !== input.resourceId
+          ) {
+            return
+          }
+
+          const local = await input.store.getResource(
+            input.accountId,
+            input.resourceType,
+            input.resourceId,
+          )
+          const localRevision = local?.revision ?? 0
+          const decision = decideAuthorityInvalidation(localRevision, invalidation.revision)
+          if (decision.action === 'ignore') {
+            input.onMetric?.({
+              name: 'authority_invalidation_ignored',
+              resourceType: input.resourceType,
+              resourceId: input.resourceId,
+              revision: invalidation.revision,
+            })
+            return
+          }
+
+          input.onMetric?.({
+            name: 'authority_invalidation_received',
+            resourceType: input.resourceType,
+            resourceId: input.resourceId,
+            revision: invalidation.revision,
+          })
+          if (decision.revisionGap) {
+            input.onMetric?.({
+              name: 'authority_invalidation_gap',
+              resourceType: input.resourceType,
+              resourceId: input.resourceId,
+              localRevision,
+              remoteRevision: invalidation.revision,
+            })
+          }
+          await input.coordinator.reconcileInvalidation(input.accountId, invalidation)
+        })
+        .catch((error: unknown) => input.onError?.(error))
+    },
+  )
+
+  await new Promise<void>((resolve, reject) => {
+    channel.subscribe((status) => {
+      if (status === 'SUBSCRIBED') {
+        const isReconnect = subscribedOnce
+        subscribedOnce = true
+        reconciliation = reconciliation.then(() => forceRefresh(isReconnect))
+        if (isReconnect) {
+          reconciliation = reconciliation.catch((error: unknown) => input.onError?.(error))
+        } else {
+          reconciliation.then(resolve).catch(reject)
+        }
+        return
+      }
+      if (
+        !subscribedOnce &&
+        (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED')
+      ) {
+        reject(new Error(`authority_channel_${status.toLowerCase()}`))
+      }
+    })
+  })
+
+  return {
+    topic,
+    async unsubscribe() {
+      await input.supabase.removeChannel(channel)
+    },
+  }
+}

--- a/apps/mobile/lib/data/server-authority/sqliteDatabase.ts
+++ b/apps/mobile/lib/data/server-authority/sqliteDatabase.ts
@@ -1,0 +1,435 @@
+import { deleteDatabaseAsync, openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite'
+import type {
+  AuthorityOutboxRecord,
+  AuthorityResourceType,
+  CanonicalResourceBundle,
+} from '@nexvoy/core'
+import type {
+  MobileAuthorityDatabase,
+  MobileAuthorityDatabaseReader,
+  MobileAuthorityDatabaseTransaction,
+  MobileAuthoritySyncState,
+  StoredMobileAuthorityResource,
+} from './database'
+
+export const MOBILE_AUTHORITY_DATABASE_NAME = 'onvoy-server-authority.db'
+export const MOBILE_AUTHORITY_SCHEMA_VERSION = 1
+
+interface SqlExecutor {
+  runAsync(source: string, params: (string | number | null)[]): Promise<unknown>
+  getFirstAsync<T>(source: string, params: (string | number | null)[]): Promise<T | null>
+  getAllAsync<T>(source: string, params: (string | number | null)[]): Promise<T[]>
+}
+
+interface ResourceRow {
+  account_id: string
+  resource_type: AuthorityResourceType
+  resource_id: string
+  bundle_json: string
+  canonical_bundle_json: string
+  local_updated_at: string
+}
+
+interface OutboxRow {
+  operation_id: string
+  account_id: string
+  resource_type: AuthorityResourceType
+  resource_id: string
+  base_revision: number
+  command_json: string
+  status: AuthorityOutboxRecord['status']
+  attempts: number
+  next_attempt_at: string | null
+  last_error: string | null
+  created_at: string
+  updated_at: string
+}
+
+interface SyncStateRow {
+  account_id: string
+  resource_type: AuthorityResourceType
+  resource_id: string
+  last_seen_revision: number
+  last_reconciled_revision: number
+  last_refreshed_at: string | null
+  last_error: string | null
+  updated_at: string
+}
+
+export async function openMobileAuthorityDatabase(
+  databaseName = MOBILE_AUTHORITY_DATABASE_NAME,
+): Promise<MobileAuthorityDatabase> {
+  const database = await openDatabaseAsync(databaseName)
+  try {
+    await migrateDatabase(database)
+    return new ExpoMobileAuthorityDatabase(database)
+  } catch (error) {
+    await database.closeAsync()
+    throw error
+  }
+}
+
+export function deleteMobileAuthorityDatabase(
+  databaseName = MOBILE_AUTHORITY_DATABASE_NAME,
+): Promise<void> {
+  return deleteDatabaseAsync(databaseName)
+}
+
+class ExpoMobileAuthorityDatabase implements MobileAuthorityDatabase {
+  private readonly reader: MobileAuthorityDatabaseReader
+
+  constructor(private readonly database: SQLiteDatabase) {
+    this.reader = createDatabaseReader(database)
+  }
+
+  getResource(...args: Parameters<MobileAuthorityDatabaseReader['getResource']>) {
+    return this.reader.getResource(...args)
+  }
+
+  listResources(...args: Parameters<MobileAuthorityDatabaseReader['listResources']>) {
+    return this.reader.listResources(...args)
+  }
+
+  getOutbox(...args: Parameters<MobileAuthorityDatabaseReader['getOutbox']>) {
+    return this.reader.getOutbox(...args)
+  }
+
+  listOutbox(...args: Parameters<MobileAuthorityDatabaseReader['listOutbox']>) {
+    return this.reader.listOutbox(...args)
+  }
+
+  getSyncState(...args: Parameters<MobileAuthorityDatabaseReader['getSyncState']>) {
+    return this.reader.getSyncState(...args)
+  }
+
+  listSyncStates(...args: Parameters<MobileAuthorityDatabaseReader['listSyncStates']>) {
+    return this.reader.listSyncStates(...args)
+  }
+
+  async transaction<T>(
+    task: (transaction: MobileAuthorityDatabaseTransaction) => Promise<T>,
+  ): Promise<T> {
+    let result: T | undefined
+    await this.database.withExclusiveTransactionAsync(async (transaction) => {
+      result = await task(createDatabaseTransaction(transaction))
+    })
+    return result as T
+  }
+
+  close(): Promise<void> {
+    return this.database.closeAsync()
+  }
+}
+
+async function migrateDatabase(database: SQLiteDatabase): Promise<void> {
+  await database.execAsync(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA foreign_keys = ON;
+    PRAGMA busy_timeout = 5000;
+  `)
+  const versionRow = await database.getFirstAsync<{ user_version: number }>(
+    'PRAGMA user_version',
+  )
+  const currentVersion = versionRow?.user_version ?? 0
+  if (currentVersion > MOBILE_AUTHORITY_SCHEMA_VERSION) {
+    throw new Error(`Unsupported mobile authority schema version: ${currentVersion}`)
+  }
+  if (currentVersion === MOBILE_AUTHORITY_SCHEMA_VERSION) return
+
+  await database.withExclusiveTransactionAsync(async (transaction) => {
+    if (currentVersion < 1) {
+      await transaction.execAsync(`
+        CREATE TABLE IF NOT EXISTS authority_resources (
+          account_id TEXT NOT NULL,
+          resource_type TEXT NOT NULL CHECK (resource_type IN ('trip', 'template')),
+          resource_id TEXT NOT NULL,
+          bundle_json TEXT NOT NULL,
+          canonical_bundle_json TEXT NOT NULL,
+          revision INTEGER NOT NULL,
+          server_updated_at TEXT NOT NULL,
+          local_updated_at TEXT NOT NULL,
+          PRIMARY KEY (account_id, resource_type, resource_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS authority_resources_account_updated_idx
+          ON authority_resources (account_id, resource_type, server_updated_at DESC);
+
+        CREATE TABLE IF NOT EXISTS authority_outbox (
+          operation_id TEXT PRIMARY KEY,
+          account_id TEXT NOT NULL,
+          resource_type TEXT NOT NULL CHECK (resource_type IN ('trip', 'template')),
+          resource_id TEXT NOT NULL,
+          base_revision INTEGER NOT NULL,
+          command_json TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (
+            status IN ('pending', 'sending', 'acked', 'retryable', 'rejected', 'conflict')
+          ),
+          attempts INTEGER NOT NULL DEFAULT 0,
+          next_attempt_at TEXT,
+          last_error TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          FOREIGN KEY (account_id, resource_type, resource_id)
+            REFERENCES authority_resources (account_id, resource_type, resource_id)
+            ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS authority_outbox_ready_idx
+          ON authority_outbox (account_id, status, next_attempt_at, created_at);
+        CREATE INDEX IF NOT EXISTS authority_outbox_resource_idx
+          ON authority_outbox (account_id, resource_type, resource_id, created_at);
+
+        CREATE TABLE IF NOT EXISTS authority_sync_state (
+          account_id TEXT NOT NULL,
+          resource_type TEXT NOT NULL CHECK (resource_type IN ('trip', 'template')),
+          resource_id TEXT NOT NULL,
+          last_seen_revision INTEGER NOT NULL DEFAULT 0,
+          last_reconciled_revision INTEGER NOT NULL DEFAULT 0,
+          last_refreshed_at TEXT,
+          last_error TEXT,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (account_id, resource_type, resource_id),
+          FOREIGN KEY (account_id, resource_type, resource_id)
+            REFERENCES authority_resources (account_id, resource_type, resource_id)
+            ON DELETE CASCADE
+        );
+
+        PRAGMA user_version = 1;
+      `)
+    }
+  })
+}
+
+function createDatabaseReader(executor: SqlExecutor): MobileAuthorityDatabaseReader {
+  return {
+    async getResource(accountId, resourceType, resourceId) {
+      const row = await executor.getFirstAsync<ResourceRow>(
+        `SELECT account_id, resource_type, resource_id, bundle_json,
+                canonical_bundle_json, local_updated_at
+           FROM authority_resources
+          WHERE account_id = ? AND resource_type = ? AND resource_id = ?`,
+        [accountId, resourceType, resourceId],
+      )
+      return row ? parseResourceRow(row) : null
+    },
+
+    async listResources(accountId, resourceType) {
+      const rows = resourceType
+        ? await executor.getAllAsync<ResourceRow>(
+            `SELECT account_id, resource_type, resource_id, bundle_json,
+                    canonical_bundle_json, local_updated_at
+               FROM authority_resources
+              WHERE account_id = ? AND resource_type = ?
+              ORDER BY server_updated_at DESC`,
+            [accountId, resourceType],
+          )
+        : await executor.getAllAsync<ResourceRow>(
+            `SELECT account_id, resource_type, resource_id, bundle_json,
+                    canonical_bundle_json, local_updated_at
+               FROM authority_resources
+              WHERE account_id = ?
+              ORDER BY server_updated_at DESC`,
+            [accountId],
+          )
+      return rows.map(parseResourceRow)
+    },
+
+    async getOutbox(operationId) {
+      const row = await executor.getFirstAsync<OutboxRow>(
+        'SELECT * FROM authority_outbox WHERE operation_id = ?',
+        [operationId],
+      )
+      return row ? parseOutboxRow(row) : null
+    },
+
+    async listOutbox(accountId, resourceType, resourceId) {
+      let sql = 'SELECT * FROM authority_outbox WHERE account_id = ?'
+      const params: (string | number | null)[] = [accountId]
+      if (resourceType) {
+        sql += ' AND resource_type = ?'
+        params.push(resourceType)
+      }
+      if (resourceId) {
+        sql += ' AND resource_id = ?'
+        params.push(resourceId)
+      }
+      sql += ' ORDER BY created_at, operation_id'
+      const rows = await executor.getAllAsync<OutboxRow>(sql, params)
+      return rows.map(parseOutboxRow)
+    },
+
+    async getSyncState(accountId, resourceType, resourceId) {
+      const row = await executor.getFirstAsync<SyncStateRow>(
+        `SELECT * FROM authority_sync_state
+          WHERE account_id = ? AND resource_type = ? AND resource_id = ?`,
+        [accountId, resourceType, resourceId],
+      )
+      return row ? parseSyncStateRow(row) : null
+    },
+
+    async listSyncStates(accountId) {
+      const rows = await executor.getAllAsync<SyncStateRow>(
+        'SELECT * FROM authority_sync_state WHERE account_id = ?',
+        [accountId],
+      )
+      return rows.map(parseSyncStateRow)
+    },
+  }
+}
+
+function createDatabaseTransaction(executor: SqlExecutor): MobileAuthorityDatabaseTransaction {
+  return {
+    ...createDatabaseReader(executor),
+
+    async putResource(resource) {
+      await executor.runAsync(
+        `INSERT INTO authority_resources (
+           account_id, resource_type, resource_id, bundle_json, canonical_bundle_json,
+           revision, server_updated_at, local_updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (account_id, resource_type, resource_id) DO UPDATE SET
+           bundle_json = excluded.bundle_json,
+           canonical_bundle_json = excluded.canonical_bundle_json,
+           revision = excluded.revision,
+           server_updated_at = excluded.server_updated_at,
+           local_updated_at = excluded.local_updated_at`,
+        [
+          resource.accountId,
+          resource.resourceType,
+          resource.resourceId,
+          JSON.stringify(resource.bundle),
+          JSON.stringify(resource.canonicalBundle),
+          resource.bundle.revision,
+          resource.bundle.serverUpdatedAt,
+          resource.updatedAt,
+        ],
+      )
+    },
+
+    async deleteResource(accountId, resourceType, resourceId) {
+      await executor.runAsync(
+        `DELETE FROM authority_resources
+          WHERE account_id = ? AND resource_type = ? AND resource_id = ?`,
+        [accountId, resourceType, resourceId],
+      )
+    },
+
+    async putOutbox(record) {
+      await executor.runAsync(
+        `INSERT INTO authority_outbox (
+           operation_id, account_id, resource_type, resource_id, base_revision,
+           command_json, status, attempts, next_attempt_at, last_error, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (operation_id) DO UPDATE SET
+           account_id = excluded.account_id,
+           resource_type = excluded.resource_type,
+           resource_id = excluded.resource_id,
+           base_revision = excluded.base_revision,
+           command_json = excluded.command_json,
+           status = excluded.status,
+           attempts = excluded.attempts,
+           next_attempt_at = excluded.next_attempt_at,
+           last_error = excluded.last_error,
+           created_at = excluded.created_at,
+           updated_at = excluded.updated_at`,
+        [
+          record.operationId,
+          record.accountId,
+          record.resourceType,
+          record.resourceId,
+          record.baseRevision,
+          JSON.stringify(record.command),
+          record.status,
+          record.attempts,
+          record.nextAttemptAt,
+          record.lastError,
+          record.createdAt,
+          record.updatedAt,
+        ],
+      )
+    },
+
+    async deleteOutbox(operationId) {
+      await executor.runAsync(
+        'DELETE FROM authority_outbox WHERE operation_id = ?',
+        [operationId],
+      )
+    },
+
+    async putSyncState(state) {
+      await executor.runAsync(
+        `INSERT INTO authority_sync_state (
+           account_id, resource_type, resource_id, last_seen_revision,
+           last_reconciled_revision, last_refreshed_at, last_error, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (account_id, resource_type, resource_id) DO UPDATE SET
+           last_seen_revision = excluded.last_seen_revision,
+           last_reconciled_revision = excluded.last_reconciled_revision,
+           last_refreshed_at = excluded.last_refreshed_at,
+           last_error = excluded.last_error,
+           updated_at = excluded.updated_at`,
+        [
+          state.accountId,
+          state.resourceType,
+          state.resourceId,
+          state.lastSeenRevision,
+          state.lastReconciledRevision,
+          state.lastRefreshedAt,
+          state.lastError,
+          state.updatedAt,
+        ],
+      )
+    },
+
+    async deleteAccount(accountId) {
+      await executor.runAsync('DELETE FROM authority_outbox WHERE account_id = ?', [accountId])
+      await executor.runAsync('DELETE FROM authority_sync_state WHERE account_id = ?', [accountId])
+      await executor.runAsync('DELETE FROM authority_resources WHERE account_id = ?', [accountId])
+    },
+  }
+}
+
+function parseResourceRow(row: ResourceRow): StoredMobileAuthorityResource {
+  return {
+    accountId: row.account_id,
+    resourceType: row.resource_type,
+    resourceId: row.resource_id,
+    bundle: parseJson<CanonicalResourceBundle>(row.bundle_json),
+    canonicalBundle: parseJson<CanonicalResourceBundle>(row.canonical_bundle_json),
+    updatedAt: row.local_updated_at,
+  }
+}
+
+function parseOutboxRow(row: OutboxRow): AuthorityOutboxRecord {
+  return {
+    operationId: row.operation_id,
+    accountId: row.account_id,
+    resourceType: row.resource_type,
+    resourceId: row.resource_id,
+    baseRevision: row.base_revision,
+    command: parseJson<AuthorityOutboxRecord['command']>(row.command_json),
+    status: row.status,
+    attempts: row.attempts,
+    nextAttemptAt: row.next_attempt_at,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function parseSyncStateRow(row: SyncStateRow): MobileAuthoritySyncState {
+  return {
+    accountId: row.account_id,
+    resourceType: row.resource_type,
+    resourceId: row.resource_id,
+    lastSeenRevision: row.last_seen_revision,
+    lastReconciledRevision: row.last_reconciled_revision,
+    lastRefreshedAt: row.last_refreshed_at,
+    lastError: row.last_error,
+    updatedAt: row.updated_at,
+  }
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value) as T
+}

--- a/apps/mobile/lib/data/server-authority/sqliteStore.ts
+++ b/apps/mobile/lib/data/server-authority/sqliteStore.ts
@@ -1,0 +1,579 @@
+import {
+  applyCanonicalChangesToBundle,
+  applyOptimisticAuthorityCommandsToBundle,
+  type AuthorityApplyResult,
+  type AuthorityCommand,
+  type AuthorityLocalStore,
+  type AuthorityOutboxRecord,
+  type AuthorityOutboxStatus,
+  type AuthorityProductSyncSnapshot,
+  type AuthorityResourceType,
+  type CanonicalResourceBundle,
+  type CommitOptimisticAuthorityMutationInput,
+  type CommitOptimisticAuthorityMutationsInput,
+} from '@nexvoy/core'
+import type {
+  MobileAuthorityDatabase,
+  MobileAuthorityDatabaseTransaction,
+  MobileAuthoritySyncState,
+  StoredMobileAuthorityResource,
+} from './database'
+
+export interface MobileAuthorityStoreChange {
+  accountId: string
+  resourceType?: AuthorityResourceType
+  resourceId?: string
+}
+
+type MobileAuthorityStoreListener = (change: MobileAuthorityStoreChange) => void
+
+export class MobileAuthoritySqliteStore implements AuthorityLocalStore {
+  private readonly listeners = new Set<MobileAuthorityStoreListener>()
+
+  constructor(private readonly database: MobileAuthorityDatabase) {}
+
+  async getResource(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<CanonicalResourceBundle | null> {
+    return (await this.database.getResource(accountId, resourceType, resourceId))?.bundle ?? null
+  }
+
+  async putResource(accountId: string, bundle: CanonicalResourceBundle): Promise<void> {
+    let changed = false
+    await this.database.transaction(async (transaction) => {
+      const existing = await transaction.getResource(
+        accountId,
+        bundle.resourceType,
+        bundle.resourceId,
+      )
+      const currentCanonical = existing?.canonicalBundle ?? existing?.bundle
+      const candidate = existing ? preserveLocalMetadata(existing.bundle, bundle) : bundle
+      if (currentCanonical && !shouldReplaceResource(currentCanonical, candidate)) return
+
+      const remaining = await transaction.listOutbox(
+        accountId,
+        bundle.resourceType,
+        bundle.resourceId,
+      )
+      const optimisticCommands = activeOutboxCommands(remaining)
+      const projected = optimisticCommands.length > 0
+        ? {
+            ...applyOptimisticAuthorityCommandsToBundle(
+              candidate,
+              optimisticCommands,
+              candidate.serverUpdatedAt,
+            ),
+            serverUpdatedAt: candidate.serverUpdatedAt,
+          }
+        : candidate
+      await transaction.putResource(
+        toStoredResource(accountId, projected, candidate, candidate.serverUpdatedAt),
+      )
+      await transaction.putSyncState(
+        toSyncState(accountId, candidate, candidate.serverUpdatedAt),
+      )
+      changed = true
+    })
+    if (changed) this.emit({ accountId, resourceType: bundle.resourceType, resourceId: bundle.resourceId })
+  }
+
+  async commitOptimisticMutation(
+    input: CommitOptimisticAuthorityMutationInput,
+  ): Promise<void> {
+    await this.commitOptimisticMutations({
+      accountId: input.accountId,
+      baseBundle: input.baseBundle,
+      bundle: input.bundle,
+      commands: [input.command],
+      now: input.now,
+    })
+  }
+
+  async commitOptimisticMutations(
+    input: CommitOptimisticAuthorityMutationsInput,
+  ): Promise<void> {
+    if (input.commands.length === 0) throw new Error('Authority mutation batch is empty.')
+    input.commands.forEach((command) => validateMutation(input.bundle, command))
+
+    await this.database.transaction(async (transaction) => {
+      const current = await transaction.getResource(
+        input.accountId,
+        input.bundle.resourceType,
+        input.bundle.resourceId,
+      )
+      if (current && input.bundle.revision < current.bundle.revision) {
+        throw new Error('Optimistic mutation is based on a stale authority revision.')
+      }
+
+      const canonicalBundle = current?.canonicalBundle
+        ?? current?.bundle
+        ?? input.baseBundle
+        ?? input.bundle
+      await transaction.putResource(
+        toStoredResource(input.accountId, input.bundle, canonicalBundle, input.now),
+      )
+      await transaction.putSyncState(
+        toSyncState(input.accountId, canonicalBundle, input.now),
+      )
+
+      for (const command of input.commands) {
+        const existing = await transaction.getOutbox(command.operationId)
+        if (existing) {
+          if (
+            existing.accountId !== input.accountId ||
+            JSON.stringify(existing.command) !== JSON.stringify(command)
+          ) {
+            throw new Error('Authority operation id is already used by another mutation.')
+          }
+          continue
+        }
+        await transaction.putOutbox({
+          operationId: command.operationId,
+          accountId: input.accountId,
+          resourceType: input.bundle.resourceType,
+          resourceId: input.bundle.resourceId,
+          baseRevision: input.bundle.revision,
+          command,
+          status: 'pending',
+          attempts: 0,
+          nextAttemptAt: null,
+          lastError: null,
+          createdAt: command.createdAt,
+          updatedAt: input.now,
+        })
+      }
+    })
+    this.emit({
+      accountId: input.accountId,
+      resourceType: input.bundle.resourceType,
+      resourceId: input.bundle.resourceId,
+    })
+  }
+
+  async listResources(
+    accountId: string,
+    resourceType?: AuthorityResourceType,
+  ): Promise<CanonicalResourceBundle[]> {
+    return (await this.database.listResources(accountId, resourceType)).map((row) => row.bundle)
+  }
+
+  async deleteResource(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+  ): Promise<void> {
+    await this.database.transaction((transaction) =>
+      transaction.deleteResource(accountId, resourceType, resourceId),
+    )
+    this.emit({ accountId, resourceType, resourceId })
+  }
+
+  async purgeAccount(accountId: string): Promise<void> {
+    await this.database.transaction((transaction) => transaction.deleteAccount(accountId))
+    this.emit({ accountId })
+  }
+
+  async getSyncSnapshot(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+    online = true,
+  ): Promise<AuthorityProductSyncSnapshot> {
+    const rows = await this.database.listOutbox(accountId, resourceType, resourceId)
+    const conflict = rows.find((row) => row.status === 'conflict')
+    const rejected = rows.find((row) => row.status === 'rejected')
+    const pending = rows.filter(isActiveOutboxRecord)
+    if (conflict) {
+      return { status: 'conflict', pendingCount: rows.length, lastError: conflict.lastError }
+    }
+    if (rejected) {
+      return { status: 'error', pendingCount: rows.length, lastError: rejected.lastError }
+    }
+    if (!online) {
+      return { status: 'offline', pendingCount: pending.length, lastError: null }
+    }
+    return {
+      status: pending.length > 0 ? 'pending' : 'synced',
+      pendingCount: pending.length,
+      lastError: pending.find((row) => row.lastError)?.lastError ?? null,
+    }
+  }
+
+  subscribe(listener: MobileAuthorityStoreListener): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  async setResourceRole(
+    accountId: string,
+    resourceType: AuthorityResourceType,
+    resourceId: string,
+    role: string,
+  ): Promise<CanonicalResourceBundle | null> {
+    let updated: CanonicalResourceBundle | null = null
+    await this.database.transaction(async (transaction) => {
+      const row = await transaction.getResource(accountId, resourceType, resourceId)
+      if (!row) return
+      const bundle = { ...row.bundle, data: { ...row.bundle.data, _role: role } }
+      const canonicalBundle = {
+        ...row.canonicalBundle,
+        data: { ...row.canonicalBundle.data, _role: role },
+      }
+      await transaction.putResource({ ...row, bundle, canonicalBundle })
+      updated = bundle
+    })
+    if (updated) this.emit({ accountId, resourceType, resourceId })
+    return updated
+  }
+
+  async getNextRetryAt(accountId: string): Promise<string | null> {
+    const retryAt = (await this.database.listOutbox(accountId))
+      .filter((row) => row.status === 'retryable' && row.nextAttemptAt)
+      .map((row) => row.nextAttemptAt as string)
+      .sort()[0]
+    return retryAt ?? null
+  }
+
+  async listReadyOutbox(
+    accountId: string,
+    now: string,
+    limit: number,
+  ): Promise<AuthorityOutboxRecord[]> {
+    return (await this.database.listOutbox(accountId))
+      .filter((row) => {
+        if (row.status === 'pending') return true
+        return row.status === 'retryable' && (!row.nextAttemptAt || row.nextAttemptAt <= now)
+      })
+      .sort(compareOutbox)
+      .slice(0, Math.max(0, limit))
+  }
+
+  async markSending(accountId: string, operationIds: string[], now: string): Promise<void> {
+    await this.updateOutbox(accountId, operationIds, (row) => ({
+      ...row,
+      status: 'sending',
+      updatedAt: now,
+    }))
+  }
+
+  async applyAcknowledgement(
+    accountId: string,
+    result: AuthorityApplyResult,
+    now: string,
+  ): Promise<void> {
+    await this.database.transaction(async (transaction) => {
+      const existing = await transaction.getResource(
+        accountId,
+        result.resourceType,
+        result.resourceId,
+      )
+      const existingCanonical = existing?.canonicalBundle ?? existing?.bundle ?? null
+      const resultBundle = result.bundle && existing
+        ? preserveLocalMetadata(existing.bundle, result.bundle)
+        : result.bundle
+      let canonicalBundle = existingCanonical
+      if (resultBundle && (!existingCanonical || shouldReplaceResource(existingCanonical, resultBundle))) {
+        canonicalBundle = resultBundle
+      } else if (existingCanonical && result.revision >= existingCanonical.revision) {
+        canonicalBundle = applyCanonicalChangesToBundle(existingCanonical, result, now)
+      } else if (!existingCanonical) {
+        throw new Error('Cannot acknowledge authority commands without a local resource cache.')
+      }
+      if (!canonicalBundle) {
+        throw new Error('Canonical authority state is unavailable after acknowledgement.')
+      }
+
+      for (const operationId of result.acknowledgedOperationIds) {
+        const row = await transaction.getOutbox(operationId)
+        if (row?.accountId === accountId) await transaction.deleteOutbox(operationId)
+      }
+
+      const remaining = await transaction.listOutbox(
+        accountId,
+        result.resourceType,
+        result.resourceId,
+      )
+      for (const row of remaining) {
+        if (
+          (row.status === 'pending' || row.status === 'retryable') &&
+          row.baseRevision < canonicalBundle.revision
+        ) {
+          await transaction.putOutbox({
+            ...row,
+            baseRevision: canonicalBundle.revision,
+            updatedAt: now,
+          })
+        }
+      }
+
+      const projection = activeOutboxCommands(remaining).length > 0
+        ? applyOptimisticAuthorityCommandsToBundle(
+            canonicalBundle,
+            activeOutboxCommands(remaining),
+            now,
+          )
+        : canonicalBundle
+      await transaction.putResource(
+        toStoredResource(accountId, projection, canonicalBundle, now),
+      )
+      await transaction.putSyncState(toSyncState(accountId, canonicalBundle, now))
+    })
+    this.emit({
+      accountId,
+      resourceType: result.resourceType,
+      resourceId: result.resourceId,
+    })
+  }
+
+  async markRetryable(
+    accountId: string,
+    operationIds: string[],
+    errorCode: string,
+    nextAttemptAt: string,
+    now: string,
+  ): Promise<void> {
+    await this.updateOutbox(accountId, operationIds, (row) => ({
+      ...row,
+      status: 'retryable',
+      attempts: row.attempts + 1,
+      nextAttemptAt,
+      lastError: errorCode,
+      updatedAt: now,
+    }))
+  }
+
+  async markRejected(
+    accountId: string,
+    operationIds: string[],
+    errorCode: string,
+    now: string,
+  ): Promise<void> {
+    await this.updateOutbox(accountId, operationIds, (row) => ({
+      ...row,
+      status: 'rejected',
+      lastError: errorCode,
+      nextAttemptAt: null,
+      updatedAt: now,
+    }))
+  }
+
+  async markConflict(
+    accountId: string,
+    operationIds: string[],
+    bundle: CanonicalResourceBundle | null,
+    now: string,
+  ): Promise<void> {
+    await this.database.transaction(async (transaction) => {
+      if (bundle) {
+        const existing = await transaction.getResource(
+          accountId,
+          bundle.resourceType,
+          bundle.resourceId,
+        )
+        const canonicalBundle = existing ? preserveLocalMetadata(existing.bundle, bundle) : bundle
+        await transaction.putResource(
+          toStoredResource(accountId, canonicalBundle, canonicalBundle, now),
+        )
+        await transaction.putSyncState({
+          ...toSyncState(accountId, canonicalBundle, now),
+          lastError: 'authority_revision_conflict',
+        })
+      }
+      for (const operationId of operationIds) {
+        const row = await transaction.getOutbox(operationId)
+        if (row?.accountId === accountId) {
+          await transaction.putOutbox({
+            ...row,
+            status: 'conflict',
+            lastError: 'authority_revision_conflict',
+            nextAttemptAt: null,
+            updatedAt: now,
+          })
+        }
+      }
+    })
+    this.emit({ accountId })
+  }
+
+  async recoverStaleSending(
+    accountId: string,
+    staleBefore: string,
+    now: string,
+  ): Promise<number> {
+    const rows = (await this.database.listOutbox(accountId)).filter(
+      (row) => row.status === 'sending' && row.updatedAt < staleBefore,
+    )
+    if (rows.length === 0) return 0
+    await this.updateOutbox(
+      accountId,
+      rows.map((row) => row.operationId),
+      (row) => ({
+        ...row,
+        status: 'retryable',
+        lastError: 'authority_sending_recovered',
+        nextAttemptAt: now,
+        updatedAt: now,
+      }),
+    )
+    return rows.length
+  }
+
+  async promoteGuestAccount(
+    guestAccountId: string,
+    accountId: string,
+    now: string,
+  ): Promise<void> {
+    if (guestAccountId === accountId) return
+    await this.database.transaction(async (transaction) => {
+      const guestResources = await transaction.listResources(guestAccountId)
+      const guestOutbox = await transaction.listOutbox(guestAccountId)
+      const guestSyncStates = await transaction.listSyncStates(guestAccountId)
+
+      for (const guestResource of guestResources) {
+        const destination = await transaction.getResource(
+          accountId,
+          guestResource.resourceType,
+          guestResource.resourceId,
+        )
+        if (!destination || shouldReplaceResource(destination.bundle, guestResource.bundle)) {
+          await transaction.putResource({ ...guestResource, accountId, updatedAt: now })
+        }
+      }
+
+      for (const guestRecord of guestOutbox) {
+        const existing = await transaction.getOutbox(guestRecord.operationId)
+        if (existing && existing.accountId !== guestAccountId) {
+          throw new Error('Guest authority operation collides with an account operation.')
+        }
+        await transaction.putOutbox({
+          ...guestRecord,
+          accountId,
+          status: normalizePromotedStatus(guestRecord.status),
+          updatedAt: now,
+        })
+      }
+
+      for (const guestState of guestSyncStates) {
+        const destination = await transaction.getSyncState(
+          accountId,
+          guestState.resourceType,
+          guestState.resourceId,
+        )
+        if (!destination || guestState.lastSeenRevision >= destination.lastSeenRevision) {
+          await transaction.putSyncState({ ...guestState, accountId, updatedAt: now })
+        }
+      }
+
+      for (const guestResource of guestResources) {
+        await transaction.deleteResource(
+          guestAccountId,
+          guestResource.resourceType,
+          guestResource.resourceId,
+        )
+      }
+    })
+    this.emit({ accountId })
+  }
+
+  close(): Promise<void> {
+    this.listeners.clear()
+    return this.database.close()
+  }
+
+  private async updateOutbox(
+    accountId: string,
+    operationIds: string[],
+    transform: (row: AuthorityOutboxRecord) => AuthorityOutboxRecord,
+  ): Promise<void> {
+    await this.database.transaction(async (transaction) => {
+      for (const operationId of operationIds) {
+        const row = await transaction.getOutbox(operationId)
+        if (row?.accountId === accountId) await transaction.putOutbox(transform(row))
+      }
+    })
+    this.emit({ accountId })
+  }
+
+  private emit(change: MobileAuthorityStoreChange): void {
+    this.listeners.forEach((listener) => listener(change))
+  }
+}
+
+function toStoredResource(
+  accountId: string,
+  bundle: CanonicalResourceBundle,
+  canonicalBundle: CanonicalResourceBundle,
+  updatedAt: string,
+): StoredMobileAuthorityResource {
+  return {
+    accountId,
+    resourceType: bundle.resourceType,
+    resourceId: bundle.resourceId,
+    bundle,
+    canonicalBundle,
+    updatedAt,
+  }
+}
+
+function toSyncState(
+  accountId: string,
+  bundle: CanonicalResourceBundle,
+  updatedAt: string,
+): MobileAuthoritySyncState {
+  return {
+    accountId,
+    resourceType: bundle.resourceType,
+    resourceId: bundle.resourceId,
+    lastSeenRevision: bundle.revision,
+    lastReconciledRevision: bundle.revision,
+    lastRefreshedAt: updatedAt,
+    lastError: null,
+    updatedAt,
+  }
+}
+
+function activeOutboxCommands(rows: AuthorityOutboxRecord[]): AuthorityCommand[] {
+  return rows.filter(isActiveOutboxRecord).sort(compareOutbox).map((row) => row.command)
+}
+
+function isActiveOutboxRecord(row: AuthorityOutboxRecord): boolean {
+  return row.status === 'pending' || row.status === 'sending' || row.status === 'retryable'
+}
+
+function shouldReplaceResource(
+  current: CanonicalResourceBundle,
+  candidate: CanonicalResourceBundle,
+): boolean {
+  return (
+    candidate.revision > current.revision ||
+    (candidate.revision === current.revision &&
+      candidate.serverUpdatedAt >= current.serverUpdatedAt)
+  )
+}
+
+function preserveLocalMetadata(
+  current: CanonicalResourceBundle,
+  candidate: CanonicalResourceBundle,
+): CanonicalResourceBundle {
+  const role = current.data._role
+  if (candidate.data._role !== undefined || role === undefined) return candidate
+  return { ...candidate, data: { ...candidate.data, _role: role } }
+}
+
+function validateMutation(bundle: CanonicalResourceBundle, command: AuthorityCommand): void {
+  const commandResourceType = command.entityType.startsWith('template') ? 'template' : 'trip'
+  if (command.resourceId !== bundle.resourceId || commandResourceType !== bundle.resourceType) {
+    throw new Error('Authority command and optimistic bundle do not match.')
+  }
+}
+
+function compareOutbox(left: AuthorityOutboxRecord, right: AuthorityOutboxRecord): number {
+  return left.createdAt.localeCompare(right.createdAt) ||
+    left.operationId.localeCompare(right.operationId)
+}
+
+function normalizePromotedStatus(status: AuthorityOutboxStatus): AuthorityOutboxStatus {
+  return status === 'sending' ? 'retryable' : status
+}

--- a/apps/mobile/lib/data/server-authority/syncService.ts
+++ b/apps/mobile/lib/data/server-authority/syncService.ts
@@ -1,0 +1,251 @@
+import { AppState, Platform } from 'react-native'
+import * as Network from 'expo-network'
+import {
+  ServerAuthoritySyncCoordinator,
+  createServerAuthorityRepository,
+  type AuthorityFlushResult,
+  type AuthorityResourceType,
+} from '@nexvoy/core'
+import { supabase } from '@/lib/supabase'
+import {
+  deleteMobileAuthorityDatabase,
+  openMobileAuthorityDatabase,
+} from './sqliteDatabase'
+import { MobileAuthoritySqliteStore } from './sqliteStore'
+import {
+  subscribeMobileAuthorityInvalidation,
+  type MobileAuthorityInvalidationSubscription,
+} from './realtimeInvalidation'
+
+interface MobileAuthorityRuntime {
+  store: MobileAuthoritySqliteStore
+  coordinator: ServerAuthoritySyncCoordinator
+}
+
+let runtimePromise: Promise<MobileAuthorityRuntime> | null = null
+let activeAccountId: string | null = null
+let appStateSubscription: ReturnType<typeof AppState.addEventListener> | null = null
+let networkSubscription: ReturnType<typeof Network.addNetworkStateListener> | null = null
+let retryTimer: ReturnType<typeof setTimeout> | null = null
+const activeRealtimeSubscriptions = new Set<MobileAuthorityInvalidationSubscription>()
+
+export async function getMobileAuthorityStore(): Promise<MobileAuthoritySqliteStore> {
+  return (await getRuntime()).store
+}
+
+export async function startMobileAuthoritySync(accountId: string): Promise<void> {
+  if (!isSupportedNativePlatform()) return
+  if (activeAccountId && activeAccountId !== accountId) {
+    await closeRealtimeSubscriptions()
+    clearRetryTimer()
+  }
+  activeAccountId = accountId
+  ensureLifecycleListeners()
+  await flushMobileAuthorityOutbox()
+}
+
+export async function stopMobileAuthoritySync(): Promise<void> {
+  activeAccountId = null
+  clearRetryTimer()
+  appStateSubscription?.remove()
+  appStateSubscription = null
+  networkSubscription?.remove()
+  networkSubscription = null
+  await closeRealtimeSubscriptions()
+}
+
+export async function flushMobileAuthorityOutbox(): Promise<AuthorityFlushResult | null> {
+  const accountId = activeAccountId
+  if (!accountId) return null
+  if (!await isNetworkOnline()) return null
+  const result = await performFlush(accountId)
+  if (result && activeAccountId === accountId) {
+    try {
+      await scheduleNextRetry(accountId)
+    } catch (error) {
+      reportAuthoritySyncError(error)
+    }
+  }
+  return result
+}
+
+export async function flushMobileAuthorityAccount(
+  accountId: string,
+): Promise<AuthorityFlushResult | null> {
+  return flushAccount(accountId)
+}
+
+export async function notifyMobileAuthorityMutationCommitted(): Promise<AuthorityFlushResult | null> {
+  return flushMobileAuthorityOutbox()
+}
+
+export async function enterMobileAuthorityResource(
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+): Promise<void> {
+  const accountId = activeAccountId
+  if (!accountId) return
+  const runtime = await getRuntime()
+  await runtime.coordinator.refreshResource(accountId, resourceType, resourceId)
+  await flushMobileAuthorityOutbox()
+}
+
+export async function watchMobileAuthorityResource(
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+): Promise<MobileAuthorityInvalidationSubscription | null> {
+  const accountId = activeAccountId
+  if (!accountId) return null
+  const runtime = await getRuntime()
+  await runtime.coordinator.refreshResource(accountId, resourceType, resourceId)
+  const subscription = await subscribeMobileAuthorityInvalidation({
+    supabase,
+    accountId,
+    resourceType,
+    resourceId,
+    store: runtime.store,
+    coordinator: runtime.coordinator,
+    onError: reportAuthoritySyncError,
+  })
+  const tracked: MobileAuthorityInvalidationSubscription = {
+    topic: subscription.topic,
+    async unsubscribe() {
+      activeRealtimeSubscriptions.delete(tracked)
+      await subscription.unsubscribe()
+    },
+  }
+  activeRealtimeSubscriptions.add(tracked)
+  return tracked
+}
+
+export async function promoteMobileAuthorityGuestAccount(
+  guestAccountId: string,
+  accountId: string,
+): Promise<AuthorityFlushResult> {
+  return (await getRuntime()).coordinator.promoteGuestAccount(guestAccountId, accountId)
+}
+
+export async function purgeMobileAuthorityResource(
+  accountId: string,
+  resourceType: AuthorityResourceType,
+  resourceId: string,
+): Promise<void> {
+  if (activeAccountId === accountId) {
+    const topic = `${resourceType}:${resourceId}`
+    const matchingSubscriptions = [...activeRealtimeSubscriptions]
+      .filter((subscription) => subscription.topic === topic)
+    await Promise.allSettled(
+      matchingSubscriptions.map((subscription) => subscription.unsubscribe()),
+    )
+  }
+  await (await getRuntime()).store.deleteResource(accountId, resourceType, resourceId)
+}
+
+export async function purgeMobileAuthorityAccount(accountId: string): Promise<void> {
+  if (!isSupportedNativePlatform()) return
+  if (activeAccountId === accountId) {
+    activeAccountId = null
+    clearRetryTimer()
+    await closeRealtimeSubscriptions()
+  }
+  const runtime = await getRuntime()
+  try {
+    await runtime.store.purgeAccount(accountId)
+  } catch {
+    // Withdrawal must not leave readable product data behind if row-level purge fails.
+    await runtime.store.close()
+    runtimePromise = null
+    await deleteMobileAuthorityDatabase()
+  }
+}
+
+async function getRuntime(): Promise<MobileAuthorityRuntime> {
+  if (!runtimePromise) {
+    runtimePromise = openMobileAuthorityDatabase().then((database) => {
+      const store = new MobileAuthoritySqliteStore(database)
+      return {
+        store,
+        coordinator: new ServerAuthoritySyncCoordinator({
+          repository: createServerAuthorityRepository(supabase),
+          store,
+        }),
+      }
+    })
+    runtimePromise.catch(() => {
+      runtimePromise = null
+    })
+  }
+  return runtimePromise
+}
+
+function ensureLifecycleListeners(): void {
+  if (!appStateSubscription) {
+    appStateSubscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void flushMobileAuthorityOutbox().catch(reportAuthoritySyncError)
+    })
+  }
+  if (!networkSubscription) {
+    networkSubscription = Network.addNetworkStateListener((state) => {
+      if (isOnline(state)) void flushMobileAuthorityOutbox().catch(reportAuthoritySyncError)
+    })
+  }
+}
+
+async function flushAccount(accountId: string): Promise<AuthorityFlushResult | null> {
+  if (!await isNetworkOnline()) return null
+  return performFlush(accountId)
+}
+
+async function performFlush(accountId: string): Promise<AuthorityFlushResult | null> {
+  try {
+    return await (await getRuntime()).coordinator.flush(accountId)
+  } catch (error) {
+    reportAuthoritySyncError(error)
+    return null
+  }
+}
+
+async function scheduleNextRetry(accountId: string): Promise<void> {
+  clearRetryTimer()
+  const retryAt = await (await getRuntime()).store.getNextRetryAt(accountId)
+  if (!retryAt || activeAccountId !== accountId) return
+  const retryTimestamp = Date.parse(retryAt)
+  if (!Number.isFinite(retryTimestamp)) return
+  const delay = Math.max(0, retryTimestamp - Date.now())
+  retryTimer = setTimeout(() => {
+    retryTimer = null
+    void flushMobileAuthorityOutbox().catch(reportAuthoritySyncError)
+  }, Math.min(delay, 2_147_483_647))
+}
+
+function clearRetryTimer(): void {
+  if (retryTimer) clearTimeout(retryTimer)
+  retryTimer = null
+}
+
+async function closeRealtimeSubscriptions(): Promise<void> {
+  const subscriptions = [...activeRealtimeSubscriptions]
+  activeRealtimeSubscriptions.clear()
+  await Promise.allSettled(subscriptions.map((subscription) => subscription.unsubscribe()))
+}
+
+function isOnline(state: Network.NetworkState): boolean {
+  return state.isConnected !== false && state.isInternetReachable !== false
+}
+
+function isSupportedNativePlatform(): boolean {
+  return Platform.OS === 'android' || Platform.OS === 'ios'
+}
+
+async function isNetworkOnline(): Promise<boolean> {
+  try {
+    return isOnline(await Network.getNetworkStateAsync())
+  } catch (error) {
+    reportAuthoritySyncError(error)
+    return false
+  }
+}
+
+function reportAuthoritySyncError(error: unknown): void {
+  console.warn('[mobile authority sync failed]', error)
+}

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -8,6 +8,9 @@ const monorepoRoot = path.resolve(projectRoot, '../..')
 
 const config = getDefaultConfig(projectRoot)
 
+// expo-sqlite Web worker가 포함하는 wa-sqlite WASM을 Metro asset으로 번들링한다.
+config.resolver.assetExts = [...new Set([...config.resolver.assetExts, 'wasm'])]
+
 // 1) 모노레포 루트 전체를 감시하여 @nexvoy/* workspace 패키지 변경 감지
 config.watchFolders = [monorepoRoot]
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,6 +11,7 @@
     "build": "expo export --platform all --output-dir dist",
     "build:development:android:local": "node scripts/eas-local-build.mjs --profile development --platform android --local --clear-cache",
     "build:preview:android:local": "node scripts/eas-local-build.mjs --profile preview --platform android --local --clear-cache",
+    "test:authority": "tsx --test lib/data/server-authority/__tests__/*.test.ts",
     "typecheck": "tsc --noEmit",
     "lint": "expo lint"
   },
@@ -28,7 +29,7 @@
     "@react-native-firebase/app": "^25.1.0",
     "@react-native-picker/picker": "^2.11.1",
     "@supabase/supabase-js": "^2.97.0",
-    "expo": "~54.0.35",
+    "expo": "~54.0.36",
     "expo-auth-session": "^7.0.11",
     "expo-background-task": "~1.0.10",
     "expo-build-properties": "^1.0.10",
@@ -38,9 +39,11 @@
     "expo-font": "^14.0.12",
     "expo-linking": "~8.0.12",
     "expo-modules-core": "~3.0.30",
+    "expo-network": "~8.0.8",
     "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.24",
     "expo-secure-store": "~15.0.8",
+    "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",
     "expo-task-manager": "~14.0.9",
     "expo-web-browser": "^15.0.11",
@@ -66,6 +69,7 @@
     "babel-preset-expo": "^54.0.11",
     "eslint": "^9.39.4",
     "eslint-config-expo": "~10.0.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.3.3"
   }
 }

--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -25,4 +25,6 @@
 - `docs/refactor/tasks/TASK-048-web-indexeddb-cache-outbox.md`
 - `docs/refactor/tasks/TASK-049-realtime-invalidation-and-revision-recovery.md`
 - `docs/refactor/tasks/TASK-050-web-server-authority-product-cutover.md`
+- `docs/refactor/tasks/TASK-051-mobile-sqlite-cache-outbox.md`
+- `docs/refactor/runbooks/TASK-051-mobile-sqlite-authority-smoke.md`
 - `docs/refactor/TECHNICAL-SPEC.md`

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -37,6 +37,15 @@
 - 기능 플래그로 document-primary 경로를 롤백 경로로 유지한다. 실제 legacy runtime 삭제는 TASK-055 범위다.
 - 단위 테스트, typecheck, Web/Mobile build와 Playwright discovery는 통과했다. 다중 사용자 E2E 실제 실행은 로컬 Supabase 환경이 필요하다.
 
+## 2026-07-17 TASK-051 구현 완료
+
+- Mobile에 account/resource-scoped SQLite v1 schema와 WAL 기반 transaction adapter를 추가했다.
+- optimistic resource 갱신과 outbox append, canonical ack/rebase, retry/conflict, guest promotion을 원자 처리한다.
+- 로그인, foreground, network reconnect, retry timer, OS background opportunity에서 공통 authority coordinator를 flush한다.
+- 로그아웃은 account cache를 보존하고 계정 전환은 namespace로 격리한다. withdrawal/revoke는 account/resource를 purge한다.
+- private Realtime invalidation과 revision gap recovery adapter를 준비했다. 상세 화면 구독과 제품 repository 전환은 TASK-052 범위다.
+- authority 단위 테스트, 전체 typecheck, Web build, 전 플랫폼 Expo export와 Android development build가 통과했다.
+
 2026-07-16 초대 흐름 재점검:
 
 - 이메일 초대와 기존 로그인 후 Accept UI가 서로 다른 registry를 사용하고 있음을 확인했다.

--- a/docs/refactor/runbooks/TASK-051-mobile-sqlite-authority-smoke.md
+++ b/docs/refactor/runbooks/TASK-051-mobile-sqlite-authority-smoke.md
@@ -1,0 +1,35 @@
+# TASK-051 Mobile SQLite Authority Smoke Test
+
+## 준비
+
+1. 최신 development build를 Android 또는 iOS 기기에 설치한다.
+2. DEV Supabase 계정 A로 로그인한다.
+3. TASK-052 제품 경로 전환 전에는 화면 대신 authority adapter 테스트와 DB 생성 여부를 확인한다.
+
+## 자동 검증
+
+```bash
+pnpm --filter nexvoy-app test:authority
+pnpm --filter nexvoy-app typecheck
+pnpm --filter nexvoy-app lint
+pnpm --filter nexvoy-app build
+pnpm --filter nexvoy-app build:development:android:local
+```
+
+## 기기 Smoke
+
+1. 앱을 실행하고 계정 A로 로그인한다.
+2. 앱을 background로 보냈다가 foreground로 복귀한다. 앱 종료나 반복 flush 오류가 없어야 한다.
+3. 비행기 모드를 켰다가 끈다. reconnect 시 authority flush가 한 번 재개되어야 한다.
+4. 로그아웃 후 계정 B로 로그인한다. 계정 A namespace의 resource/outbox가 계정 B 조회에 노출되면 안 된다.
+5. 계정 A로 다시 로그인한다. logout만으로 계정 A cache가 삭제되면 안 된다.
+6. 회원 탈퇴를 완료하면 계정 A의 `authority_resources`, `authority_outbox`, `authority_sync_state`가 모두 삭제되어야 한다.
+
+Android debug build에서는 필요 시 `adb shell run-as xyz.nexvoy.app`로 앱 DB 디렉터리를 확인한다. OS background 실행은 보장하지 않으므로 중단된 `sending` row가 다음 foreground에서 `retryable`로 회수되는지를 최종 기준으로 삼는다.
+
+## TASK-052 인계
+
+- 화면 repository는 `getMobileAuthorityStore()`를 사용한다.
+- mutation commit 후 `notifyMobileAuthorityMutationCommitted()`를 호출한다.
+- 상세 화면 진입/해제 시 `watchMobileAuthorityResource()` 구독을 생성하고 해제한다.
+- 멤버 revoke 시 `purgeMobileAuthorityResource()`로 해당 cache/outbox와 Realtime 구독을 제거한다.

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -119,7 +119,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-048-web-indexeddb-cache-outbox.md` | 완료 | Web account-scoped IndexedDB cache와 transactional outbox |
 | `TASK-049-realtime-invalidation-and-revision-recovery.md` | 완료 | private Broadcast invalidation과 Web revision gap 복구 |
 | `TASK-050-web-server-authority-product-cutover.md` | 구현 완료 | Web 전체 기능 server-authority 전환, 로컬 Supabase E2E 실행 대기 |
-| `TASK-051-mobile-sqlite-cache-outbox.md` | 대기 | Mobile SQLite cache/outbox와 Realtime adapter |
+| `TASK-051-mobile-sqlite-cache-outbox.md` | 구현 완료 | Mobile SQLite cache/outbox, lifecycle flush, Realtime adapter, Android development build |
 | `TASK-052-mobile-server-authority-product-cutover.md` | 대기 | Mobile 전체 기능 server-authority 제품 경로 전환 |
 | `TASK-053-membership-invitation-without-document-keys.md` | 대기 | document key 없는 membership/invitation/role/revoke |
 | `TASK-054-direct-asset-storage-and-delivery.md` | 대기 | Storage 직접 업로드, thumbnail, CDN, orphan cleanup |
@@ -216,7 +216,7 @@ rotating room secret 보안 하드닝을 완료했다.
 - [x] `TASK-048-web-indexeddb-cache-outbox.md`: Web IndexedDB cache/outbox adapter
 - [x] `TASK-049-realtime-invalidation-and-revision-recovery.md`: Realtime invalidation과 Web revision recovery
 - [x] `TASK-050-web-server-authority-product-cutover.md`: Web 전체 제품 경로 전환 (로컬 Supabase E2E 실행 대기)
-- [ ] `TASK-051-mobile-sqlite-cache-outbox.md`: Mobile SQLite cache/outbox와 Realtime adapter
+- [x] `TASK-051-mobile-sqlite-cache-outbox.md`: Mobile SQLite cache/outbox와 Realtime adapter
 - [ ] `TASK-052-mobile-server-authority-product-cutover.md`: Mobile 전체 제품 경로 전환
 - [ ] `TASK-053-membership-invitation-without-document-keys.md`: keyless membership/invitation 전환
 - [ ] `TASK-054-direct-asset-storage-and-delivery.md`: asset 직접 전송과 egress 최적화

--- a/docs/refactor/tasks/TASK-051-mobile-sqlite-cache-outbox.md
+++ b/docs/refactor/tasks/TASK-051-mobile-sqlite-cache-outbox.md
@@ -1,6 +1,6 @@
 # TASK-051: Mobile SQLite Cache and Transactional Outbox
 
-- 상태: 대기
+- 상태: 구현 완료
 
 ## 목적
 
@@ -15,13 +15,13 @@ queue의 비원자성을 제거하고 Web과 동일한 command/revision 계약�
 - foreground/network reconnect/background opportunity sync
 - batch RPC flush와 canonical ack 적용
 - TASK-049 계약을 사용하는 Mobile Realtime subscription/revision recovery adapter
-- account switch/logout/revoke purge
+- account switch namespace 격리, logout cache 보존, withdrawal/revoke purge
 - native lifecycle 및 실제 개발 빌드 검증
 
 제외:
 
 - Mobile 화면 repository cutover
-- Realtime subscription
+- 제품 화면의 Realtime subscription 연결(TASK-052)
 - AsyncStorage/Yjs/crypto 파일 제거
 
 ## 선행 조건
@@ -47,9 +47,10 @@ queue의 비원자성을 제거하고 Web과 동일한 command/revision 계약�
 5. network reconnect, foreground, background execution opportunity에서 제한된 batch를 flush한다.
 6. OS background 제한을 보장처럼 표현하지 않고 다음 foreground에서도 반드시 이어서 처리한다.
 7. canonical ack와 revision을 transaction으로 반영하고 terminal error를 보존한다.
-8. 계정 전환과 revoke에서 활성 query/cache/outbox가 격리·정리되는지 검증한다.
+8. 계정 전환에서는 namespace를 격리하고 logout에서는 cache를 보존한다. withdrawal은 account namespace를,
+   revoke는 해당 resource namespace를 purge한다.
 9. guest namespace의 draft는 로그인 시 authenticated create command로 승격한다.
-10. active detail Realtime invalidation과 foreground/reconnect revision recovery를 연결한다.
+10. Realtime invalidation/revision recovery adapter를 구현한다. active detail 화면 연결은 TASK-052에서 수행한다.
 11. Android/iOS development build와 Expo export를 검증한다.
 
 ## 데이터 고려사항

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,13 +19,13 @@ importers:
         version: 8.0.0
       '@config-plugins/react-native-webrtc':
         specifier: 13.0.0
-        version: 13.0.0(expo@54.0.35)
+        version: 13.0.0(expo@54.0.36)
       '@expo/metro-runtime':
         specifier: ~6.1.2
-        version: 6.1.2(expo@54.0.35)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 6.1.2(expo@54.0.36)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/vector-icons':
         specifier: ^15.1.1
-        version: 15.1.1(expo-font@14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 15.1.1(expo-font@14.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@nexvoy/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -40,13 +40,13 @@ importers:
         version: 2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       '@react-native-community/datetimepicker':
         specifier: ^8.4.4
-        version: 8.4.4(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 8.4.4(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@react-native-firebase/analytics':
         specifier: ^25.1.0
-        version: 25.1.0(@react-native-firebase/app@25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.35)
+        version: 25.1.0(@react-native-firebase/app@25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.36)
       '@react-native-firebase/app':
         specifier: ^25.1.0
-        version: 25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@react-native-picker/picker':
         specifier: ^2.11.1
         version: 2.11.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -54,53 +54,59 @@ importers:
         specifier: ^2.97.0
         version: 2.98.0
       expo:
-        specifier: ~54.0.35
-        version: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+        specifier: ~54.0.36
+        version: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-auth-session:
         specifier: ^7.0.11
-        version: 7.0.11(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 7.0.11(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-background-task:
         specifier: ~1.0.10
-        version: 1.0.10(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+        version: 1.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       expo-build-properties:
         specifier: ^1.0.10
-        version: 1.0.10(expo@54.0.35)
+        version: 1.0.10(expo@54.0.36)
       expo-clipboard:
         specifier: ^8.0.8
-        version: 8.0.8(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 8.0.8(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-constants:
         specifier: ~18.0.13
-        version: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+        version: 18.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       expo-dev-client:
         specifier: ~6.0.21
-        version: 6.0.21(expo@54.0.35)
+        version: 6.0.21(expo@54.0.36)
       expo-font:
         specifier: ^14.0.12
-        version: 14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 14.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-linking:
         specifier: ~8.0.12
-        version: 8.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 8.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-modules-core:
         specifier: ~3.0.30
         version: 3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-network:
+        specifier: ~8.0.8
+        version: 8.0.8(expo@54.0.36)(react@19.1.0)
       expo-notifications:
         specifier: ~0.32.17
-        version: 0.32.17(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+        version: 0.32.17(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-router:
         specifier: ~6.0.24
-        version: 6.0.24(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.35)(react-dom@19.1.0(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 6.0.24(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.36)(react-dom@19.1.0(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-secure-store:
         specifier: ~15.0.8
-        version: 15.0.8(expo@54.0.35)
+        version: 15.0.8(expo@54.0.36)
+      expo-sqlite:
+        specifier: ~16.0.10
+        version: 16.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-status-bar:
         specifier: ~3.0.9
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-task-manager:
         specifier: ~14.0.9
-        version: 14.0.9(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+        version: 14.0.9(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       expo-web-browser:
         specifier: ^15.0.11
-        version: 15.0.11(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+        version: 15.0.11(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       metro-runtime:
         specifier: ^0.85.0
         version: 0.85.0
@@ -124,7 +130,7 @@ importers:
         version: 1.20.1(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-quick-crypto:
         specifier: ^1.1.5
-        version: 1.1.5(expo-build-properties@1.0.10(expo@54.0.35))(expo@54.0.35)(react-native-nitro-modules@0.36.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-quick-base64@3.0.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 1.1.5(expo-build-properties@1.0.10(expo@54.0.36))(expo@54.0.36)(react-native-nitro-modules@0.36.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-quick-base64@3.0.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-safe-area-context:
         specifier: 5.6.2
         version: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -155,13 +161,16 @@ importers:
         version: 19.1.17
       babel-preset-expo:
         specifier: ^54.0.11
-        version: 54.0.11(@babel/core@7.29.0)(@babel/runtime@8.0.0)(expo@54.0.35)(react-refresh@0.14.2)
+        version: 54.0.11(@babel/core@7.29.0)(@babel/runtime@8.0.0)(expo@54.0.36)(react-refresh@0.14.2)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4
       eslint-config-expo:
         specifier: ~10.0.0
         version: 10.0.0(eslint@9.39.4)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1251,8 +1260,8 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@expo/cli@54.0.25':
-    resolution: {integrity: sha512-WnUqIb8oMBhtwSfIqdCHCzcaDIpLNXItRVd5miuvWi4GO0SGo89PSsAkbVJ+LJgcaY+v5rbgMELJS9I/CqOulA==}
+  '@expo/cli@54.0.26':
+    resolution: {integrity: sha512-BjsAoKINLEo3LRE+sDC6FCgjxuOWsyfOFOKz0txrbEcxSatzIjJDVuX8XaTdmeicZdcoN524yl1sfwCWfxhYMw==}
     hasBin: true
     peerDependencies:
       expo: '*'
@@ -1270,11 +1279,17 @@ packages:
   '@expo/config-plugins@54.0.4':
     resolution: {integrity: sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==}
 
+  '@expo/config-plugins@54.0.5':
+    resolution: {integrity: sha512-aWQ3sViNRoQWw6So4A2qhWCt24CuGBK6MrRHI1AG+V6/NQAjIZCHaSvcXK2gXKpmisRhTSUWaKPIgLJQFB+AeQ==}
+
   '@expo/config-types@54.0.10':
     resolution: {integrity: sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==}
 
   '@expo/config@12.0.13':
     resolution: {integrity: sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==}
+
+  '@expo/config@12.0.14':
+    resolution: {integrity: sha512-3dfbBd9LnPDgyylhCgkOsaG8Adg52uOVOTQYH5lf23a/t8M5eQpXKCvzUarrf62B78057n2NnkiofK9TfPgvzw==}
 
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
@@ -1293,6 +1308,9 @@ packages:
   '@expo/env@2.0.11':
     resolution: {integrity: sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==}
 
+  '@expo/env@2.0.12':
+    resolution: {integrity: sha512-wVfzeBGlUohZG5kS8QCqXurpuWZFJEkBB1wXCifai3EZ/Llcg/VMTiUCpAgHImD3lI7GIU3V1uI64c04XIo98Q==}
+
   '@expo/fingerprint@0.15.5':
     resolution: {integrity: sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==}
     hasBin: true
@@ -1306,8 +1324,8 @@ packages:
   '@expo/json-file@10.2.0':
     resolution: {integrity: sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==}
 
-  '@expo/metro-config@54.0.16':
-    resolution: {integrity: sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==}
+  '@expo/metro-config@54.0.17':
+    resolution: {integrity: sha512-PQFgQCZGY0DffZUvBzJttDPreZfHrQakaBlKjnvOUMNXbDna+TYmg1IFZuIDUYJezLcdp+TvVFTLjNi1+mqaVw==}
     peerDependencies:
       expo: '*'
     peerDependenciesMeta:
@@ -1338,8 +1356,8 @@ packages:
   '@expo/plist@0.4.9':
     resolution: {integrity: sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==}
 
-  '@expo/prebuild-config@54.0.8':
-    resolution: {integrity: sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==}
+  '@expo/prebuild-config@54.0.9':
+    resolution: {integrity: sha512-3/Rmyzt8vduPjnSVHbnc0wYFrlhwLWn2g596rDyKcLGeqN2WTLJbzVeznsrUwyzhBNXgnTomZWO5HDzbZ/4E7g==}
     peerDependencies:
       expo: '*'
 
@@ -1353,6 +1371,9 @@ packages:
 
   '@expo/schema-utils@0.1.8':
     resolution: {integrity: sha512-9I6ZqvnAvKKDiO+ZF8BpQQFYWXOJvTAL5L/227RUbWG1OVZDInFifzCBiqAZ3b67NRfeAgpgvbA7rejsqhY62A==}
+
+  '@expo/schema-utils@0.1.9':
+    resolution: {integrity: sha512-t9bYwG4Z0yCVzHYJoDMci1OFq2FkBkhStlfUGSkspKYTwB/84+x6sY+CXCgdhkQNQtvWaugW5KUs9YZfAXq9Sg==}
 
   '@expo/sdk-runtime-versions@1.0.0':
     resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
@@ -3426,6 +3447,9 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3474,6 +3498,18 @@ packages:
 
   babel-preset-expo@54.0.11:
     resolution: {integrity: sha512-dEpeFDtYEFzmWtWVwvt7sUCZH0fxXPfbJlgXd7XNZSQDa/Ki/hTOj9exMTzqR2oyPHDNcE9VxYCJ4oS6xw4Pjg==}
+    peerDependencies:
+      '@babel/runtime': ^7.20.0
+      expo: '*'
+      react-refresh: '>=0.14.0 <1.0.0'
+    peerDependenciesMeta:
+      '@babel/runtime':
+        optional: true
+      expo:
+        optional: true
+
+  babel-preset-expo@54.0.12:
+    resolution: {integrity: sha512-6xeSkdaixmQhWSYL7tfLu0pOS0BY+8ftwmdNSHtpEFSizrXYZkCjk/B6Dxr+6nwNRihixMcS0aBlWS1wlDl3pw==}
     peerDependencies:
       '@babel/runtime': ^7.20.0
       expo: '*'
@@ -4324,6 +4360,12 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-network@8.0.8:
+    resolution: {integrity: sha512-dgrL8UHAmWofqeY4UEjWskCl/RoQAM0DG6PZR8xz2WZt+6aQEboQgFRXowCfhbKZ71d16sNuKXtwBEsp2DtdNw==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+
   expo-notifications@0.32.17:
     resolution: {integrity: sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==}
     peerDependencies:
@@ -4374,6 +4416,13 @@ packages:
     resolution: {integrity: sha512-mcmyML3oXcqFUXUxtdtCL1O00ztNI2v76d+MdniXRUgHNxIcHZ05zo+DqBaOOT6LQnPk4vA4YHqQl7iGUfRb3g==}
     engines: {node: '>=20.16.0'}
 
+  expo-sqlite@16.0.10:
+    resolution: {integrity: sha512-tUOKxE9TpfneRG3eOfbNfhN9236SJ7IiUnP8gCqU7umd9DtgDGB/5PhYVVfl+U7KskgolgNoB9v9OZ9iwXN8Eg==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
   expo-status-bar@3.0.9:
     resolution: {integrity: sha512-xyYyVg6V1/SSOZWh4Ni3U129XHCnFHBTcUo0dhWtFDrZbNp/duw5AGsQfb2sVeU0gxWHXSY1+5F0jnKYC7WuOw==}
     peerDependencies:
@@ -4397,8 +4446,8 @@ packages:
       expo: '*'
       react-native: '*'
 
-  expo@54.0.35:
-    resolution: {integrity: sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==}
+  expo@54.0.36:
+    resolution: {integrity: sha512-HMHp1H+actmnX85NJE6lILKzSJV6pTDNkwghq9EMOP3zTynjvBYVqJGSLlm6sEVzJCC5Z2ZiKgLvtsHrqlY0dg==}
     hasBin: true
     peerDependencies:
       '@expo/dom-webview': '*'
@@ -7836,9 +7885,9 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@config-plugins/react-native-webrtc@13.0.0(expo@54.0.35)':
+  '@config-plugins/react-native-webrtc@13.0.0(expo@54.0.36)':
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   '@craftzdog/react-native-buffer@6.1.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -8076,23 +8125,23 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@expo/cli@54.0.25(expo-router@6.0.24)(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)':
+  '@expo/cli@54.0.26(expo-router@6.0.24)(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)':
     dependencies:
       '@0no-co/graphql.web': 1.3.2
       '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 12.0.13
-      '@expo/config-plugins': 54.0.4
+      '@expo/config': 12.0.14
+      '@expo/config-plugins': 54.0.5
       '@expo/devcert': 1.2.1
-      '@expo/env': 2.0.11
+      '@expo/env': 2.0.12
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       '@expo/json-file': 10.2.0
       '@expo/metro': 54.2.0
-      '@expo/metro-config': 54.0.16(expo@54.0.35)
+      '@expo/metro-config': 54.0.17(expo@54.0.36)
       '@expo/osascript': 2.6.0
       '@expo/package-manager': 1.12.1
       '@expo/plist': 0.4.9
-      '@expo/prebuild-config': 54.0.8(expo@54.0.35)(typescript@5.9.3)
-      '@expo/schema-utils': 0.1.8
+      '@expo/prebuild-config': 54.0.9(expo@54.0.36)(typescript@5.9.3)
+      '@expo/schema-utils': 0.1.9
       '@expo/spawn-async': 1.8.0
       '@expo/ws-tunnel': 1.0.6
       '@expo/xcpretty': 4.4.4
@@ -8110,7 +8159,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       env-editor: 0.4.2
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-server: 1.0.7
       freeport-async: 2.0.0
       getenv: 2.0.0
@@ -8143,7 +8192,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.19.0
     optionalDependencies:
-      expo-router: 6.0.24(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.35)(react-dom@19.1.0(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-router: 6.0.24(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.36)(react-dom@19.1.0(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -8157,6 +8206,25 @@ snapshots:
       node-forge: 1.4.0
 
   '@expo/config-plugins@54.0.4':
+    dependencies:
+      '@expo/config-types': 54.0.10
+      '@expo/json-file': 10.0.16
+      '@expo/plist': 0.4.9
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.6
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      slash: 3.0.0
+      slugify: 1.6.9
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/config-plugins@54.0.5':
     dependencies:
       '@expo/config-types': 54.0.10
       '@expo/json-file': 10.0.16
@@ -8195,6 +8263,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config@12.0.14':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@expo/config-plugins': 54.0.5
+      '@expo/config-types': 54.0.10
+      '@expo/json-file': 10.2.0
+      deepmerge: 4.3.1
+      getenv: 2.0.0
+      glob: 13.0.6
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
+      resolve-workspace-root: 2.0.1
+      semver: 7.7.4
+      slugify: 1.6.9
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/devcert@1.2.1':
     dependencies:
       '@expo/sudo-prompt': 9.3.2
@@ -8210,6 +8296,16 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
   '@expo/env@2.0.11':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      dotenv: 16.4.7
+      dotenv-expand: 11.0.7
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/env@2.0.12':
     dependencies:
       chalk: 4.1.2
       debug: 4.4.3
@@ -8258,13 +8354,13 @@ snapshots:
       '@babel/code-frame': 7.29.7
       json5: 2.2.3
 
-  '@expo/metro-config@54.0.16(expo@54.0.35)':
+  '@expo/metro-config@54.0.17(expo@54.0.36)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.7
-      '@expo/config': 12.0.13
-      '@expo/env': 2.0.11
+      '@expo/config': 12.0.14
+      '@expo/env': 2.0.12
       '@expo/json-file': 10.0.16
       '@expo/metro': 54.2.0
       '@expo/spawn-async': 1.8.0
@@ -8282,16 +8378,16 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@expo/metro-runtime@6.1.2(expo@54.0.35)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@expo/metro-runtime@6.1.2(expo@54.0.36)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       anser: 1.4.10
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
@@ -8340,16 +8436,16 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  '@expo/prebuild-config@54.0.8(expo@54.0.35)(typescript@5.9.3)':
+  '@expo/prebuild-config@54.0.9(expo@54.0.36)(typescript@5.9.3)':
     dependencies:
-      '@expo/config': 12.0.13
-      '@expo/config-plugins': 54.0.4
+      '@expo/config': 12.0.14
+      '@expo/config-plugins': 54.0.5
       '@expo/config-types': 54.0.10
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       '@expo/json-file': 10.2.0
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -8369,6 +8465,8 @@ snapshots:
 
   '@expo/schema-utils@0.1.8': {}
 
+  '@expo/schema-utils@0.1.9': {}
+
   '@expo/sdk-runtime-versions@1.0.0': {}
 
   '@expo/spawn-async@1.8.0':
@@ -8377,9 +8475,9 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@15.1.1(expo-font@14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@expo/vector-icons@15.1.1(expo-font@14.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      expo-font: 14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-font: 14.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
@@ -9631,28 +9729,28 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@react-native-community/datetimepicker@8.4.4(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@react-native-community/datetimepicker@8.4.4(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  '@react-native-firebase/analytics@25.1.0(@react-native-firebase/app@25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.35)':
+  '@react-native-firebase/analytics@25.1.0(@react-native-firebase/app@25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.36)':
     dependencies:
-      '@react-native-firebase/app': 25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-native-firebase/app': 25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       superstruct: 2.0.2
     optionalDependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  '@react-native-firebase/app@25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@react-native-firebase/app@25.1.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       firebase: 12.15.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
 
@@ -10806,6 +10904,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  await-lock@2.2.2: {}
+
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -10895,39 +10995,7 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.35)(react-refresh@0.14.2):
-    dependencies:
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.0)
-      '@babel/preset-react': 7.29.7(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.0)
-      '@react-native/babel-preset': 0.81.5(@babel/core@7.29.0)
-      babel-plugin-react-compiler: 1.0.0
-      babel-plugin-react-native-web: 0.21.2
-      babel-plugin-syntax-hermes-parser: 0.29.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      debug: 4.4.3
-      react-refresh: 0.14.2
-      resolve-from: 5.0.0
-    optionalDependencies:
-      '@babel/runtime': 7.29.7
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@8.0.0)(expo@54.0.35)(react-refresh@0.14.2):
+  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@8.0.0)(expo@54.0.36)(react-refresh@0.14.2):
     dependencies:
       '@babel/helper-module-imports': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.0)
@@ -10954,7 +11022,39 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 8.0.0
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  babel-preset-expo@54.0.12(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.36)(react-refresh@0.14.2):
+    dependencies:
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.0)
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.0)
+      '@react-native/babel-preset': 0.81.5(@babel/core@7.29.0)
+      babel-plugin-react-compiler: 1.0.0
+      babel-plugin-react-native-web: 0.21.2
+      babel-plugin-syntax-hermes-parser: 0.29.1
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
+      debug: 4.4.3
+      react-refresh: 0.14.2
+      resolve-from: 5.0.0
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -11620,9 +11720,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-expo: 1.0.3(eslint@9.39.4)(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
       globals: 16.5.0
@@ -11640,7 +11740,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11651,18 +11751,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -11675,7 +11775,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11686,7 +11786,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11835,28 +11935,28 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  expo-application@7.0.8(expo@54.0.35):
+  expo-application@7.0.8(expo@54.0.36):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo-asset@12.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-auth-session@7.0.11(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-auth-session@7.0.11(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo-application: 7.0.8(expo@54.0.35)
-      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
-      expo-crypto: 15.0.9(expo@54.0.35)
-      expo-linking: 8.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-web-browser: 15.0.11(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-application: 7.0.8(expo@54.0.36)
+      expo-constants: 18.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-crypto: 15.0.9(expo@54.0.36)
+      expo-linking: 8.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-web-browser: 15.0.11(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
@@ -11864,90 +11964,90 @@ snapshots:
       - expo
       - supports-color
 
-  expo-background-task@1.0.10(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+  expo-background-task@1.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-task-manager: 14.0.9(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-task-manager: 14.0.9(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
     transitivePeerDependencies:
       - react-native
 
-  expo-build-properties@1.0.10(expo@54.0.35):
+  expo-build-properties@1.0.10(expo@54.0.36):
     dependencies:
       ajv: 8.18.0
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       semver: 7.7.4
 
-  expo-clipboard@8.0.8(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-clipboard@8.0.8(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-constants@18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+  expo-constants@18.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-crypto@15.0.9(expo@54.0.35):
+  expo-crypto@15.0.9(expo@54.0.36):
     dependencies:
       base64-js: 1.5.1
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-dev-client@6.0.21(expo@54.0.35):
+  expo-dev-client@6.0.21(expo@54.0.36):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-dev-launcher: 6.0.21(expo@54.0.35)
-      expo-dev-menu: 7.0.19(expo@54.0.35)
-      expo-dev-menu-interface: 2.0.0(expo@54.0.35)
-      expo-manifests: 1.0.11(expo@54.0.35)
-      expo-updates-interface: 2.0.0(expo@54.0.35)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-dev-launcher: 6.0.21(expo@54.0.36)
+      expo-dev-menu: 7.0.19(expo@54.0.36)
+      expo-dev-menu-interface: 2.0.0(expo@54.0.36)
+      expo-manifests: 1.0.11(expo@54.0.36)
+      expo-updates-interface: 2.0.0(expo@54.0.36)
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-launcher@6.0.21(expo@54.0.35):
+  expo-dev-launcher@6.0.21(expo@54.0.36):
     dependencies:
       ajv: 8.18.0
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-dev-menu: 7.0.19(expo@54.0.35)
-      expo-manifests: 1.0.11(expo@54.0.35)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-dev-menu: 7.0.19(expo@54.0.36)
+      expo-manifests: 1.0.11(expo@54.0.36)
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-menu-interface@2.0.0(expo@54.0.35):
+  expo-dev-menu-interface@2.0.0(expo@54.0.36):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-dev-menu@7.0.19(expo@54.0.35):
+  expo-dev-menu@7.0.19(expo@54.0.36):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-dev-menu-interface: 2.0.0(expo@54.0.35)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-dev-menu-interface: 2.0.0(expo@54.0.36)
 
-  expo-file-system@19.0.23(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+  expo-file-system@19.0.23(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-font@14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-font@14.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
   expo-json-utils@0.15.0: {}
 
-  expo-keep-awake@15.0.8(expo@54.0.35)(react@19.1.0):
+  expo-keep-awake@15.0.8(expo@54.0.36)(react@19.1.0):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
 
-  expo-linking@8.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-linking@8.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-constants: 18.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
@@ -11955,10 +12055,10 @@ snapshots:
       - expo
       - supports-color
 
-  expo-manifests@1.0.11(expo@54.0.35):
+  expo-manifests@1.0.11(expo@54.0.36):
     dependencies:
       '@expo/config': 12.0.13
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-json-utils: 0.15.0
     transitivePeerDependencies:
       - supports-color
@@ -11977,25 +12077,30 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-notifications@0.32.17(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo-network@8.0.8(expo@54.0.36)(react@19.1.0):
+    dependencies:
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+
+  expo-notifications@0.32.17(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       '@ide/backoff': 1.0.0
       abort-controller: 3.0.0
       assert: 2.1.0
       badgin: 1.2.3
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-application: 7.0.8(expo@54.0.35)
-      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-application: 7.0.8(expo@54.0.36)
+      expo-constants: 18.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-router@6.0.24(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.35)(react-dom@19.1.0(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-router@6.0.24(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.36)(react-dom@19.1.0(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@expo/metro-runtime': 6.1.2(expo@54.0.35)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@expo/metro-runtime': 6.1.2(expo@54.0.36)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
       '@radix-ui/react-slot': 1.2.0(@types/react@19.1.17)(react@19.1.0)
       '@radix-ui/react-tabs': 1.1.15(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12005,9 +12110,9 @@ snapshots:
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
-      expo-linking: 8.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-linking: 8.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.7
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
@@ -12034,11 +12139,18 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  expo-secure-store@15.0.8(expo@54.0.35):
+  expo-secure-store@15.0.8(expo@54.0.36):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-server@1.0.7: {}
+
+  expo-sqlite@16.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      await-lock: 2.2.2
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
   expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -12046,39 +12158,39 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
-  expo-task-manager@14.0.9(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+  expo-task-manager@14.0.9(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
       unimodules-app-loader: 6.0.8
 
-  expo-updates-interface@2.0.0(expo@54.0.35):
+  expo-updates-interface@2.0.0(expo@54.0.36):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-web-browser@15.0.11(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+  expo-web-browser@15.0.11(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo@54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo@54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 54.0.25(expo-router@6.0.24)(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
-      '@expo/config': 12.0.13
-      '@expo/config-plugins': 54.0.4
+      '@expo/cli': 54.0.26(expo-router@6.0.24)(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
+      '@expo/config': 12.0.14
+      '@expo/config-plugins': 54.0.5
       '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/fingerprint': 0.15.5
       '@expo/metro': 54.2.0
-      '@expo/metro-config': 54.0.16(expo@54.0.35)
-      '@expo/vector-icons': 15.1.1(expo-font@14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@expo/metro-config': 54.0.17(expo@54.0.36)
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@ungap/structured-clone': 1.3.1
-      babel-preset-expo: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.35)(react-refresh@0.14.2)
-      expo-asset: 12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
-      expo-file-system: 19.0.23(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
-      expo-font: 14.0.12(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-keep-awake: 15.0.8(expo@54.0.35)(react@19.1.0)
+      babel-preset-expo: 54.0.12(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.36)(react-refresh@0.14.2)
+      expo-asset: 12.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-file-system: 19.0.23(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-font: 14.0.12(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-keep-awake: 15.0.8(expo@54.0.36)(react@19.1.0)
       expo-modules-autolinking: 3.0.26
       expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       pretty-format: 29.7.0
@@ -12087,7 +12199,7 @@ snapshots:
       react-refresh: 0.14.2
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
-      '@expo/metro-runtime': 6.1.2(expo@54.0.35)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@expo/metro-runtime': 6.1.2(expo@54.0.36)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -13846,7 +13958,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  react-native-quick-crypto@1.1.5(expo-build-properties@1.0.10(expo@54.0.35))(expo@54.0.35)(react-native-nitro-modules@0.36.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-quick-base64@3.0.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  react-native-quick-crypto@1.1.5(expo-build-properties@1.0.10(expo@54.0.36))(expo@54.0.36)(react-native-nitro-modules@0.36.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-quick-base64@3.0.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@craftzdog/react-native-buffer': 6.1.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       events: 3.3.0
@@ -13859,8 +13971,8 @@ snapshots:
       string_decoder: 1.3.0
       util: 0.12.5
     optionalDependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-build-properties: 1.0.10(expo@54.0.35)
+      expo: 54.0.36(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-build-properties: 1.0.10(expo@54.0.36)
 
   react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -2,7 +2,7 @@
 
 ## 결과
 
-Issue [#358](https://github.com/ysjee141/nexvoy-frontend/issues/358)의 Mobile server-authority persistence 기반을 구현했다. Mobile 화면은 아직 기존 repository를 유지하지만, TASK-052가 사용할 SQLite cache/outbox와 lifecycle sync 경계가 준비됐다.
+Issue [#358](https://github.com/ysjee141/nexvoy-frontend/issues/358)의 Mobile server-authority persistence 기반을 구현했다. Mobile 화면은 아직 기존 repository를 유지하지만, TASK-052가 사용할 SQLite cache/outbox와 lifecycle sync 경계가 준비됐다. Pull Request: [#359](https://github.com/ysjee141/nexvoy-frontend/pull/359)
 
 ```mermaid
 flowchart LR

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,44 @@
+# Walkthrough: TASK-051 Mobile SQLite Cache and Transactional Outbox
+
+## 결과
+
+Issue [#358](https://github.com/ysjee141/nexvoy-frontend/issues/358)의 Mobile server-authority persistence 기반을 구현했다. Mobile 화면은 아직 기존 repository를 유지하지만, TASK-052가 사용할 SQLite cache/outbox와 lifecycle sync 경계가 준비됐다.
+
+```mermaid
+flowchart LR
+    UI["TASK-052 product repository"] --> Store["Account-scoped SQLite store"]
+    Store --> TX["Atomic optimistic update + outbox"]
+    TX --> Coordinator["Shared authority coordinator"]
+    Coordinator --> RPC["Authenticated batch RPC"]
+    RPC --> Ack["Canonical ack + revision rebase"]
+    Realtime["Private Realtime invalidation"] --> Coordinator
+    Lifecycle["Foreground / reconnect / background"] --> Coordinator
+```
+
+## 구현
+
+- `authority_resources`, `authority_outbox`, `authority_sync_state`를 포함하는 version 1 SQLite migration과 WAL/foreign-key 설정을 추가했다.
+- optimistic mutation과 command append, acknowledgement, retry/conflict, stale sending recovery, guest promotion, account/resource purge를 exclusive transaction으로 구현했다.
+- 로그인 시 sync runtime/background task를 시작하고 foreground, network reconnect, retry 시각에 queue를 재개한다.
+- logout에서는 namespaced cache를 보존하고 withdrawal에서는 account purge 실패 시 전체 authority DB 삭제로 local data 잔존을 막는다.
+- Realtime invalidation/revision recovery adapter를 추가하되 제품 화면의 실제 구독은 TASK-052로 남겼다.
+- Expo Web export의 SQLite WASM asset을 위해 Metro에 `wasm` 확장자를 등록했다.
+
+## 검증
+
+| 항목 | 결과 |
+|---|---|
+| Mobile authority transaction tests | PASS, 5 tests |
+| Core tests | PASS |
+| `pnpm typecheck` | PASS |
+| Mobile lint | PASS |
+| Web production build | PASS |
+| Web/iOS/Android Expo export | PASS |
+| Android development local build | PASS |
+| Expo dependency compatibility | PASS |
+
+실기기 계정 전환, 비행기 모드, OS background smoke 절차는 `docs/refactor/runbooks/TASK-051-mobile-sqlite-authority-smoke.md`에 정리했다. 실제 제품 화면의 offline mutation과 Realtime 구독 검증은 TASK-052에서 수행한다.
+
 # Walkthrough: TASK-050 Plan Command Recovery
 
 ## Summary


### PR DESCRIPTION
## Summary

- add an account-scoped Expo SQLite cache, sync state, and durable transactional outbox for Mobile server-authority data
- wire foreground, reconnect, retry timer, background opportunity, logout preservation, withdrawal purge, and private Realtime invalidation recovery
- add focused transaction/rebase/account isolation tests and a native smoke-test runbook

## Scope

TASK-051 prepares the persistence and lifecycle boundary. Mobile product screen repository cutover and active detail Realtime subscription wiring remain in TASK-052.

## Verification

- `pnpm --filter nexvoy-app test:authority` (5 tests)
- `pnpm --filter @nexvoy/core test`
- `pnpm typecheck`
- `pnpm --filter nexvoy-app typecheck`
- `pnpm --filter nexvoy-app lint`
- `pnpm build`
- `pnpm build:mobile` (Web/iOS/Android export)
- `pnpm --filter nexvoy-app exec expo install --check`
- Android development local build on Expo 54.0.36 (`BUILD SUCCESSFUL`)

## Notes

- No Supabase migration or RLS change is included.
- Logout preserves account-namespaced cache; withdrawal purges it.
- Signed-in physical-device airplane-mode/account-switch/background checks are documented in `docs/refactor/runbooks/TASK-051-mobile-sqlite-authority-smoke.md` and will be exercised with the TASK-052 product path.

Closes #358
