### PR TITLE
docs(TASK-057): migration ledger 판정 기준 정정

### DIFF
--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -35,7 +35,7 @@ migration, 제품 E2E 자동화 공백, 실기기 플랫폼 매트릭스, 7일 �
 |---|---|---|
 | G0 문서·책임 | 문서 버전과 Release/DB/QA/Web/Mobile/on-call 담당자 지정 | NO-GO |
 | G1 로컬 자동화 | P0 자동화 공백 보완, 전체 test/typecheck/build PASS | 부분 PASS |
-| G2 DEV schema | migration ledger drift 0, TASK-056 migration 정상 적용 | NO-GO |
+| G2 DEV schema | historical 9건+TASK-056 전체 fingerprint, migration history drift 0 | NO-GO |
 | G3 DEV 제품 | 수동 P0/P1과 필수 플랫폼 조합 100% PASS | NO-GO |
 | G4 관측 | 연속 7일 무사고와 지표 임계치 충족 | NO-GO |
 | G5 복구 | DB+Storage 격리 복구와 RTO/RPO 검증 | NO-GO |
@@ -72,7 +72,7 @@ migration, 제품 E2E 자동화 공백, 실기기 플랫폼 매트릭스, 7일 �
 | 항목 | GO 기준 | 증적 |
 |---|---|---|
 | Project | DEV/Production ref 교차 확인 | Release ticket |
-| Migration | local/remote history 일치, dry-run 대상 0건 | 전·후 migration list |
+| Migration | 객체 적용과 history 등록을 분리 감사, local/remote history 일치, dry-run 대상 0건 | schema diff와 전·후 migration list |
 | RLS/RPC | owner/editor/viewer/revoked/outsider 정책 PASS | SQL과 제품 smoke |
 | Realtime | private invalidation과 gap recovery PASS | Supabase report와 client log |
 | Storage | 플랫폼 공통 path, RLS, thumbnail, orphan cleanup scheduler PASS | object manifest, scheduler와 network log |
@@ -119,7 +119,7 @@ migration, 제품 E2E 자동화 공백, 실기기 플랫폼 매트릭스, 7일 �
 1. 데이터 손실·변질 또는 duplicate canonical row가 발생한다.
 2. 계정 간 cache, row, Realtime, asset이 노출된다.
 3. viewer, revoked, outsider가 허용되지 않은 작업을 수행한다.
-4. migration history drift 또는 미승인 object 변경이 있다.
+4. migration history drift, 원격 전용 version 미분류 또는 미승인 object 변경이 있다.
 5. DB와 Storage 복구가 같은 기준 시점으로 완료되지 않는다.
 6. 미해결 P0/P1 결함이 있다.
 7. Rollback과 on-call 담당자가 지정되지 않았다.

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -4,6 +4,17 @@
 기준 브랜치: `refactoring/local-first-architecture`  
 현재 목표: **Supabase normalized row authority + account-scoped local cache + durable outbox + Realtime invalidation으로 Web/Mobile 전체 기능을 전환하고 Initial Production gate를 통과한다.**
 
+## 2026-07-23 TASK-057 Migration 판정 정정
+
+- Issue #372에서 SQL 객체 적용과 `supabase_migrations.schema_migrations` history 등록을 분리했다.
+- DEV는 historical version 9건과 TASK-056이 history에 없지만 TASK-055/056 핵심 객체는 확인됐다.
+- Production도 TASK-055/056 핵심 객체가 확인됐으나 로컬 version 대부분이 미등록이고 원격 전용
+  version 4건과 `public` schema 차이가 존재한다.
+- 양쪽 환경의 일부 `SECURITY DEFINER` authority helper·wrapper에 예상 밖 `anon` 실행 grant가 확인돼
+  TASK-059 grant hardening과 익명 호출 회귀 테스트로 분리했다.
+- TASK-055/056 원본 SQL 재실행을 금지하고 전체 fingerprint가 일치하는 version만 하나씩 repair한다.
+- TASK-059는 신규 원격 적용이 아니라 DEV object/history 정합화와 Production 감사 입력 작성으로 정정했다.
+
 ## 2026-07-23 TASK-057 Production 최종 검증 문서화 완료
 
 - TASK-056의 남은 차단 항목을 `G0`~`G7`과 `B-01`~`B-11`로 재구성했다.

--- a/docs/refactor/reports/TASK-056-production-go-no-go.md
+++ b/docs/refactor/reports/TASK-056-production-go-no-go.md
@@ -9,9 +9,9 @@
 
 ## 결론
 
-코드와 로컬 자동화는 통과했다. 원격 migration, 실기기 통합 테스트, 7일 관측, DB와 Storage 복구,
-Production preflight 증적이 없으므로 출시할 수 없다. TASK-058~063을 실행해 TASK-057의 `G0`~`G7`을
-모두 통과해야 Production Gate를 GO로 변경한다.
+코드와 로컬 자동화는 통과했다. 원격 객체·migration history 정합화, 실기기 통합 테스트, 7일 관측,
+DB와 Storage 복구, Production preflight 증적이 없으므로 출시할 수 없다. TASK-058~063을 실행해
+TASK-057의 `G0`~`G7`을 모두 통과해야 Production Gate를 GO로 변경한다.
 
 ## 통과한 근거
 
@@ -29,13 +29,13 @@ Production preflight 증적이 없으므로 출시할 수 없다. TASK-058~063�
 
 | ID | 차단 항목 | 현재 상태 | 실행 문서 |
 |---|---|---|---|
-| B-01 | DEV historical migration 9건 fingerprint와 ledger repair | 미실행 | [TASK-057 Runbook](../runbooks/TASK-057-production-validation-runbook.md#2단계-dev-migration-ledger-정합화) |
-| B-02 | DEV에 `20260723000002` 정상 적용과 원격 안전 smoke | 미실행 | 같은 Runbook 3단계 |
+| B-01 | DEV historical version 9건의 전체 객체 fingerprint와 history repair | 미실행 | [TASK-057 Runbook](../runbooks/TASK-057-production-validation-runbook.md#2단계-dev-migration-ledger-정합화) |
+| B-02 | TASK-056 grant hardening, 전체 fingerprint, `20260723000002` history 등록, 원격 안전 smoke | 핵심 객체와 예상 밖 `anon` grant 확인 | 같은 Runbook 3단계 |
 | B-03 | 초대·권한·계정·템플릿·asset P0 자동화 공백 보완 | 미구현 | [통합 테스트 케이스](../test-plans/TASK-057-production-integration-test-cases.md#추가할-자동-테스트) |
 | B-04 | Web/Mobile·Mobile/Mobile 실기기 매트릭스 | 미실행 | 같은 테스트 문서의 필수 플랫폼 매트릭스 |
 | B-05 | DEV 7일 운영 지표 | 미실행 | TASK-057 Runbook 5단계 |
 | B-06 | DB와 `place-photos` Storage 복구 rehearsal | 미실행 | TASK-057 Runbook 6단계 |
-| B-07 | Production migration history 독립 감사와 backup | 미실행 | TASK-057 Runbook 7단계 |
+| B-07 | Production 원격 전용 history·실제 schema drift 독립 감사와 backup | 미실행 | TASK-057 Runbook 7단계 |
 | B-08 | 최소 Mobile 버전, rollout, on-call 책임자 | 미지정 | [마스터 계획](TASK-057-production-final-validation-plan.md#역할과-책임) |
 | B-09 | 환경변수·OAuth·이메일·push·법무·alert 운영 준비 | 미완료 | TASK-057 Runbook 7단계 |
 | B-10 | 내부→5%→25%→100% 단계적 rollout | 미실행 | TASK-057 Runbook 8단계 |
@@ -44,6 +44,8 @@ Production preflight 증적이 없으므로 출시할 수 없다. TASK-058~063�
 ## 판정 규칙
 
 - 각 항목에는 실행자, 검토자, 시각, project ref, release SHA, 원시 결과 링크가 필요하다.
+- SQL Editor로 직접 실행된 migration은 객체 적용과 history 등록을 별도로 판정한다.
+- TASK-055/056은 양쪽 환경에 핵심 적용 결과가 있으므로 원본 SQL을 다시 실행하지 않는다.
 - 데이터 손실, 계정 간 노출, 권한 우회, duplicate canonical row, 복구 실패는 한 건도 허용하지 않는다.
 - 필수 자동 테스트와 수동 P0/P1은 100% PASS여야 한다.
 - DEV 7일 관측에서 임계치를 넘으면 수정 release로 기간을 다시 시작한다.

--- a/docs/refactor/reports/TASK-057-production-final-validation-plan.md
+++ b/docs/refactor/reports/TASK-057-production-final-validation-plan.md
@@ -24,8 +24,9 @@
 | Core/저장소/SQL | PASS | TASK-056 자동 테스트 | release SHA마다 재실행 |
 | Web 제품 E2E | 부분 PASS | 여행·일정·준비물·offline·충돌 3건 포함 | 초대·권한·템플릿·asset·계정 전환 추가 |
 | Mobile 정적/저장소 | PASS | typecheck, lint, Expo export, SQLite tests | Preview 실기기 검증 |
-| DEV schema | NO-GO | historical migration ledger 9건 불일치 | object fingerprint 후 repair |
-| DEV TASK-056 migration | NO-GO | 원격 미적용 | ledger 정합화 후 정상 적용 |
+| DEV schema | NO-GO | historical version 9건의 객체는 수동 적용 가능성이 있으나 history 미등록 | 전체 object fingerprint 후 version별 repair |
+| DEV TASK-056 | 부분 확인 / NO-GO | 핵심 함수·wrapper는 존재하지만 history 미등록, authority helper·wrapper에 예상 밖 `anon` 실행 grant 확인 | grant hardening, 전체 fingerprint와 smoke 후 history repair |
+| Production schema/history | NO-GO | 로컬 version 대부분 미등록, 원격 전용 version 4건과 `public` schema 차이 존재 | DEV와 독립적인 drift 분류·승인 |
 | 다중 플랫폼 | NO-GO | Web/Mobile·Mobile/Mobile 증적 없음 | 필수 매트릭스 실행 |
 | 운영 관측 | NO-GO | 7일 지표 없음 | 임계치 기반 관찰 |
 | 복구 | NO-GO | DB+Storage 동시 복구 증적 없음 | 격리 프로젝트 rehearsal |
@@ -36,7 +37,7 @@
 ```mermaid
 flowchart TD
     G0["G0 문서와 책임자 확정"] --> G1["G1 로컬 자동화 PASS"]
-    G1 --> G2["G2 DEV migration 정합화"]
+    G1 --> G2["G2 DEV schema/history 정합화"]
     G2 --> G3["G3 DEV 통합·실기기 PASS"]
     G3 --> G4["G4 7일 관측 PASS"]
     G4 --> G5["G5 DB+Storage 복구 PASS"]
@@ -54,13 +55,13 @@ flowchart TD
 
 | ID | 차단 항목 | 완료 기준 | 필수 증적 | Gate |
 |---|---|---|---|---|
-| B-01 | DEV migration ledger 9건 불일치 | 각 migration object fingerprint 일치 후 history repair, 최종 drift 0 | 전·후 migration list, function/policy/trigger 정의, 실행자 | G2 |
-| B-02 | TASK-056 migration 원격 미적용 | `20260723000002`가 DEV history에 정상 기록되고 authenticated smoke PASS | dry-run, 적용 로그, remote schema 확인 | G2 |
+| B-01 | DEV historical version 9건 history 미등록 | 각 migration object fingerprint 일치 후 version별 history repair, 최종 drift 0 | 전·후 migration list, function/policy/trigger 정의, 실행자 | G2 |
+| B-02 | TASK-056 객체·grant·history 상태 미확정 | authority helper/internal/wrapper의 `anon` 실행 권한 제거, 전체 fingerprint 일치, `20260723000002` history 등록, authenticated smoke PASS | schema dump, 익명 호출 차단 SQL test, grant 비교, repair 로그, smoke 결과 | G2 |
 | B-03 | 제품 E2E 자동화 공백 | P0 자동화 케이스 전부 구현·PASS | CI URL, 리포트, 실패 재현 링크 | G1 |
 | B-04 | 실기기·다중 플랫폼 미검증 | 필수 플랫폼 조합과 수동 P0/P1 케이스 100% PASS | 기기/OS/build, 영상·스크린샷, network/Logcat | G3 |
 | B-05 | 7일 운영 지표 없음 | 연속 7일 동안 임계치와 무사고 기준 충족 | GA4/Firebase/Supabase 대시보드 export | G4 |
 | B-06 | DB+Storage 복구 미검증 | 격리 프로젝트에서 동일 기준 시점 데이터와 object 복구 검증 | dump/checksum, object manifest, row count, RTO/RPO | G5 |
-| B-07 | Production history·backup 미확정 | Production ledger drift 0, pre-deploy DB/Storage backup 완료 | 독립 감사 기록, backup 위치·checksum | G6 |
+| B-07 | Production history·schema drift·backup 미확정 | 원격 전용 version 4건과 `public` schema 차이 분류·승인, ledger 정합화, pre-deploy DB/Storage backup 완료 | 독립 감사 기록, schema diff, backup 위치·checksum | G6 |
 | B-08 | Mobile 최소 버전·출시 책임 미확정 | 최소 지원 버전과 강제 업데이트 정책, 배포·on-call 담당자 승인 | release ticket, 연락망, store 설정 | G6 |
 | B-09 | 제품 운영 준비 미확정 | 환경변수, OAuth, 이메일, push, 도메인, 약관·개인정보, alert test PASS | 설정 inventory와 각 검증 링크 | G6 |
 | B-10 | 단계적 rollout 미실행 | 내부→5%→25%→100% 각 hold 구간 통과 | 단계별 지표와 GO 승인 | G7 |
@@ -74,7 +75,7 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 | 작업 | 실행 범위 | 해소 차단 항목 | 선행 작업 |
 |---|---|---|---|
 | `TASK-058` | P0 제품 통합 테스트 자동화와 asset path 계약 통일 | B-03, B-11의 계약 부분 | TASK-057 |
-| `TASK-059` | DEV migration ledger 정합화와 원격 적용 | B-01, B-02 | TASK-058 |
+| `TASK-059` | DEV 객체 fingerprint와 migration history 정합화 | B-01, B-02 | TASK-058 |
 | `TASK-060` | Web/Mobile 실기기·다중 계정·asset 검증 | B-04, B-11의 실환경 검증 부분 | TASK-059 |
 | `TASK-061` | DEV 7일 안정성·비용 관측 | B-05 | TASK-060 |
 | `TASK-062` | DB+Storage 재해 복구 rehearsal | B-06 | TASK-060 |
@@ -99,10 +100,17 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 
 ### G2. DEV schema와 migration Gate
 
-- DEV `ivgkqzwosbjukonlpfdw`의 9개 history gap을 migration별로 fingerprint한다.
-- object가 실제로 없으면 `repair --status applied`를 사용하지 않는다.
-- history repair 후 `db push --dry-run` 결과가 TASK-056 migration만 표시되는지 확인한다.
-- TASK-056 migration 적용 후 function 정의, grant, revision 동작을 authenticated test account로 검증한다.
+- DEV `ivgkqzwosbjukonlpfdw`의 historical gap 9건과 TASK-056 version을 migration별로 fingerprint한다.
+- 2026-07-23 schema dump에서 TASK-055/056 핵심 함수·정책은 확인됐지만, 이것만으로 전체 SQL 일치를
+  판정하지 않는다.
+- 양쪽 환경에서 stale-batch helper, command wrapper와 일부 internal authority function에 명시적인
+  `anon` 실행 grant가 확인됐다. 내부 `auth.uid()` 검사가 익명 쓰기는 차단하지만 목표 RPC 노출 범위와
+  다르므로 새 forward migration에서 권한을 회수하고 익명 호출 테스트를 추가한다.
+- object와 권한이 migration 전체와 일치하는 version만 `repair --status applied`로 history에 등록한다.
+- 부분 적용 또는 정의 차이가 있으면 원본 SQL을 재실행하지 않는다. 별도 forward reconciliation
+  migration을 검토한 뒤 원래 version의 history 처리 근거를 남긴다.
+- 정합화 후 `db push --dry-run`은 적용 대상이 없어야 한다.
+- authenticated test account로 function, grant, revision, role/revoke 동작을 검증한다.
 
 ### G3. DEV 제품·실기기 Gate
 
@@ -128,6 +136,9 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 ### G6. Production Preflight
 
 - Production `runbcaegpefqnljsswhv`를 DEV와 독립적으로 감사한다.
+- Production history에만 있는 `20260403070821`, `20260423112332`, `20260427021704`,
+  `20260427023948`의 출처와 객체를 보존·분류한다.
+- Production 전용 `public` 객체와 DEV 전용 객체가 의도된 차이인지 migration 누락인지 판정한다.
 - migration dry-run이 승인 대상만 표시되는지 확인한다.
 - DB와 Storage backup을 생성하고 checksum과 보관 위치를 기록한다.
 - Web/Mobile release SHA, 환경변수, OAuth redirect, 이메일, push, 약관·개인정보 URL을 검증한다.
@@ -188,7 +199,7 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 | 단계 | 최소 기간 | 산출물 |
 |---|---:|---|
 | 자동화 공백 보완 | 2~4영업일 | 테스트 PR, CI 결과 |
-| DEV schema/migration | 1영업일 | migration ledger 증적 |
+| DEV schema/history | 1영업일 | migration ledger 증적 |
 | 실기기 통합 테스트 | 2~3영업일 | 케이스별 증적, 결함 목록 |
 | DEV 관측 | 연속 7일 | 일별 지표와 최종 요약 |
 | 복구 rehearsal | 1~2영업일 | RTO/RPO와 정합성 보고서 |

--- a/docs/refactor/runbooks/TASK-056-production-rollout-and-recovery.md
+++ b/docs/refactor/runbooks/TASK-056-production-rollout-and-recovery.md
@@ -8,38 +8,40 @@
 
 ## 현재 Gate
 
-코드와 Local DB Gate는 PASS다. DEV와 Production은 NO-GO다. 연결된 DEV migration ledger에는 9개의
-historical gap이 있고 TASK-056 migration도 아직 원격 적용되지 않았다. Fingerprint와 ledger repair 전에
-`db push`를 실행하지 않는다.
+코드와 Local DB Gate는 PASS다. DEV와 Production은 NO-GO다. DEV migration history에는 historical
+version 9건과 TASK-056 version이 등록되지 않았다. 그러나 2026-07-23 schema dump에서 TASK-055/056의
+핵심 함수·정책·권한은 양쪽 환경에 존재했다. 따라서 원본 SQL을 다시 실행하지 않고 전체 fingerprint와
+history 정합화부터 수행한다.
 
 ## DEV Migration Ledger 정합화
 
-2026-07-23 확인 기준 local에만 표시된 historical version은 다음과 같다.
+2026-07-23 확인 기준 DEV history에 없는 version은 다음 10건이다.
 
 ```text
 20260712000001  20260713000001  20260714000001
 20260716000003  20260717000001  20260717000002
 20260718000001  20260718000002  20260723000001
+20260723000002
 ```
 
 각 migration의 table, function, grant, trigger, policy를 DEV remote object와 대조한다. SQL을 수동 실행해
-object가 이미 있을 수 있다. Object가 누락됐다면 migration을 적용해야 하며 applied로 표시하면 안 된다.
+object가 이미 있을 수 있다. 핵심 object 존재만으로 통과시키지 않고 migration의 전체 statement를
+대조한다.
 
-모든 fingerprint가 일치한 뒤에만 history를 repair한다.
+전체 fingerprint가 일치한 version만 하나씩 history를 repair한다.
 
 ```bash
 supabase link --project-ref ivgkqzwosbjukonlpfdw
 supabase migration list
-supabase migration repair --linked --status applied \
-  20260712000001 20260713000001 20260714000001 \
-  20260716000003 20260717000001 20260717000002 \
-  20260718000001 20260718000002 20260723000001
+VERIFIED_VERSION="승인된_14자리_version"
+supabase migration repair --linked --status applied "$VERIFIED_VERSION"
 supabase migration list
 supabase db push --linked --dry-run
 ```
 
-`20260723000002`는 repair 목록에 넣지 않는다. Entity-version rebase migration이므로 정상 migration
-경로로 적용한다. Production history는 DEV 결과를 추정하지 않고 독립적으로 감사한다.
+부분 적용 또는 정의 차이가 있으면 원본 migration을 재실행하지 않는다. 별도 forward reconciliation
+migration으로 목표 상태를 만든 뒤 원래 version의 history 처리 근거를 승인받는다. Production history는
+DEV 결과를 추정하지 않고 독립적으로 감사한다.
 
 ## 배포 전 Backup
 
@@ -67,13 +69,13 @@ find "backup/$PROJECT_REF/$RELEASE_SHA" -type f ! -name SHA256SUMS \
 
 ## 배포 순서
 
-1. DEV ledger를 repair하고 최종 drift를 확인한다.
-2. `20260723000002_task056_entity_version_rebase.sql`을 DEV에 정상 적용한다.
-3. Local 전체 SQL/E2E와 DEV authenticated smoke를 실행한다.
+1. DEV 10개 version의 전체 객체 fingerprint를 완료한다.
+2. 일치하는 version만 history에 등록하고 dry-run 대상 0건을 확인한다.
+3. TASK-055/056 원본 SQL을 다시 실행하지 않고 Local 전체 SQL/E2E와 DEV authenticated smoke를 실행한다.
 4. Web과 내부 Mobile build에서 Web/Web, Web/Mobile, Mobile/Mobile 테스트를 실행한다.
 5. DEV에서 연속 7일 동안 데이터·권한 incident 없이 지표 임계치를 통과한다.
 6. Recovery project에서 DB와 Storage를 함께 복구한다.
-7. Production history 감사와 pre-deploy backup을 완료한다.
+7. Production 원격 전용 history 4건과 실제 schema drift 감사, pre-deploy backup을 완료한다.
 8. Web, Mobile 내부, 5%, 25%, 100% 순서로 확대한다.
 
 Local SQL smoke와 service-role Playwright를 DEV나 Production에 직접 실행하지 않는다. 원격 검증은 전용

--- a/docs/refactor/runbooks/TASK-057-production-validation-runbook.md
+++ b/docs/refactor/runbooks/TASK-057-production-validation-runbook.md
@@ -13,7 +13,7 @@
 - [0단계: 실행 기록 생성](#0단계-실행-기록-생성)
 - [1단계: 로컬 Gate](#1단계-로컬-gate)
 - [2단계: DEV migration ledger 정합화](#2단계-dev-migration-ledger-정합화)
-- [3단계: DEV migration과 원격 안전 검증](#3단계-dev-migration과-원격-안전-검증)
+- [3단계: DEV history 정합화와 원격 안전 검증](#3단계-dev-history-정합화와-원격-안전-검증)
 - [4단계: 실기기 통합 테스트](#4단계-실기기-통합-테스트)
 - [5단계: 7일 관측](#5단계-7일-관측)
 - [6단계: DB와 Storage 복구 Rehearsal](#6단계-db와-storage-복구-rehearsal)
@@ -132,6 +132,19 @@ supabase db push --linked --dry-run --include-all
 | `20260718000001` | keyless membership | invitation/role/revoke function |
 | `20260718000002` | asset registry | asset table, function, Storage policy |
 | `20260723000001` | legacy revoke | revoked function/grant 상태 |
+| `20260723000002` | entity version rebase | helper, command wrapper, grant |
+
+2026-07-23 read-only schema dump에서 TASK-055/056의 핵심 결과는 DEV와 Production 모두 확인됐다.
+
+- TASK-055: `revoke_document_member`, legacy grant 회수, signaling policy 제거, authority invalidation policy
+- TASK-056: 두 stale-batch helper와 이를 호출하는 trip/template command wrapper
+
+이 확인은 SQL 전체 fingerprint를 대체하지 않는다. migration history에는 두 version이 모두 등록되지 않았다.
+
+추가로 양쪽 schema dump에서 `trip_authority_stale_batch_is_rebasable`,
+`template_authority_stale_batch_is_rebasable`, command wrapper와 일부 internal authority function에
+명시적인 `anon` 실행 grant가 확인됐다. 내부 함수의 `auth.uid()` 검사가 익명 쓰기를 차단하더라도
+`SECURITY DEFINER` 함수의 목표 노출 범위와 다르므로 B-02는 실패 상태다.
 
 ### 2.2 Object fingerprint
 
@@ -171,36 +184,45 @@ order by routine_name, grantee;
 
 ### 2.3 History repair
 
-모든 fingerprint가 일치한 version만 한 번에 repair한다. 하나라도 object가 누락되면 중단한다.
+전체 fingerprint가 일치한 version만 하나씩 repair한다. `$VERIFIED_VERSION`에는 검토자 승인이 끝난
+version 하나만 넣는다.
 
 ```bash
-supabase migration repair --linked --status applied \
-  20260712000001 20260713000001 20260714000001 \
-  20260716000003 20260717000001 20260717000002 \
-  20260718000001 20260718000002 20260723000001
+VERIFIED_VERSION="승인된_14자리_version"
+supabase migration repair --linked --status applied "$VERIFIED_VERSION"
 supabase migration list
 supabase db push --linked --dry-run
 ```
 
-`20260723000002`는 repair 목록에 넣지 않는다. 이 migration은 정상 migration 경로로 적용한다.
+TASK-055/056을 포함해 이미 수동 실행된 SQL을 다시 실행하지 않는다. 일부 statement가 다르면 그 version을
+repair하지 않고 차이를 분류한다. 필요한 변경은 새 version의 forward reconciliation migration으로
+작성하고, 원래 version history 처리에는 별도 승인을 남긴다.
 
-## 3단계: DEV migration과 원격 안전 검증
+Grant hardening migration은 최소한 다음을 검증한다.
 
-### 3.1 적용 전
+- `anon`: stale-batch helper, internal apply function, write wrapper 실행 불가
+- `authenticated`: `apply_trip_commands`, `apply_template_commands`만 실행 가능
+- 내부 helper/apply function: API role 직접 실행 불가
+- 익명 호출 차단과 authenticated owner/editor 성공을 SQL 회귀 테스트로 고정
+
+## 3단계: DEV history 정합화와 원격 안전 검증
+
+### 3.1 정합화 전
 
 - DB managed backup 또는 지원되는 snapshot을 생성한다.
 - `place-photos` object manifest를 별도로 저장한다.
-- `db push --dry-run`이 `20260723000002`만 표시되는지 두 사람이 확인한다.
+- 10개 version의 fingerprint와 repair 근거를 두 사람이 확인한다.
+- `db push --dry-run` 결과에 미검증 migration이 남아 있으면 중단한다.
 
-### 3.2 적용
+### 3.2 History 확인
 
 ```bash
-supabase db push --linked
 supabase migration list
 supabase db push --linked --dry-run
 ```
 
-최종 dry-run에는 적용 대상이 없어야 한다.
+최종 dry-run에는 적용 대상이 없어야 한다. 새 reconciliation migration이 필요한 경우에는 별도 PR,
+backup, dry-run 승인을 거쳐 적용하며 이 Runbook의 history repair와 섞지 않는다.
 
 ### 3.3 원격 안전 검증
 
@@ -332,13 +354,18 @@ where bucket_id = 'place-photos';
 
 1. Production으로 다시 link하고 project ref를 두 사람이 확인한다.
 2. DEV와 독립적으로 migration history와 object fingerprint를 감사한다.
-3. `db push --dry-run` 결과를 release ticket에 저장한다.
-4. managed DB backup, logical export, Storage manifest/object export를 만든다.
-5. Web/Mobile env, OAuth redirect, 이메일 발신, push, Maps, analytics, alert를 검증한다.
-6. `ASSET_CLEANUP_SECRET`을 secret store에 등록하고 scheduler의 인증 header, 주기, timeout, 실패 alert를 검증한다.
-7. 약관·개인정보 처리방침 URL과 store privacy/data safety 정보를 검토한다.
-8. 최소 Mobile 버전, 강제 업데이트, Web rollback, on-call 담당자를 승인한다.
-9. 최종 GO 회의에서 Release manager와 DB operator가 각각 서명한다.
+3. 원격 history에만 있는 `20260403070821`, `20260423112332`, `20260427021704`,
+   `20260427023948`의 출처와 실제 객체를 보존·분류한다.
+4. Production 전용 `app_versions`, `delete_user()`, `profiles.kakao_id`, push 함수·정책 등 `public`
+   schema 차이가 의도된 운영 차이인지 누락된 migration인지 판정한다.
+5. 원격 전용 version을 삭제하거나 local version 전체를 일괄 repair하지 않는다.
+6. 승인된 정합화 이후 `db push --dry-run` 결과를 release ticket에 저장한다.
+7. managed DB backup, logical export, Storage manifest/object export를 만든다.
+8. Web/Mobile env, OAuth redirect, 이메일 발신, push, Maps, analytics, alert를 검증한다.
+9. `ASSET_CLEANUP_SECRET`을 secret store에 등록하고 scheduler의 인증 header, 주기, timeout, 실패 alert를 검증한다.
+10. 약관·개인정보 처리방침 URL과 store privacy/data safety 정보를 검토한다.
+11. 최소 Mobile 버전, 강제 업데이트, Web rollback, on-call 담당자를 승인한다.
+12. 최종 GO 회의에서 Release manager와 DB operator가 각각 서명한다.
 
 Production preflight에서는 고객 row를 수정하는 테스트를 하지 않는다. 승인된 내부 계정 smoke는 migration과
 client 배포 후 내부 rollout 단계에서 수행한다.

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -127,7 +127,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-056-production-data-integrity-and-cost-gate.md` | 구현 완료, 운영 gate 대기 | 코드 gate PASS; DEV/Production/legacy 삭제 NO-GO, PR [#369](https://github.com/ysjee141/nexvoy-frontend/pull/369) |
 | `TASK-057-production-final-validation.md` | 문서화 완료 | Production 마스터 Gate, 자동·수동 통합 테스트, 증적·출시 Runbook, Issue [#370](https://github.com/ysjee141/nexvoy-frontend/issues/370) |
 | `TASK-058-production-p0-integration-automation.md` | 대기 | 초대·권한·계정·템플릿·asset·재시도 P0 자동화 |
-| `TASK-059-dev-migration-production-gate.md` | 대기 | DEV migration ledger 정합화, TASK-056 정상 적용, remote-safe smoke |
+| `TASK-059-dev-migration-production-gate.md` | 대기 | DEV 객체 fingerprint, migration history 정합화, remote-safe smoke |
 | `TASK-060-cross-platform-device-validation.md` | 대기 | Web·Android·iOS 실기기, 다중 계정, asset 전체 회귀 |
 | `TASK-061-dev-stability-cost-soak.md` | 대기 | DEV 연속 7일 안정성·비용 관측 |
 | `TASK-062-disaster-recovery-rehearsal.md` | 대기 | DB·Storage 격리 복구와 RTO/RPO 검증 |
@@ -234,7 +234,7 @@ rotating room secret 보안 하드닝을 완료했다.
 ### Phase 10: Production Final Validation
 
 - [ ] `TASK-058-production-p0-integration-automation.md`: Production P0 통합 테스트 자동화
-- [ ] `TASK-059-dev-migration-production-gate.md`: DEV migration 정합화와 원격 Gate
+- [ ] `TASK-059-dev-migration-production-gate.md`: DEV 객체·migration history 정합화와 원격 Gate
 - [ ] `TASK-060-cross-platform-device-validation.md`: Web·Mobile 실기기 통합 검증
 - [ ] `TASK-061-dev-stability-cost-soak.md`: DEV 안정성·비용 7일 관측
 - [ ] `TASK-062-disaster-recovery-rehearsal.md`: DB·Storage 재해 복구 rehearsal
@@ -259,7 +259,7 @@ flowchart TD
     T55 --> T56["TASK-056 Production 코드 gate"]
     T56 --> T57["TASK-057 최종 검증 문서화"]
     T57 --> T58["TASK-058 P0 자동화"]
-    T58 --> T59["TASK-059 DEV migration"]
+    T58 --> T59["TASK-059 DEV schema/history"]
     T59 --> T60["TASK-060 실기기 통합"]
     T60 --> T61["TASK-061 7일 관측"]
     T60 --> T62["TASK-062 복구 rehearsal"]
@@ -274,5 +274,5 @@ flowchart TD
 5. `TASK-055`는 신규 경로 검증 전 실행하지 않는다.
 6. `TASK-056`에서 Initial Production go/no-go를 판정한다.
 7. `TASK-057`에서 최종 검증 기준과 Runbook을 확정한다.
-8. `TASK-058`~`TASK-060`에서 자동화, DEV migration, 실기기 Gate를 순서대로 통과한다.
+8. `TASK-058`~`TASK-060`에서 자동화, DEV schema/history, 실기기 Gate를 순서대로 통과한다.
 9. `TASK-061` 관측과 `TASK-062` 복구를 병렬 완료한 뒤 `TASK-063`에서 단계적 출시를 승인한다.

--- a/docs/refactor/tasks/TASK-056-production-data-integrity-and-cost-gate.md
+++ b/docs/refactor/tasks/TASK-056-production-data-integrity-and-cost-gate.md
@@ -109,6 +109,7 @@
   byte budget tests를 추가했다.
 - Production rollout/recovery runbook, Initial 비용 baseline, go/no 판정서를 작성했다.
 
-자동화 가능한 코드 gate는 PASS다. 원격 DEV migration history repair, TASK-056 migration 배포,
-실기기 matrix, 7일 지표, DB+Storage restore rehearsal은 운영 증적이 없으므로 DEV와 Production은
-NO-GO로 유지한다. Legacy object 물리 삭제도 별도 destructive migration 승인 전까지 유예한다.
+자동화 가능한 코드 gate는 PASS다. TASK-055/056 핵심 객체는 DEV와 Production에서 확인됐지만
+migration history와 전체 schema fingerprint, 실기기 matrix, 7일 지표, DB+Storage restore rehearsal은
+운영 증적이 없으므로 DEV와 Production은 NO-GO로 유지한다. Legacy object 물리 삭제도 별도 destructive
+migration 승인 전까지 유예한다.

--- a/docs/refactor/tasks/TASK-057-production-final-validation.md
+++ b/docs/refactor/tasks/TASK-057-production-final-validation.md
@@ -2,14 +2,15 @@
 
 - 상태: 문서화 완료, 후속 실행 작업 대기
 - Issue: [#370](https://github.com/ysjee141/nexvoy-frontend/issues/370)
+- Migration 판정 정정: [#372](https://github.com/ysjee141/nexvoy-frontend/issues/372)
 - 선행 작업: `TASK-046`~`TASK-056`
 
 ## 결론
 
 TASK-057은 TASK-056의 코드 게이트 이후 필요한 검증 기준, 테스트 케이스, 실행 Runbook을 확정한다.
 현재 상태는 **Production NO-GO**다. 실제 검증과 출시는 `TASK-058`~`TASK-063`에서 단계적으로 수행하며,
-원격 migration, 실기기 통합 테스트, 7일 관측, DB와 Storage 복구, 출시 책임자 지정이 모두 끝나야
-GO로 전환한다.
+원격 객체와 migration history 정합화, 실기기 통합 테스트, 7일 관측, DB와 Storage 복구, 출시 책임자
+지정이 모두 끝나야 GO로 전환한다.
 
 ## 산출물
 
@@ -25,7 +26,7 @@ GO로 전환한다.
 - 여행, 일정, 준비물, 템플릿, 초대, 권한, asset 전체 제품 회귀
 - Web/Web, Web/Mobile, Mobile/Mobile 및 동일 계정 새 기기 검증
 - offline, 강제 종료, reconnect, Realtime 유실, 충돌, revoke 검증
-- DEV migration ledger 정합화와 TASK-056 migration 적용
+- DEV 객체 fingerprint와 migration history 정합화
 - 7일 운영 지표 관찰과 비용 기준 확인
 - DB와 `place-photos` Storage의 분리 백업·복구 rehearsal
 - Production preflight, canary, 단계적 확대, 중단과 롤백
@@ -40,7 +41,7 @@ GO로 전환한다.
 ## 실행 단계
 
 1. `TASK-058`에서 P0 제품 통합 테스트 자동화를 보완한다.
-2. `TASK-059`에서 DEV schema fingerprint, migration ledger, TASK-056 migration을 검증한다.
+2. `TASK-059`에서 DEV schema fingerprint와 migration history를 정합화한다.
 3. `TASK-060`에서 원격 안전 smoke와 전체 실기기 매트릭스를 실행한다.
 4. `TASK-061`에서 7일 안정성·비용 지표를 수집한다.
 5. `TASK-062`에서 DB+Storage 복구 rehearsal을 통과한다.

--- a/docs/refactor/tasks/TASK-059-dev-migration-production-gate.md
+++ b/docs/refactor/tasks/TASK-059-dev-migration-production-gate.md
@@ -1,4 +1,4 @@
-# TASK-059: DEV Migration 정합화 및 원격 Gate
+# TASK-059: DEV 객체·Migration History 정합화
 
 - 상태: 대기
 - 선행 작업: `TASK-058`
@@ -6,23 +6,29 @@
 
 ## 목적
 
-DEV `ivgkqzwosbjukonlpfdw`의 migration history와 실제 DB object를 일치시키고 TASK-056 migration을
-정상 경로로 적용한다. history repair는 object 존재를 증명한 migration에만 사용한다.
+DEV `ivgkqzwosbjukonlpfdw`의 migration history와 실제 DB object를 일치시킨다. SQL Editor로 직접
+실행한 migration은 객체 적용과 history 등록을 분리해 판정한다. TASK-055/056 핵심 객체는 이미
+확인됐으므로 원본 SQL을 다시 실행하지 않는다.
 
 ## 범위
 
-- 알려진 historical gap 9건의 function·policy·trigger·grant fingerprint
+- 알려진 historical gap 9건과 TASK-056의 function·policy·trigger·grant 전체 fingerprint
+- `SECURITY DEFINER` authority helper·internal·wrapper의 `anon` 실행 권한 회수와 회귀 SQL test
 - 잘못 적용되거나 누락된 migration history 정정
 - `supabase db push --dry-run` 결과 검토
-- `20260723000002` 정상 적용과 history 기록
+- 전체 fingerprint가 일치하는 `20260723000002` history 기록
 - service role 없는 authenticated remote-safe smoke
 - 전·후 migration list, 실행자, 시간, SQL 결과 증적
+- Production 원격 전용 version 4건과 실제 `public` schema 차이를 TASK-063 입력으로 정리
 
 ## 완료 조건
 
-- Local과 DEV migration drift가 0이다.
-- 9개 gap은 object fingerprint와 repair 근거가 각각 존재한다.
-- TASK-056 migration은 history repair가 아닌 정상 migration으로 적용된다.
+- Local과 DEV migration history drift가 0이다.
+- historical gap 9건과 TASK-056은 전체 object fingerprint와 repair 근거가 각각 존재한다.
+- TASK-055/056 원본 SQL을 재실행하지 않고 검증된 version만 history에 등록한다.
+- 부분 적용 version은 별도 forward reconciliation migration과 승인 근거로 정합화한다.
+- 익명 사용자는 authority helper·internal·write wrapper를 실행할 수 없고 authenticated는 공개 wrapper만
+  실행할 수 있다.
 - 권한·revision·멱등성 remote-safe smoke가 PASS한다.
 - 실패 시 중단·복구 절차가 실행 기록과 함께 검증된다.
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,34 @@
+# Walkthrough: TASK-057 Migration Ledger 판정 정정
+
+## 결과
+
+Issue [#372](https://github.com/ysjee141/nexvoy-frontend/issues/372)에서 SQL Editor 수동 실행으로 생성된
+실제 객체와 Supabase migration history를 분리해 판정하도록 TASK-057·TASK-059 문서를 정정했다.
+
+| 환경 | 객체 확인 | History 상태 |
+|---|---|---|
+| DEV `ivgkqzwosbjukonlpfdw` | TASK-055/056 핵심 함수·정책 확인 | historical 9건과 TASK-056 미등록 |
+| Production `runbcaegpefqnljsswhv` | TASK-055/056 핵심 함수·정책 확인 | 로컬 version 대부분 미등록, 원격 전용 4건 |
+
+## 핵심 결정
+
+- TASK-055/056 원본 SQL은 다시 실행하지 않는다.
+- 핵심 객체 존재만으로 완료 처리하지 않고 migration 전체 statement를 fingerprint한다.
+- 양쪽 환경에 남은 authority helper·wrapper의 `anon` 실행 grant는 forward migration과 SQL test로
+  회수한다.
+- 일치하는 version만 하나씩 `migration repair --status applied`로 history에 등록한다.
+- 부분 적용 또는 실제 정의 차이는 새 forward reconciliation migration으로 정리한다.
+- Production의 원격 전용 history와 `public` schema 차이는 삭제·일괄 repair하지 않고 TASK-063에서
+  독립적으로 분류·승인한다.
+
+## 검증
+
+- DEV와 Production의 `supabase migration list`를 읽기 전용으로 확인했다.
+- 양쪽 `public,realtime` schema dump에서 TASK-055/056 핵심 결과를 확인했다.
+- Supabase 연결은 확인 후 DEV로 복원했다.
+
+---
+
 # Walkthrough: TASK-057 Production 최종 검증 계획
 
 ## 결과
@@ -8,7 +39,7 @@ PASS, DEV/Production NO-GO이며, 실제 실행은 `TASK-058`~`TASK-063`으로 �
 
 ```mermaid
 flowchart LR
-    Local["G1 로컬 자동화"] --> Dev["G2 DEV migration"]
+    Local["G1 로컬 자동화"] --> Dev["G2 DEV schema/history"]
     Dev --> Matrix["G3 실기기 통합"]
     Matrix --> Observe["G4 7일 관측"]
     Observe --> Restore["G5 DB+Storage 복구"]
@@ -35,8 +66,8 @@ flowchart LR
 ## 다음 작업
 
 1. `TASK-058`에서 `NEW-A01`~`NEW-A13` P0 자동 테스트를 구현한다.
-2. `TASK-059`에서 DEV historical migration 9건을 fingerprint하고 ledger를 정합화한다.
-3. `TASK-060`에서 TASK-059로 적용된 schema를 기준으로 전체 실기기·asset 매트릭스를 실행한다.
+2. `TASK-059`에서 DEV historical 9건과 TASK-056 전체를 fingerprint하고 history를 정합화한다.
+3. `TASK-060`에서 TASK-059에서 정합화한 schema를 기준으로 전체 실기기·asset 매트릭스를 실행한다.
 4. `TASK-061`·`TASK-062`의 7일 관측과 복구 후 `TASK-063` Production preflight를 진행한다.
 
 ---


### PR DESCRIPTION
## 요약

- SQL 객체 적용과 `supabase_migrations.schema_migrations` history 등록을 분리해 판정하도록
  TASK-056/057/059 및 Production Runbook을 정정했습니다.
- DEV와 Production에서 TASK-055/056 핵심 객체가 확인됐음을 반영하고 원본 SQL 재실행을 금지했습니다.
- 전체 fingerprint가 일치하는 version만 하나씩 history repair하도록 절차를 보수적으로 변경했습니다.
- Production 원격 전용 version 4건과 환경별 `public` schema 차이를 독립 감사 대상으로 명시했습니다.

## 확인 결과

- DEV history에는 historical version 9건과 TASK-056 version이 등록되지 않았습니다.
- Production history에는 로컬 version 대부분이 없고 원격 전용 version 4건이 있습니다.
- 양쪽 환경의 일부 `SECURITY DEFINER` authority helper·wrapper에 예상 밖 `anon` 실행 grant가
  확인됐습니다.
- 익명 grant 회수와 SQL 회귀 테스트는 TASK-059의 forward migration 범위로 분리했습니다.

## 검증

- `pnpm typecheck`
- `pnpm build`
- `pnpm build:mobile`
- 변경 Markdown 상대 링크·anchor 검사
- Markdown 표 열 수 일치 검사
- `git diff --check`

## 운영 참고

- DEV: `ivgkqzwosbjukonlpfdw`
- Production: `runbcaegpefqnljsswhv`
- 이 PR은 문서만 변경하며 SQL 실행, migration history repair, 원격 배포를 수행하지 않습니다.

Closes #372
