### PR TITLE
test(TASK-058): automate production P0 integration gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI Quality Gates
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [refactoring/local-first-architecture, develop, main]
   push:
-    branches: [develop]
+    branches: [refactoring/local-first-architecture, develop]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,19 +2,16 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [refactoring/local-first-architecture, develop, main]
   push:
-    branches: [develop]
+    branches: [refactoring/local-first-architecture, develop]
   workflow_dispatch:
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
       NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: e2e-dummy-key
       NEXT_PUBLIC_APP_URL: http://localhost:3001
       CI: "true"
@@ -36,16 +33,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.105.0
+
+      - name: Start local Supabase
+        run: supabase start
+
       - name: Install Playwright browsers
         run: pnpm --filter nexvoy-web exec playwright install --with-deps chromium
 
-      - name: Run E2E tests
-        run: pnpm --filter nexvoy-web test:e2e
+      - name: Run production P0 gate
+        run: |
+          set -o pipefail
+          pnpm test:production:p0 2>&1 | tee production-p0.log
 
-      - name: Upload Playwright report
+      - name: Upload production P0 artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: apps/web/playwright-report/
-          retention-days: 7
+          name: production-p0-${{ github.sha }}
+          path: |
+            production-p0.log
+            apps/web/playwright-report/
+            apps/web/test-results/
+          if-no-files-found: warn
+          retention-days: 14

--- a/apps/mobile/app/trip/[id].tsx
+++ b/apps/mobile/app/trip/[id].tsx
@@ -61,6 +61,7 @@ import {
   PLACE_PHOTO_ORIGINAL_WIDTH,
   PLACE_PHOTO_THUMB_WIDTH,
   derivePlacePhotoThumbUrl,
+  placeIdHash8,
   placePhotoObjectPath,
   type PlacePhotoWidth,
 } from '@nexvoy/core/supabase/storagePaths'
@@ -391,15 +392,6 @@ function PlanCardThumbnailImage({ imageUrl, title }: { imageUrl: string; title: 
       }}
     />
   )
-}
-
-function placeIdHash8(placeId: string): string {
-  let hash = 5381
-  for (let i = 0; i < placeId.length; i += 1) {
-    hash = ((hash << 5) + hash) + placeId.charCodeAt(i)
-    hash |= 0
-  }
-  return Math.abs(hash).toString(16).padStart(8, '0').slice(0, 8)
 }
 
 function decodeHtmlEntity(value: string): string {

--- a/apps/mobile/lib/data/server-authority/__tests__/sqliteStore.test.ts
+++ b/apps/mobile/lib/data/server-authority/__tests__/sqliteStore.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   applyOptimisticAuthorityCommandsToBundle,
+  type AuthorityApplyResult,
   type AuthorityCommand,
   type AuthorityOutboxRecord,
   type AuthorityResourceType,
@@ -80,32 +81,40 @@ test('canonical acknowledgement removes acked commands and rebases pending proje
     now: T2,
   })
   await store.markSending(ACCOUNT_A, [first.operationId], T2)
-  await store.applyAcknowledgement(
-    ACCOUNT_A,
-    {
-      status: 'applied',
-      resourceType: 'trip',
-      resourceId: TRIP_ID,
-      revision: 2,
-      serverUpdatedAt: T2,
-      acknowledgedOperationIds: [first.operationId],
-      changes: [{
-        operationId: first.operationId,
-        entityType: 'plan',
-        entityId: first.entityId,
-        action: 'upsert',
-        row: { id: first.entityId, title: 'canonical', version: 1, updated_at: T2 },
-      }],
-    },
-    T2,
-  )
+  const acknowledgement: AuthorityApplyResult = {
+    status: 'applied',
+    resourceType: 'trip',
+    resourceId: TRIP_ID,
+    revision: 2,
+    serverUpdatedAt: T2,
+    acknowledgedOperationIds: [first.operationId],
+    changes: [{
+      operationId: first.operationId,
+      entityType: 'plan',
+      entityId: first.entityId,
+      action: 'upsert',
+      row: { id: first.entityId, title: 'canonical', version: 1, updated_at: T2 },
+    }],
+  }
+  await store.applyAcknowledgement(ACCOUNT_A, acknowledgement, T2)
 
-  const outbox = await store.listReadyOutbox(ACCOUNT_A, T2, 10)
+  let outbox = await store.listReadyOutbox(ACCOUNT_A, T2, 10)
   assert.equal(outbox.length, 1)
   assert.equal(outbox[0]?.operationId, second.operationId)
   assert.equal(outbox[0]?.baseRevision, 2)
-  const bundle = await store.getResource(ACCOUNT_A, 'trip', TRIP_ID)
+  let bundle = await store.getResource(ACCOUNT_A, 'trip', TRIP_ID)
   assert.equal(bundle?.revision, 2)
+  assert.deepEqual(
+    (bundle?.data.plans as Array<{ id: string }>).map((plan) => plan.id).sort(),
+    ['plan-1', 'plan-2'],
+  )
+
+  await store.applyAcknowledgement(ACCOUNT_A, acknowledgement, T2)
+  outbox = await store.listReadyOutbox(ACCOUNT_A, T2, 10)
+  bundle = await store.getResource(ACCOUNT_A, 'trip', TRIP_ID)
+  assert.equal(outbox.length, 1)
+  assert.equal(outbox[0]?.operationId, second.operationId)
+  assert.equal(outbox[0]?.baseRevision, 2)
   assert.deepEqual(
     (bundle?.data.plans as Array<{ id: string }>).map((plan) => plan.id).sort(),
     ['plan-1', 'plan-2'],

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@react-native-community/cli": "20.2.0",
     "@react-native/metro-config": "0.81.5",
+    "@types/node": "^20.19.35",
     "@types/react": "~19.1.17",
     "babel-preset-expo": "^54.0.11",
     "eslint": "^9.39.4",

--- a/apps/web/app/api/places/photo/store/route.ts
+++ b/apps/web/app/api/places/photo/store/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { createHash } from 'crypto'
 import {
   PLACE_PHOTO_ORIGINAL_WIDTH,
   PLACE_PHOTO_THUMB_WIDTH,
+  placeIdHash8,
   placePhotoObjectPath,
   type PlacePhotoWidth,
 } from '@nexvoy/core/supabase/storagePaths'
@@ -60,10 +60,6 @@ async function fetchPhotoReferenceByPlaceId(
         console.error('[photo/store] Places Details fetch failed:', message)
         return null
     }
-}
-
-function placeIdHash8(placeId: string): string {
-    return createHash('sha256').update(placeId).digest('hex').slice(0, 8)
 }
 
 interface FetchedPhoto {

--- a/apps/web/app/trips/detail/TripClient.tsx
+++ b/apps/web/app/trips/detail/TripClient.tsx
@@ -252,9 +252,10 @@ export default function TripPlansPage({ isActive = true, tripId: propsTripId }: 
         void subscribeWebProductResource(supabase, 'trip', tripId, () => {
             void fetchTrip()
             void fetchPlans()
+            void fetchUserRole()
         }).then((next) => { unsubscribe = next })
         return () => { void unsubscribe?.() }
-    }, [fetchPlans, fetchTrip, supabase, tripId])
+    }, [fetchPlans, fetchTrip, fetchUserRole, supabase, tripId])
 
     const handleDeletePlan = async (planId: string) => {
         if (!tripId) return

--- a/apps/web/e2e/account-isolation.spec.ts
+++ b/apps/web/e2e/account-isolation.spec.ts
@@ -1,0 +1,99 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures/auth'
+import {
+  cleanupTripsByUser,
+  seedAuthorityTrip,
+} from './helpers/seed'
+
+const TEST_PASSWORD = 'E2eTestPassword1!'
+
+test.describe('TASK-058 account-scoped browser data', () => {
+  test('NEW-A06 A to B to A login never exposes another account cache or trip list', async ({
+    createAuthenticatedContextFor,
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id)
+    await cleanupTripsByUser(multiUsers.outsider.id)
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-058 계정 A 전용',
+    })
+
+    try {
+      const ownerContext = await createAuthenticatedContextFor(multiUsers.owner)
+      const page = await ownerContext.newPage()
+      await page.goto('/')
+      await expect(page.getByText('TASK-058 계정 A 전용', { exact: true })).toBeVisible({
+        timeout: 15000,
+      })
+      await expect.poll(
+        () => countCachedTripForAccount(page, multiUsers.owner.id, trip.id),
+        { timeout: 10000 },
+      ).toBe(1)
+
+      await signOut(page)
+      await loginWithEmail(page, multiUsers.outsider.email)
+      await expect(page.getByText('TASK-058 계정 A 전용', { exact: true })).toHaveCount(0)
+      await expect(page.getByText('아직 계획된 여행이 없네요.')).toBeVisible({
+        timeout: 15000,
+      })
+      expect(await countCachedTripForAccount(page, multiUsers.outsider.id, trip.id)).toBe(0)
+
+      await signOut(page)
+      await loginWithEmail(page, multiUsers.owner.email)
+      await expect(page.getByText('TASK-058 계정 A 전용', { exact: true })).toBeVisible({
+        timeout: 15000,
+      })
+      expect(await countCachedTripForAccount(page, multiUsers.outsider.id, trip.id)).toBe(0)
+      expect(await countCachedTripForAccount(page, multiUsers.owner.id, trip.id)).toBe(1)
+    } finally {
+      await cleanupTripsByUser(multiUsers.owner.id)
+      await cleanupTripsByUser(multiUsers.outsider.id)
+    }
+  })
+})
+
+async function signOut(page: Page): Promise<void> {
+  await page.getByRole('button', { name: '로그아웃' }).click()
+  await expect(page.getByRole('link', { name: '로그인', exact: true })).toBeVisible({
+    timeout: 15000,
+  })
+}
+
+async function loginWithEmail(page: Page, email: string): Promise<void> {
+  await page.goto('/login')
+  await page.getByRole('button', { name: '이메일로 계속하기' }).click()
+  await page.locator('input[type="email"]').fill(email)
+  await page.locator('input[type="password"]').fill(TEST_PASSWORD)
+  await page.getByRole('button', { name: '여정 시작하기' }).click()
+  await expect(page.getByRole('button', { name: '로그아웃' })).toBeVisible({
+    timeout: 15000,
+  })
+  await page.goto('/')
+}
+
+async function countCachedTripForAccount(
+  page: Page,
+  accountId: string,
+  tripId: string,
+): Promise<number> {
+  return page.evaluate(async ({ selectedAccount, selectedTrip }) => {
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('onvoy-server-authority')
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    const transaction = database.transaction('resources', 'readonly')
+    const rows = await new Promise<Array<{
+      accountId?: string
+      resourceId?: string
+    }>>((resolve, reject) => {
+      const request = transaction.objectStore('resources').getAll()
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    database.close()
+    return rows.filter(
+      (row) => row.accountId === selectedAccount && row.resourceId === selectedTrip,
+    ).length
+  }, { selectedAccount: accountId, selectedTrip: tripId })
+}

--- a/apps/web/e2e/asset-authority.spec.ts
+++ b/apps/web/e2e/asset-authority.spec.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from 'node:crypto'
+import {
+  PLACE_PHOTO_BUCKET,
+  PLACE_PHOTO_ORIGINAL_WIDTH,
+  placeIdHash8,
+  placePhotoObjectPath,
+} from '@nexvoy/core'
+import { test, expect } from './fixtures/auth'
+import {
+  cleanupPlacePhotoAssets,
+  cleanupTripsByUser,
+  createAuthenticatedTestClient,
+  revokeAuthorityDocumentMember,
+  seedAuthorityDocumentMember,
+  seedAuthorityPlan,
+  seedAuthorityTrip,
+} from './helpers/seed'
+import type { TestUser } from './helpers/supabase'
+
+const TEST_IMAGE = new Uint8Array([0xff, 0xd8, 0xff, 0xd9])
+
+test.describe('TASK-058 place photo authority', () => {
+  test('NEW-A08 canonical path writes and metadata follow trip authority', async ({
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id)
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-058 자산 권한',
+    })
+    const plan = await seedAuthorityPlan(multiUsers.owner, trip, '자산 검증 일정')
+    await seedAuthorityDocumentMember(trip.id, multiUsers.viewer, 'viewer')
+    const editorMember = await seedAuthorityDocumentMember(
+      trip.id,
+      multiUsers.editor,
+      'editor',
+    )
+
+    const ownerPath = pathFor(multiUsers.owner, trip.id, plan.id, 'owner-place', 800)
+    const editorPath = pathFor(multiUsers.editor, trip.id, plan.id, 'editor-place', 800)
+    const editorDeletePath = pathFor(
+      multiUsers.editor,
+      trip.id,
+      plan.id,
+      'editor-delete-place',
+      240,
+    )
+    const viewerPath = pathFor(multiUsers.viewer, trip.id, plan.id, 'viewer-place', 800)
+    const outsiderPath = pathFor(multiUsers.outsider, trip.id, plan.id, 'outsider-place', 800)
+    const allPaths = [
+      ownerPath,
+      editorPath,
+      editorDeletePath,
+      viewerPath,
+      outsiderPath,
+    ]
+
+    try {
+      const ownerClient = createAuthenticatedTestClient(multiUsers.owner)
+      const editorClient = createAuthenticatedTestClient(multiUsers.editor)
+      const viewerClient = createAuthenticatedTestClient(multiUsers.viewer)
+      const outsiderClient = createAuthenticatedTestClient(multiUsers.outsider)
+
+      expect(await upload(ownerClient, ownerPath)).toBeNull()
+      expect(await upload(editorClient, editorPath)).toBeNull()
+      expect(await upload(editorClient, editorDeletePath)).toBeNull()
+      expect(await upload(viewerClient, viewerPath)).toMatch(/row-level security|not authorized/i)
+      expect(await upload(outsiderClient, outsiderPath)).toMatch(/row-level security|not authorized/i)
+
+      const malformedPath = placePhotoObjectPath(
+        multiUsers.editor.id,
+        randomUUID(),
+        plan.id,
+        placeIdHash8('wrong-trip'),
+        PLACE_PHOTO_ORIGINAL_WIDTH,
+      )
+      expect(await upload(editorClient, malformedPath)).toMatch(/row-level security|not authorized/i)
+
+      expect(await register(ownerClient, trip.id, plan.id, ownerPath, 800)).toBeNull()
+      expect(await register(editorClient, trip.id, plan.id, editorPath, 800)).toBeNull()
+      expect(await register(ownerClient, trip.id, plan.id, ownerPath, 240)).toMatch(
+        /asset_path_forbidden/,
+      )
+      expect(await register(editorClient, trip.id, plan.id, ownerPath, 800)).toMatch(
+        /asset_path_forbidden/,
+      )
+
+      const { data: viewerRows, error: viewerReadError } = await viewerClient
+        .from('trip_asset_objects')
+        .select('object_path')
+        .eq('trip_id', trip.id)
+      expect(viewerReadError).toBeNull()
+      expect(viewerRows?.map((row) => row.object_path).sort()).toEqual(
+        [editorPath, ownerPath].sort(),
+      )
+
+      const { data: outsiderRows, error: outsiderReadError } = await outsiderClient
+        .from('trip_asset_objects')
+        .select('object_path')
+        .eq('trip_id', trip.id)
+      expect(outsiderReadError).toBeNull()
+      expect(outsiderRows).toEqual([])
+
+      const ownerPublicUrl = publicUrl(ownerClient, ownerPath)
+      const editorPublicUrl = publicUrl(editorClient, editorPath)
+      const editorDeletePublicUrl = publicUrl(editorClient, editorDeletePath)
+
+      expect(await remove(viewerClient, ownerPath)).toBeNull()
+      expect((await fetch(ownerPublicUrl)).status).toBe(200)
+      expect(await remove(editorClient, editorDeletePath)).toBeNull()
+      expect((await fetch(editorDeletePublicUrl)).status).not.toBe(200)
+
+      const anonymousDownload = await fetch(ownerPublicUrl)
+      expect(anonymousDownload.status).toBe(200)
+      expect(new Uint8Array(await anonymousDownload.arrayBuffer())).toEqual(TEST_IMAGE)
+
+      await revokeAuthorityDocumentMember(multiUsers.owner, editorMember.id)
+
+      const { data: revokedRows, error: revokedReadError } = await editorClient
+        .from('trip_asset_objects')
+        .select('object_path')
+        .eq('trip_id', trip.id)
+      expect(revokedReadError).toBeNull()
+      expect(revokedRows).toEqual([])
+      expect(await remove(editorClient, editorPath)).toBeNull()
+      expect((await fetch(editorPublicUrl)).status).toBe(200)
+      expect((await fetch(ownerPublicUrl)).status).toBe(200)
+
+      expect(await remove(ownerClient, ownerPath)).toBeNull()
+      expect((await fetch(ownerPublicUrl)).status).not.toBe(200)
+    } finally {
+      await cleanupPlacePhotoAssets(allPaths)
+      await cleanupTripsByUser(multiUsers.owner.id)
+    }
+  })
+})
+
+function pathFor(
+  user: TestUser,
+  tripId: string,
+  planId: string,
+  placeId: string,
+  width: 240 | 800,
+): string {
+  return placePhotoObjectPath(user.id, tripId, planId, placeIdHash8(placeId), width)
+}
+
+async function upload(
+  client: ReturnType<typeof createAuthenticatedTestClient>,
+  objectPath: string,
+): Promise<string | null> {
+  const { error } = await client.storage
+    .from(PLACE_PHOTO_BUCKET)
+    .upload(objectPath, TEST_IMAGE, { contentType: 'image/jpeg', upsert: true })
+  return error?.message ?? null
+}
+
+async function remove(
+  client: ReturnType<typeof createAuthenticatedTestClient>,
+  objectPath: string,
+): Promise<string | null> {
+  const { error } = await client.storage.from(PLACE_PHOTO_BUCKET).remove([objectPath])
+  return error?.message ?? null
+}
+
+function publicUrl(
+  client: ReturnType<typeof createAuthenticatedTestClient>,
+  objectPath: string,
+): string {
+  return client.storage.from(PLACE_PHOTO_BUCKET).getPublicUrl(objectPath).data.publicUrl
+}
+
+async function register(
+  client: ReturnType<typeof createAuthenticatedTestClient>,
+  tripId: string,
+  planId: string,
+  objectPath: string,
+  width: 240 | 800,
+): Promise<string | null> {
+  const { error } = await client.rpc('register_place_photo_asset', {
+    p_trip_id: tripId,
+    p_plan_id: planId,
+    p_object_path: objectPath,
+    p_width: width,
+  })
+  return error?.message ?? null
+}

--- a/apps/web/e2e/authority-permission-revoke.spec.ts
+++ b/apps/web/e2e/authority-permission-revoke.spec.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from 'node:crypto'
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures/auth'
+import type { TestUser } from './helpers/supabase'
+import {
+  cleanupTripsByUser,
+  createAuthenticatedTestClient,
+  getChecklistItemByName,
+  getOrCreateChecklist,
+  revokeAuthorityDocumentMember,
+  seedAuthorityDocumentMember,
+  seedAuthorityTrip,
+  setAuthorityDocumentMemberRole,
+} from './helpers/seed'
+
+test.describe('TASK-058 permission and revoke authority', () => {
+  test('NEW-A03 viewer writes are blocked by both the UI and command RPC', async ({
+    createAuthenticatedContextFor,
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id)
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-058 뷰어 권한',
+    })
+    await seedAuthorityDocumentMember(trip.id, multiUsers.viewer, 'viewer')
+
+    try {
+      const viewerContext = await createAuthenticatedContextFor(multiUsers.viewer)
+      const viewerPage = await viewerContext.newPage()
+      await viewerPage.goto(`/trips/detail?id=${trip.id}&tab=plans&serverAuthority=1`)
+      await expect(viewerPage.getByRole('heading', {
+        name: 'TASK-058 뷰어 권한 여행',
+        exact: true,
+      })).toBeVisible({ timeout: 15000 })
+      await expect(viewerPage.getByRole('button', { name: '일정 추가' })).toHaveCount(0)
+
+      expect(await attemptPlanWrite(multiUsers.viewer, trip.id)).toMatch(
+        /authority_trip_(write_)?forbidden/,
+      )
+    } finally {
+      await cleanupTripsByUser(multiUsers.owner.id)
+    }
+  })
+
+  test('NEW-A04 editor downgrade is reflected on an active screen and blocks the next command', async ({
+    createAuthenticatedContextFor,
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id)
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-058 권한 하향',
+    })
+    const member = await seedAuthorityDocumentMember(trip.id, multiUsers.editor, 'editor')
+
+    try {
+      const editorContext = await createAuthenticatedContextFor(multiUsers.editor)
+      const editorPage = await editorContext.newPage()
+      await editorPage.goto(`/trips/detail?id=${trip.id}&tab=plans&serverAuthority=1`)
+      await expect(editorPage.getByRole('heading', {
+        name: 'TASK-058 권한 하향 여행',
+        exact: true,
+      })).toBeVisible({ timeout: 15000 })
+      await expect(editorPage.getByRole('button', { name: '일정 추가' })).toBeVisible()
+      await editorPage.waitForTimeout(1000)
+
+      await setAuthorityDocumentMemberRole(multiUsers.owner, member.id, 'viewer')
+
+      await expect(editorPage.getByRole('button', { name: '일정 추가' })).toHaveCount(0, {
+        timeout: 15000,
+      })
+      expect(await attemptPlanWrite(multiUsers.editor, trip.id)).toMatch(
+        /authority_trip_(write_)?forbidden/,
+      )
+    } finally {
+      await cleanupTripsByUser(multiUsers.owner.id)
+    }
+  })
+
+  test('NEW-A05 revoked offline work is rejected and its local resource and outbox are purged', async ({
+    createAuthenticatedContextFor,
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id)
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-058 오프라인 회수',
+    })
+    const member = await seedAuthorityDocumentMember(trip.id, multiUsers.editor, 'editor')
+    const checklist = await getOrCreateChecklist(trip.id)
+
+    try {
+      const editorContext = await createAuthenticatedContextFor(multiUsers.editor)
+      const editorPage = await editorContext.newPage()
+      await editorPage.goto(`/trips/detail?id=${trip.id}&tab=checklist&serverAuthority=1`)
+      await expect(editorPage.getByRole('heading', {
+        name: 'TASK-058 오프라인 회수 여행',
+        exact: true,
+      })).toBeVisible({ timeout: 15000 })
+
+      await editorContext.setOffline(true)
+      await editorPage.getByRole('button', { name: '항목 추가' }).click()
+      const itemName = `회수 전 오프라인 항목 ${Date.now()}`
+      await editorPage.getByPlaceholder('어떤 준비물인가요?').fill(itemName)
+      await editorPage.getByRole('button', { name: '추가', exact: true }).click()
+      await expect(editorPage.getByText(itemName)).toBeVisible()
+      await expect(editorPage.getByRole('status', { name: '오프라인 저장', exact: true }).first())
+        .toBeVisible()
+      expect(await getChecklistItemByName(checklist.id, itemName)).toBeNull()
+
+      await revokeAuthorityDocumentMember(multiUsers.owner, member.id)
+      await editorContext.setOffline(false)
+
+      await expect.poll(
+        () => getChecklistItemByName(checklist.id, itemName),
+        { timeout: 15000 },
+      ).toBeNull()
+      await expect.poll(
+        () => readAuthorityLocalCounts(editorPage, multiUsers.editor.id, trip.id),
+        { timeout: 15000 },
+      ).toEqual({ resources: 0, outbox: 0 })
+      expect(await attemptPlanWrite(multiUsers.editor, trip.id)).toMatch(
+        /authority_trip_(write_)?forbidden/,
+      )
+    } finally {
+      await cleanupTripsByUser(multiUsers.owner.id)
+    }
+  })
+})
+
+async function attemptPlanWrite(
+  user: TestUser,
+  tripId: string,
+): Promise<string> {
+  const client = createAuthenticatedTestClient(user)
+  const { data: revision, error: revisionError } = await client.rpc(
+    'get_trip_authority_revision',
+    { p_trip_id: tripId },
+  )
+  if (revisionError) return revisionError.message
+  const planId = randomUUID()
+  const { error } = await client.rpc('apply_trip_commands', {
+    p_trip_id: tripId,
+    p_commands: [{
+      operation_id: randomUUID(),
+      entity_type: 'plan',
+      entity_id: planId,
+      action: 'upsert',
+      payload: {
+        title: '허용되지 않은 일정',
+        start_datetime_local: '2026-07-23T10:00:00',
+        end_datetime_local: '2026-07-23T11:00:00',
+        timezone_string: 'Asia/Seoul',
+      },
+      created_at: new Date().toISOString(),
+    }],
+    p_base_revision: revision,
+  })
+  return error?.message ?? 'write_succeeded'
+}
+
+async function readAuthorityLocalCounts(
+  page: Page,
+  accountId: string,
+  resourceId: string,
+): Promise<{ resources: number; outbox: number }> {
+  return page.evaluate(async ({ accountId: selectedAccount, resourceId: selectedResource }) => {
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('onvoy-server-authority')
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    const readStore = async (storeName: 'resources' | 'outbox') => {
+      const transaction = database.transaction(storeName, 'readonly')
+      const rows = await new Promise<Array<{ accountId?: string; resourceId?: string }>>(
+        (resolve, reject) => {
+          const request = transaction.objectStore(storeName).getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        },
+      )
+      return rows.filter(
+        (row) => row.accountId === selectedAccount && row.resourceId === selectedResource,
+      ).length
+    }
+    const [resources, outbox] = await Promise.all([
+      readStore('resources'),
+      readStore('outbox'),
+    ])
+    database.close()
+    return { resources, outbox }
+  }, { accountId, resourceId })
+}

--- a/apps/web/e2e/checklist.spec.ts
+++ b/apps/web/e2e/checklist.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from './fixtures/auth'
 import {
-  seedTrip,
+  seedAuthorityTrip,
   getOrCreateChecklist,
   getChecklistItemByName,
   getChecklistItem,
@@ -20,7 +20,7 @@ test.describe('체크리스트 핵심 플로우', () => {
     authenticatedContext,
     testUser,
   }) => {
-    const trip = await seedTrip(testUser.id)
+    const trip = await seedAuthorityTrip(testUser)
     await getOrCreateChecklist(trip.id)
 
     const page = await authenticatedContext.newPage()
@@ -40,7 +40,7 @@ test.describe('체크리스트 핵심 플로우', () => {
     authenticatedContext,
     testUser,
   }) => {
-    const trip = await seedTrip(testUser.id)
+    const trip = await seedAuthorityTrip(testUser)
     await getOrCreateChecklist(trip.id)
 
     const page = await authenticatedContext.newPage()

--- a/apps/web/e2e/fixtures/auth.ts
+++ b/apps/web/e2e/fixtures/auth.ts
@@ -14,6 +14,8 @@ export type AuthFixtures = {
     owner: TestUser;
     editor: TestUser;
     viewer: TestUser;
+    outsider: TestUser;
+    inviteMismatch: TestUser;
   };
   createAuthenticatedContextFor: (user: TestUser) => Promise<BrowserContext>;
 };
@@ -92,7 +94,9 @@ export const test = base.extend<AuthFixtures>({
     const owner = await createTestUser(`e2e-owner-${runId}@onvoy.local`, MULTI_USER_PASSWORD);
     const editor = await createTestUser(`e2e-editor-${runId}@onvoy.local`, MULTI_USER_PASSWORD);
     const viewer = await createTestUser(`e2e-viewer-${runId}@onvoy.local`, MULTI_USER_PASSWORD);
-    await use({ owner, editor, viewer });
+    const outsider = await createTestUser(`e2e-outsider-${runId}@onvoy.local`, MULTI_USER_PASSWORD);
+    const inviteMismatch = await createTestUser(`e2e-mismatch-${runId}@onvoy.local`, MULTI_USER_PASSWORD);
+    await use({ owner, editor, viewer, outsider, inviteMismatch });
   },
 
   createAuthenticatedContextFor: async ({ browser }, use) => {

--- a/apps/web/e2e/helpers/seed.ts
+++ b/apps/web/e2e/helpers/seed.ts
@@ -39,6 +39,16 @@ function getServiceClient(): SupabaseClient {
   return cachedClient;
 }
 
+export function createAuthenticatedTestClient(user: TestUser): SupabaseClient {
+  const url = getEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const anonKey = getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  assertLocalSupabaseUrl(url);
+  return createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: `Bearer ${user.accessToken}` } },
+  });
+}
+
 /** YYYY-MM-DD 형식으로 오늘 기준 offset일 후 날짜를 반환 */
 function dateOffset(days: number): string {
   const d = new Date();
@@ -151,17 +161,118 @@ export async function seedAuthorityDocumentMember(
   documentId: string,
   user: TestUser,
   role: 'editor' | 'viewer',
-): Promise<void> {
+): Promise<{ id: string }> {
   const client = getServiceClient();
-  const { error } = await client.from('document_members').upsert({
-    document_id: documentId,
-    user_id: user.id,
-    invited_email: user.email,
-    role,
-    status: 'accepted',
-    updated_at: new Date().toISOString(),
-  }, { onConflict: 'document_id,user_id' });
-  if (error) throw new Error(`seedAuthorityDocumentMember 실패: ${error.message}`);
+  const { data, error } = await client
+    .from('document_members')
+    .upsert({
+      document_id: documentId,
+      user_id: user.id,
+      invited_email: user.email,
+      role,
+      status: 'accepted',
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'document_id,user_id' })
+    .select('id')
+    .single();
+  if (error || !data) {
+    throw new Error(`seedAuthorityDocumentMember 실패: ${error?.message ?? '데이터 없음'}`);
+  }
+  return { id: data.id as string };
+}
+
+export interface SeededAuthorityInvitation {
+  id: string;
+  token: string;
+  inviteCode: string;
+}
+
+export async function createAuthorityInvitation(
+  owner: TestUser,
+  documentId: string,
+  input: {
+    role?: 'editor' | 'viewer';
+    targetEmail?: string | null;
+    expiresAt?: string | null;
+    maxUses?: number | null;
+  } = {},
+): Promise<SeededAuthorityInvitation> {
+  const client = createAuthenticatedTestClient(owner);
+  const { data, error } = await client.rpc('create_document_invitation_link', {
+    p_document_id: documentId,
+    p_role: input.role ?? 'editor',
+    p_expires_at: input.expiresAt ?? null,
+    p_max_uses: input.maxUses ?? 1,
+    p_target_email: input.targetEmail ?? null,
+    p_destination: 'TASK-058 초대 검증',
+    p_start_date: dateOffset(1),
+    p_end_date: dateOffset(2),
+  });
+  if (error) throw new Error(`createAuthorityInvitation 실패: ${error.message}`);
+  const row = data as { id?: unknown; token?: unknown; invite_code?: unknown } | null;
+  if (
+    !row ||
+    typeof row.id !== 'string' ||
+    typeof row.token !== 'string' ||
+    typeof row.invite_code !== 'string'
+  ) {
+    throw new Error('createAuthorityInvitation 응답 형식이 올바르지 않습니다.');
+  }
+  return { id: row.id, token: row.token, inviteCode: row.invite_code };
+}
+
+export async function setAuthorityDocumentMemberRole(
+  owner: TestUser,
+  memberId: string,
+  role: 'editor' | 'viewer',
+): Promise<void> {
+  const { error } = await createAuthenticatedTestClient(owner).rpc('set_document_member_role', {
+    p_member_id: memberId,
+    p_role: role,
+  });
+  if (error) throw new Error(`setAuthorityDocumentMemberRole 실패: ${error.message}`);
+}
+
+export async function revokeAuthorityDocumentMember(
+  owner: TestUser,
+  memberId: string,
+): Promise<void> {
+  const { error } = await createAuthenticatedTestClient(owner).rpc('revoke_document_member', {
+    p_member_id: memberId,
+  });
+  if (error) throw new Error(`revokeAuthorityDocumentMember 실패: ${error.message}`);
+}
+
+export async function getAuthorityDocumentMember(
+  documentId: string,
+  userId: string,
+): Promise<{ id: string; role: string; status: string } | null> {
+  const { data, error } = await getServiceClient()
+    .from('document_members')
+    .select('id, role, status')
+    .eq('document_id', documentId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) throw new Error(`getAuthorityDocumentMember 실패: ${error.message}`);
+  return (data as { id: string; role: string; status: string } | null) ?? null;
+}
+
+export async function cleanupPlacePhotoAssets(objectPaths: string[]): Promise<void> {
+  if (objectPaths.length === 0) return;
+  const client = getServiceClient();
+  const { error: storageError } = await client.storage
+    .from('place-photos')
+    .remove(objectPaths);
+  if (storageError) {
+    throw new Error(`cleanupPlacePhotoAssets storage 정리 실패: ${storageError.message}`);
+  }
+  const { error: registryError } = await client
+    .from('trip_asset_objects')
+    .delete()
+    .in('object_path', objectPaths);
+  if (registryError) {
+    throw new Error(`cleanupPlacePhotoAssets registry 정리 실패: ${registryError.message}`);
+  }
 }
 
 export async function seedAuthorityPlan(

--- a/apps/web/e2e/invitation-authority.spec.ts
+++ b/apps/web/e2e/invitation-authority.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from './fixtures/auth'
+import {
+  cleanupTripsByUser,
+  createAuthorityInvitation,
+  getAuthorityDocumentMember,
+  seedAuthorityTrip,
+} from './helpers/seed'
+
+test.describe('TASK-058 invitation authority', () => {
+  test('NEW-A01 targeted invitation rejects mismatched account and the invited account accepts from pending UI', async ({
+    createAuthenticatedContextFor,
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id)
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-058 이메일 초대',
+    })
+    const invitation = await createAuthorityInvitation(multiUsers.owner, trip.id, {
+      role: 'editor',
+      targetEmail: multiUsers.editor.email,
+    })
+
+    try {
+      const mismatchContext = await createAuthenticatedContextFor(multiUsers.inviteMismatch)
+      const mismatchPage = await mismatchContext.newPage()
+      await mismatchPage.goto(`/join?token=${encodeURIComponent(invitation.token)}`)
+      await expect(mismatchPage.getByRole('button', { name: '여정에 참여하기' })).toBeVisible()
+      await mismatchPage.getByRole('button', { name: '여정에 참여하기' }).click()
+      await expect(mismatchPage.getByText(/다른 계정으로 발송되었습니다/)).toBeVisible()
+      expect(await getAuthorityDocumentMember(trip.id, multiUsers.inviteMismatch.id)).toBeNull()
+
+      const editorContext = await createAuthenticatedContextFor(multiUsers.editor)
+      const editorPage = await editorContext.newPage()
+      await editorPage.goto('/')
+      await expect(editorPage.getByRole('region', { name: '여행 초대' })).toBeVisible({
+        timeout: 15000,
+      })
+      await expect(editorPage.getByText('새로운 여행 초대 1건')).toBeVisible()
+      await editorPage.getByRole('button', { name: '초대 수락' }).click()
+      await expect(editorPage).toHaveURL(new RegExp(`/trips/detail\\?id=${trip.id}`), {
+        timeout: 15000,
+      })
+      await expect(editorPage.getByRole('heading', {
+        name: 'TASK-058 이메일 초대 여행',
+        exact: true,
+      })).toBeVisible({ timeout: 15000 })
+      await expect.poll(
+        () => getAuthorityDocumentMember(trip.id, multiUsers.editor.id),
+        { timeout: 10000 },
+      ).toMatchObject({ role: 'editor', status: 'accepted' })
+    } finally {
+      await cleanupTripsByUser(multiUsers.owner.id)
+    }
+  })
+
+  test('NEW-A02 link and code invitations enforce expiry and max use', async ({
+    createAuthenticatedContextFor,
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id)
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-058 링크 코드 초대',
+    })
+
+    try {
+      const linkInvitation = await createAuthorityInvitation(multiUsers.owner, trip.id, {
+        role: 'editor',
+        maxUses: 1,
+      })
+      const outsiderContext = await createAuthenticatedContextFor(multiUsers.outsider)
+      const outsiderPage = await outsiderContext.newPage()
+      await outsiderPage.goto(`/join?token=${encodeURIComponent(linkInvitation.token)}`)
+      await expect(outsiderPage.getByRole('button', { name: '여정에 참여하기' })).toBeVisible()
+      await outsiderPage.getByRole('button', { name: '여정에 참여하기' }).click()
+      await expect(outsiderPage.getByRole('heading', {
+        name: 'TASK-058 링크 코드 초대 여행',
+        exact: true,
+      })).toBeVisible({ timeout: 15000 })
+
+      const reusedContext = await createAuthenticatedContextFor(multiUsers.inviteMismatch)
+      const reusedPage = await reusedContext.newPage()
+      await reusedPage.goto(`/join?token=${encodeURIComponent(linkInvitation.token)}`)
+      await expect(reusedPage.getByRole('heading', { name: '초대를 확인할 수 없어요' })).toBeVisible()
+      expect(await getAuthorityDocumentMember(trip.id, multiUsers.inviteMismatch.id)).toBeNull()
+
+      const codeInvitation = await createAuthorityInvitation(multiUsers.owner, trip.id, {
+        role: 'viewer',
+        maxUses: 1,
+      })
+      const viewerContext = await createAuthenticatedContextFor(multiUsers.viewer)
+      const viewerPage = await viewerContext.newPage()
+      await viewerPage.goto('/join')
+      await viewerPage.getByLabel('초대 코드').fill(codeInvitation.inviteCode)
+      await viewerPage.getByRole('button', { name: '초대 확인' }).click()
+      await expect(viewerPage.getByText('권한: 뷰어')).toBeVisible()
+      await viewerPage.getByRole('button', { name: '여정에 참여하기' }).click()
+      await expect(viewerPage.getByRole('heading', {
+        name: 'TASK-058 링크 코드 초대 여행',
+        exact: true,
+      })).toBeVisible({ timeout: 15000 })
+      await expect.poll(
+        () => getAuthorityDocumentMember(trip.id, multiUsers.viewer.id),
+        { timeout: 10000 },
+      ).toMatchObject({ role: 'viewer', status: 'accepted' })
+
+      const expiredInvitation = await createAuthorityInvitation(multiUsers.owner, trip.id, {
+        expiresAt: '2020-01-01T00:00:00.000Z',
+      })
+      await reusedPage.goto(`/join?token=${encodeURIComponent(expiredInvitation.token)}`)
+      await expect(reusedPage.getByRole('heading', { name: '초대를 확인할 수 없어요' })).toBeVisible()
+    } finally {
+      await cleanupTripsByUser(multiUsers.owner.id)
+    }
+  })
+})

--- a/apps/web/e2e/server-authority-product.spec.ts
+++ b/apps/web/e2e/server-authority-product.spec.ts
@@ -180,4 +180,65 @@ test.describe('TASK-050 Web server-authority product integration', () => {
       await cleanupTripsByUser(multiUsers.owner.id);
     }
   });
+
+  test('NEW-A09 retrying the local conflict rebases once and converges', async ({
+    createAuthenticatedContextFor,
+    multiUsers,
+  }) => {
+    await cleanupTripsByUser(multiUsers.owner.id);
+    const trip = await seedAuthorityTrip(multiUsers.owner, {
+      destination: 'TASK-058 로컬 충돌 재적용',
+    });
+    await seedAuthorityDocumentMember(trip.id, multiUsers.editor, 'editor');
+    const plan = await seedAuthorityPlan(multiUsers.owner, trip, '재적용 공통 일정');
+
+    try {
+      const ownerContext = await createAuthenticatedContextFor(multiUsers.owner);
+      const editorContext = await createAuthenticatedContextFor(multiUsers.editor);
+      const ownerPage = await ownerContext.newPage();
+      const editorPage = await editorContext.newPage();
+      const detailUrl = `/trips/detail?id=${trip.id}&tab=plans&serverAuthority=1`;
+      await Promise.all([ownerPage.goto(detailUrl), editorPage.goto(detailUrl)]);
+      await Promise.all([
+        expect(ownerPage.getByText(plan.title, { exact: true })).toBeVisible({ timeout: 15000 }),
+        expect(editorPage.getByText(plan.title, { exact: true })).toBeVisible({ timeout: 15000 }),
+      ]);
+
+      const ownerTitle = '소유자 로컬 재적용';
+      const editorTitle = '편집자 로컬 재적용';
+      for (const [page, nextTitle] of [
+        [ownerPage, ownerTitle],
+        [editorPage, editorTitle],
+      ] as const) {
+        await page.getByRole('button', { name: `일정 수정: ${plan.title}`, exact: true }).click();
+        await page.getByPlaceholder('예: 근사한 저녁 식사, 박물관 투어').fill(nextTitle);
+      }
+
+      await Promise.all([ownerContext.setOffline(true), editorContext.setOffline(true)]);
+      await Promise.all([
+        ownerPage.getByRole('button', { name: '수정 완료', exact: true }).click(),
+        editorPage.getByRole('button', { name: '수정 완료', exact: true }).click(),
+      ]);
+      await Promise.all([ownerContext.setOffline(false), editorContext.setOffline(false)]);
+
+      await expect.poll(async () => (
+        await ownerPage.getByRole('button', { name: /해결 방법 선택/ }).count() +
+        await editorPage.getByRole('button', { name: /해결 방법 선택/ }).count()
+      ), { timeout: 15000 }).toBe(1);
+
+      const ownerHasConflict = await ownerPage.getByRole('button', { name: /해결 방법 선택/ }).count() > 0;
+      const conflictPage = ownerHasConflict ? ownerPage : editorPage;
+      const retriedTitle = ownerHasConflict ? ownerTitle : editorTitle;
+      await conflictPage.getByRole('button', { name: /해결 방법 선택/ }).click();
+      await conflictPage.getByRole('button', { name: '이 기기 변경 다시 적용', exact: true }).click();
+
+      await expect.poll(async () => await getPlanById(plan.id), {
+        timeout: 15000,
+      }).toMatchObject({ id: plan.id, title: retriedTitle, version: 3 });
+      await expect(ownerPage.getByText(retriedTitle, { exact: true })).toBeVisible({ timeout: 15000 });
+      await expect(editorPage.getByText(retriedTitle, { exact: true })).toBeVisible({ timeout: 15000 });
+    } finally {
+      await cleanupTripsByUser(multiUsers.owner.id);
+    }
+  });
 });

--- a/apps/web/e2e/template-authority.spec.ts
+++ b/apps/web/e2e/template-authority.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from './fixtures/auth'
+import {
+  cleanupTemplatesByUser,
+  cleanupTripsByUser,
+  getChecklistItemBySourceTemplate,
+  getOrCreateChecklist,
+  getTemplateByTitle,
+  getTemplateItems,
+  seedAuthorityTrip,
+} from './helpers/seed'
+
+test.describe('TASK-058 template authority product flow', () => {
+  test('NEW-A07 template create, item replacement, and trip application converge', async ({
+    authenticatedContext,
+    testUser,
+  }) => {
+    await cleanupTemplatesByUser(testUser.id)
+    await cleanupTripsByUser(testUser.id)
+    const trip = await seedAuthorityTrip(testUser, {
+      destination: 'TASK-058 템플릿 적용',
+    })
+    const checklist = await getOrCreateChecklist(trip.id)
+    const initialTitle = `TASK-058 템플릿 ${Date.now()}`
+    const updatedTitle = `${initialTitle} 수정`
+    const firstItem = '여권'
+    const replacedItem = '충전기'
+    const addedItem = '상비약'
+
+    try {
+      const page = await authenticatedContext.newPage()
+      await page.goto('/templates')
+      await expect(page.getByRole('heading', { name: '내 체크리스트 템플릿' })).toBeVisible({
+        timeout: 15000,
+      })
+      await page.getByRole('button', { name: '새 템플릿 만들기' }).click()
+      await page.getByPlaceholder(/여름 바다 여행 필수템/).fill(initialTitle)
+      await page.getByPlaceholder('1번째 준비물').fill(firstItem)
+      await page.getByRole('button', { name: '템플릿 저장할게요' }).click()
+
+      await expect(page.getByText(initialTitle, { exact: true })).toBeVisible({ timeout: 15000 })
+      await expect.poll(
+        () => getTemplateByTitle(testUser.id, initialTitle),
+        { timeout: 10000 },
+      ).not.toBeNull()
+      const createdTemplate = await getTemplateByTitle(testUser.id, initialTitle)
+      if (!createdTemplate) throw new Error('Created template was not materialized.')
+
+      await page.getByRole('button', { name: new RegExp(initialTitle) }).click()
+      await expect(page.getByRole('heading', { name: '템플릿 수정하기' })).toBeVisible()
+      const editModal = page.getByRole('heading', { name: '템플릿 수정하기' }).locator('..').locator('..')
+      await editModal.getByPlaceholder(/여름 바다 여행 필수템/).fill(updatedTitle)
+      await editModal.getByPlaceholder('1번째 준비물').fill(replacedItem)
+      await editModal.getByRole('button', { name: '준비물 항목 추가하기' }).click()
+      await editModal.getByPlaceholder('2번째 준비물').fill(addedItem)
+      await editModal.getByRole('button', { name: '변경 내용 저장할게요' }).click()
+
+      await expect(
+        page.getByRole('heading', { name: updatedTitle, exact: true }),
+      ).toBeVisible({ timeout: 15000 })
+      await expect.poll(
+        async () => (await getTemplateItems(createdTemplate.id)).map((item) => item.item_name),
+        { timeout: 10000 },
+      ).toEqual([replacedItem, addedItem])
+
+      await page.goto(`/trips/detail?id=${trip.id}&tab=checklist&serverAuthority=1`)
+      await expect(page.getByRole('heading', {
+        name: 'TASK-058 템플릿 적용 여행',
+        exact: true,
+      })).toBeVisible({ timeout: 15000 })
+      await page.getByRole('button', { name: '템플릿 불러오기' }).filter({ visible: true }).click()
+      await expect(page.getByRole('heading', { name: '템플릿 불러오기' })).toBeVisible()
+      const templateRow = page.getByText(updatedTitle, { exact: true }).locator('..').locator('..')
+      await templateRow.getByRole('button', { name: '가져오기' }).click()
+
+      await expect(page.getByText(replacedItem, { exact: true })).toBeVisible({ timeout: 15000 })
+      await expect(page.getByText(addedItem, { exact: true })).toBeVisible({ timeout: 15000 })
+      await expect.poll(
+        async () => (
+          await getChecklistItemBySourceTemplate(checklist.id, updatedTitle)
+        ).map((item) => item.item_name).sort(),
+        { timeout: 10000 },
+      ).toEqual([addedItem, replacedItem].sort())
+    } finally {
+      await cleanupTemplatesByUser(testUser.id)
+      await cleanupTripsByUser(testUser.id)
+    }
+  })
+})

--- a/apps/web/e2e/trips.spec.ts
+++ b/apps/web/e2e/trips.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from './fixtures/auth';
 import {
-  seedTrip,
+  seedAuthorityTrip,
   getOrCreateChecklist,
   getChecklistItem,
   getChecklistItemByName,
@@ -47,7 +47,7 @@ test.describe('여행 생성 및 체크리스트 플로우', () => {
 
   test('체크리스트 항목 추가 → 체크(완료 처리)', async ({ authenticatedContext, testUser }) => {
     // UI 생성에 의존하지 않고 독립적으로 여행을 시드해 테스트 격리를 보장한다.
-    const trip = await seedTrip(testUser.id);
+    const trip = await seedAuthorityTrip(testUser);
     // 앱이 페이지 마운트 시 체크리스트를 concurrent하게 생성하면 race condition으로
     // 두 개의 checklist가 생성되고 setItems가 덮어쓰이는 문제가 발생한다.
     // 미리 checklist를 생성해 앱이 기존 row를 조회하도록 한다.

--- a/apps/web/lib/server-authority/__tests__/indexedDbStore.test.ts
+++ b/apps/web/lib/server-authority/__tests__/indexedDbStore.test.ts
@@ -267,6 +267,17 @@ async function run(): Promise<void> {
     '전주 후속 변경',
   )
 
+  await store.applyAcknowledgement('account-a', acknowledgement, '2026-07-17T01:04:01.000Z')
+  const duplicateAcknowledgementOutbox = await store.listReadyOutbox('account-a', now, 10)
+  assert.equal(duplicateAcknowledgementOutbox.length, 1)
+  assert.equal(duplicateAcknowledgementOutbox[0]?.operationId, secondOperation)
+  assert.equal(duplicateAcknowledgementOutbox[0]?.baseRevision, 1)
+  assert.equal(
+    ((await store.getResource('account-a', 'trip', tripId))?.data.trip as { destination?: string })
+      .destination,
+    '전주 후속 변경',
+  )
+
   await store.putResource('account-role', {
     ...bundle('role cache', 1),
     data: { ...bundle('role cache', 1).data, _role: 'editor' },

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: 'html',
+  reporter: process.env.CI
+    ? [
+        ['line'],
+        ['html', { open: 'never' }],
+        ['junit', { outputFile: 'test-results/junit.xml' }],
+      ]
+    : 'html',
   use: {
     baseURL: 'http://localhost:3001',
     trace: 'on-first-retry',

--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -28,6 +28,7 @@
 - `docs/refactor/tasks/TASK-051-mobile-sqlite-cache-outbox.md`
 - `docs/refactor/runbooks/TASK-051-mobile-sqlite-authority-smoke.md`
 - `docs/refactor/tasks/TASK-052-mobile-server-authority-product-cutover.md`
+- `docs/refactor/tasks/TASK-058-production-p0-integration-automation.md`
 - `docs/refactor/runbooks/TASK-052-mobile-authority-product-smoke.md`
 - `docs/refactor/TECHNICAL-SPEC.md`
 - `docs/refactor/runbooks/TASK-055-legacy-runtime-retirement.md`
@@ -37,3 +38,7 @@
 `TASK-055` 이후 제품 런타임은 Supabase normalized row authority, 계정별 Web IndexedDB/
 Mobile SQLite cache, durable command outbox, Realtime revision invalidation만 사용한다. Yjs, WebRTC,
 document key, encrypted backup, 별도 다운로드 여행 번들은 새 구현에서 사용하지 않는다.
+
+Production P0 자동 Gate는 로컬 Supabase를 시작한 뒤 `pnpm test:production:p0`로 실행한다. 원격
+DEV/Production에는 테스트 service role seed를 실행하지 않는다. 다음 작업 기준은 `TASK-059`의 DEV
+schema fingerprint와 migration history 정합화다.

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -4,6 +4,19 @@
 기준 브랜치: `refactoring/local-first-architecture`  
 현재 목표: **Supabase normalized row authority + account-scoped local cache + durable outbox + Realtime invalidation으로 Web/Mobile 전체 기능을 전환하고 Initial Production gate를 통과한다.**
 
+## 2026-07-23 TASK-058 구현 완료 / PR CI 검증 대기
+
+- `NEW-A01`~`NEW-A13`을 초대, 권한 전이/revoke, 계정 격리, 템플릿, asset, 충돌 재적용,
+  stale sending, SQL 우회 차단, Web/Mobile path 계약 자동 테스트로 구현했다.
+- role 변경 Realtime invalidation이 활성 일정 화면의 `userRole` state를 갱신하지 않던 결함을 수정했다.
+- 기존 E2E의 legacy direct trip fixture를 authority command seed로 교체했다.
+- 장소 사진 hash를 Core SHA-256 구현으로 통일하고 Web/React Native Node crypto 차이를 제거했다.
+- Storage write는 owner/editor, 활성 plan, canonical path를 확인하며 revoke 후 asset metadata 접근을
+  차단한다. 장소 사진 byte는 public provider cache 분류를 유지한다.
+- `pnpm test:production:p0` 단일 명령으로 Core, Web/Mobile store, SQL 7개, 전체 Playwright를
+  로컬 Supabase에서 실행하도록 CI를 구성했다.
+- 신규 forward migration의 DEV/Production 적용과 history 관리는 TASK-059에서 수행한다.
+
 ## 2026-07-23 TASK-057 Migration 판정 정정
 
 - Issue #372에서 SQL 객체 적용과 `supabase_migrations.schema_migrations` history 등록을 분리했다.

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -4,7 +4,7 @@
 기준 브랜치: `refactoring/local-first-architecture`  
 현재 목표: **Supabase normalized row authority + account-scoped local cache + durable outbox + Realtime invalidation으로 Web/Mobile 전체 기능을 전환하고 Initial Production gate를 통과한다.**
 
-## 2026-07-23 TASK-058 구현 완료 / PR CI 검증 대기
+## 2026-07-23 TASK-058 완료
 
 - `NEW-A01`~`NEW-A13`을 초대, 권한 전이/revoke, 계정 격리, 템플릿, asset, 충돌 재적용,
   stale sending, SQL 우회 차단, Web/Mobile path 계약 자동 테스트로 구현했다.
@@ -15,6 +15,8 @@
   차단한다. 장소 사진 byte는 public provider cache 분류를 유지한다.
 - `pnpm test:production:p0` 단일 명령으로 Core, Web/Mobile store, SQL 7개, 전체 Playwright를
   로컬 Supabase에서 실행하도록 CI를 구성했다.
+- PR [#375](https://github.com/ysjee141/nexvoy-frontend/pull/375)의 Quality, E2E, Vercel 검증이
+  동일 release SHA에서 모두 PASS했다.
 - 신규 forward migration의 DEV/Production 적용과 history 관리는 TASK-059에서 수행한다.
 
 ## 2026-07-23 TASK-057 Migration 판정 정정

--- a/docs/refactor/reports/TASK-056-production-go-no-go.md
+++ b/docs/refactor/reports/TASK-056-production-go-no-go.md
@@ -31,7 +31,7 @@ TASK-057의 `G0`~`G7`을 모두 통과해야 Production Gate를 GO로 변경한�
 |---|---|---|---|
 | B-01 | DEV historical version 9건의 전체 객체 fingerprint와 history repair | 미실행 | [TASK-057 Runbook](../runbooks/TASK-057-production-validation-runbook.md#2단계-dev-migration-ledger-정합화) |
 | B-02 | TASK-056 grant hardening, 전체 fingerprint, `20260723000002` history 등록, 원격 안전 smoke | 핵심 객체와 예상 밖 `anon` grant 확인 | 같은 Runbook 3단계 |
-| B-03 | 초대·권한·계정·템플릿·asset P0 자동화 공백 보완 | 미구현 | [통합 테스트 케이스](../test-plans/TASK-057-production-integration-test-cases.md#추가할-자동-테스트) |
+| B-03 | 초대·권한·계정·템플릿·asset P0 자동화 공백 보완 | TASK-058 로컬 PASS, PR CI 증적 대기 | [통합 테스트 케이스](../test-plans/TASK-057-production-integration-test-cases.md#자동화-테스트-목록) |
 | B-04 | Web/Mobile·Mobile/Mobile 실기기 매트릭스 | 미실행 | 같은 테스트 문서의 필수 플랫폼 매트릭스 |
 | B-05 | DEV 7일 운영 지표 | 미실행 | TASK-057 Runbook 5단계 |
 | B-06 | DB와 `place-photos` Storage 복구 rehearsal | 미실행 | TASK-057 Runbook 6단계 |
@@ -39,7 +39,7 @@ TASK-057의 `G0`~`G7`을 모두 통과해야 Production Gate를 GO로 변경한�
 | B-08 | 최소 Mobile 버전, rollout, on-call 책임자 | 미지정 | [마스터 계획](TASK-057-production-final-validation-plan.md#역할과-책임) |
 | B-09 | 환경변수·OAuth·이메일·push·법무·alert 운영 준비 | 미완료 | TASK-057 Runbook 7단계 |
 | B-10 | 내부→5%→25%→100% 단계적 rollout | 미실행 | TASK-057 Runbook 8단계 |
-| B-11 | asset cleanup scheduler·secret, 경로 일치, thumbnail network 검증 | 미완료 | `TASK-058`, `TASK-060`, `TASK-063` |
+| B-11 | asset cleanup scheduler·secret, 경로 일치, thumbnail network 검증 | path 계약·write RLS 완료, 실환경·운영 설정 대기 | `TASK-058`, `TASK-060`, `TASK-063` |
 
 ## 판정 규칙
 

--- a/docs/refactor/reports/TASK-057-production-final-validation-plan.md
+++ b/docs/refactor/reports/TASK-057-production-final-validation-plan.md
@@ -57,7 +57,7 @@ flowchart TD
 |---|---|---|---|---|
 | B-01 | DEV historical version 9건 history 미등록 | 각 migration object fingerprint 일치 후 version별 history repair, 최종 drift 0 | 전·후 migration list, function/policy/trigger 정의, 실행자 | G2 |
 | B-02 | TASK-056 객체·grant·history 상태 미확정 | authority helper/internal/wrapper의 `anon` 실행 권한 제거, 전체 fingerprint 일치, `20260723000002` history 등록, authenticated smoke PASS | schema dump, 익명 호출 차단 SQL test, grant 비교, repair 로그, smoke 결과 | G2 |
-| B-03 | 제품 E2E 자동화 공백 | P0 자동화 케이스 전부 구현·PASS | CI URL, 리포트, 실패 재현 링크 | G1 |
+| B-03 | 제품 E2E 자동화 공백 | TASK-058 구현·로컬 PASS, PR CI 증적 대기 | CI URL, 리포트, 실패 재현 링크 | G1 |
 | B-04 | 실기기·다중 플랫폼 미검증 | 필수 플랫폼 조합과 수동 P0/P1 케이스 100% PASS | 기기/OS/build, 영상·스크린샷, network/Logcat | G3 |
 | B-05 | 7일 운영 지표 없음 | 연속 7일 동안 임계치와 무사고 기준 충족 | GA4/Firebase/Supabase 대시보드 export | G4 |
 | B-06 | DB+Storage 복구 미검증 | 격리 프로젝트에서 동일 기준 시점 데이터와 object 복구 검증 | dump/checksum, object manifest, row count, RTO/RPO | G5 |
@@ -65,7 +65,7 @@ flowchart TD
 | B-08 | Mobile 최소 버전·출시 책임 미확정 | 최소 지원 버전과 강제 업데이트 정책, 배포·on-call 담당자 승인 | release ticket, 연락망, store 설정 | G6 |
 | B-09 | 제품 운영 준비 미확정 | 환경변수, OAuth, 이메일, push, 도메인, 약관·개인정보, alert test PASS | 설정 inventory와 각 검증 링크 | G6 |
 | B-10 | 단계적 rollout 미실행 | 내부→5%→25%→100% 각 hold 구간 통과 | 단계별 지표와 GO 승인 | G7 |
-| B-11 | asset 운영 수명주기 미완료 | cleanup scheduler·secret 설정, Web/Mobile canonical path 일치, DEV thumbnail network 검증 PASS | scheduler 실행 로그, path fixture, network log, orphan 보존·삭제 결과 | G3/G6 |
+| B-11 | asset 운영 수명주기 미완료 | canonical path/write RLS는 TASK-058 완료; cleanup scheduler·secret 설정과 DEV thumbnail network 검증 PASS 필요 | scheduler 실행 로그, path fixture, network log, orphan 보존·삭제 결과 | G3/G6 |
 
 ## 후속 작업 분리
 

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -126,7 +126,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-055-retire-yjs-p2p-encrypted-backup.md` | 구현 완료 | Yjs/P2P/key/custom backup runtime 제거와 V1 reset, Issue #366, PR #367 |
 | `TASK-056-production-data-integrity-and-cost-gate.md` | 구현 완료, 운영 gate 대기 | 코드 gate PASS; DEV/Production/legacy 삭제 NO-GO, PR [#369](https://github.com/ysjee141/nexvoy-frontend/pull/369) |
 | `TASK-057-production-final-validation.md` | 문서화 완료 | Production 마스터 Gate, 자동·수동 통합 테스트, 증적·출시 Runbook, Issue [#370](https://github.com/ysjee141/nexvoy-frontend/issues/370) |
-| `TASK-058-production-p0-integration-automation.md` | 대기 | 초대·권한·계정·템플릿·asset·재시도 P0 자동화 |
+| `TASK-058-production-p0-integration-automation.md` | 구현 완료, PR CI 검증 대기 | `NEW-A01`~`A13`, 로컬 Supabase 단일 Gate, asset write/path hardening, Issue [#374](https://github.com/ysjee141/nexvoy-frontend/issues/374) |
 | `TASK-059-dev-migration-production-gate.md` | 대기 | DEV 객체 fingerprint, migration history 정합화, remote-safe smoke |
 | `TASK-060-cross-platform-device-validation.md` | 대기 | Web·Android·iOS 실기기, 다중 계정, asset 전체 회귀 |
 | `TASK-061-dev-stability-cost-soak.md` | 대기 | DEV 연속 7일 안정성·비용 관측 |
@@ -233,7 +233,7 @@ rotating room secret 보안 하드닝을 완료했다.
 
 ### Phase 10: Production Final Validation
 
-- [ ] `TASK-058-production-p0-integration-automation.md`: Production P0 통합 테스트 자동화
+- [x] `TASK-058-production-p0-integration-automation.md`: Production P0 통합 테스트 자동화
 - [ ] `TASK-059-dev-migration-production-gate.md`: DEV 객체·migration history 정합화와 원격 Gate
 - [ ] `TASK-060-cross-platform-device-validation.md`: Web·Mobile 실기기 통합 검증
 - [ ] `TASK-061-dev-stability-cost-soak.md`: DEV 안정성·비용 7일 관측

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -126,7 +126,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-055-retire-yjs-p2p-encrypted-backup.md` | 구현 완료 | Yjs/P2P/key/custom backup runtime 제거와 V1 reset, Issue #366, PR #367 |
 | `TASK-056-production-data-integrity-and-cost-gate.md` | 구현 완료, 운영 gate 대기 | 코드 gate PASS; DEV/Production/legacy 삭제 NO-GO, PR [#369](https://github.com/ysjee141/nexvoy-frontend/pull/369) |
 | `TASK-057-production-final-validation.md` | 문서화 완료 | Production 마스터 Gate, 자동·수동 통합 테스트, 증적·출시 Runbook, Issue [#370](https://github.com/ysjee141/nexvoy-frontend/issues/370) |
-| `TASK-058-production-p0-integration-automation.md` | 구현 완료, PR CI 검증 대기 | `NEW-A01`~`A13`, 로컬 Supabase 단일 Gate, asset write/path hardening, Issue [#374](https://github.com/ysjee141/nexvoy-frontend/issues/374) |
+| `TASK-058-production-p0-integration-automation.md` | 완료 | `NEW-A01`~`A13`, 로컬 Supabase 단일 Gate, asset write/path hardening, Issue [#374](https://github.com/ysjee141/nexvoy-frontend/issues/374), PR [#375](https://github.com/ysjee141/nexvoy-frontend/pull/375) |
 | `TASK-059-dev-migration-production-gate.md` | 대기 | DEV 객체 fingerprint, migration history 정합화, remote-safe smoke |
 | `TASK-060-cross-platform-device-validation.md` | 대기 | Web·Android·iOS 실기기, 다중 계정, asset 전체 회귀 |
 | `TASK-061-dev-stability-cost-soak.md` | 대기 | DEV 연속 7일 안정성·비용 관측 |

--- a/docs/refactor/tasks/TASK-058-production-p0-integration-automation.md
+++ b/docs/refactor/tasks/TASK-058-production-p0-integration-automation.md
@@ -1,7 +1,8 @@
 # TASK-058: Production P0 통합 테스트 자동화
 
-- 상태: 구현 완료, PR CI 검증 대기
+- 상태: 완료
 - Issue: [#374](https://github.com/ysjee141/nexvoy-frontend/issues/374)
+- PR: [#375](https://github.com/ysjee141/nexvoy-frontend/pull/375)
 - 선행 작업: `TASK-057`
 - 해소 대상: `B-03`, `B-11` 계약 부분
 
@@ -76,7 +77,7 @@ TASK-059의 fingerprint·history 절차에서 forward migration으로 적용한�
 - `pnpm typecheck`, `pnpm build:packages`, `pnpm build`: PASS
 - `pnpm lint:mobile`, `pnpm build:mobile`: PASS
 
-PR CI가 같은 release SHA에서 통과하면 TASK-058을 완료 처리한다.
+PR CI에서 Quality, E2E, Vercel이 같은 release SHA로 모두 PASS했다.
 
 ## 제외 범위
 

--- a/docs/refactor/tasks/TASK-058-production-p0-integration-automation.md
+++ b/docs/refactor/tasks/TASK-058-production-p0-integration-automation.md
@@ -1,6 +1,7 @@
 # TASK-058: Production P0 통합 테스트 자동화
 
-- 상태: 대기
+- 상태: 구현 완료, PR CI 검증 대기
+- Issue: [#374](https://github.com/ysjee141/nexvoy-frontend/issues/374)
 - 선행 작업: `TASK-057`
 - 해소 대상: `B-03`, `B-11` 계약 부분
 
@@ -29,6 +30,53 @@
 - 모든 P0 테스트가 실패 원인을 식별할 수 있는 assertion과 artifact를 남긴다.
 - local-only 보호 장치 우회가 없고 원격 project ref를 넣으면 즉시 중단된다.
 - 전체 자동 Gate 명령과 CI URL을 release 증적에 기록한다.
+
+## 구현 결과
+
+| 범위 | 자동 검증 |
+|---|---|
+| `NEW-A01`~`A02` | 이메일·링크·코드 초대, 대상 불일치, 만료, 재사용 |
+| `NEW-A03`~`A05` | viewer 차단, role 하향 실시간 반영, revoke 후 outbox/cache purge |
+| `NEW-A06` | 동일 브라우저 A→B→A 계정 전환과 IndexedDB 격리 |
+| `NEW-A07` | 템플릿 생성·수정·항목 교체·여행 적용 |
+| `NEW-A08` | owner/editor Storage write, viewer/outsider/revoked 차단, metadata RLS, canonical path |
+| `NEW-A09` | 동일 entity 충돌 후 local 재적용과 revision 3 수렴 |
+| `NEW-A10` | Web IndexedDB/Mobile SQLite stale `sending` 회수와 중복 ACK 멱등성 |
+| `NEW-A11`~`A12` | cross-trip ID 변조, outsider RPC, invitation/revoke/Realtime 경계 SQL |
+| `NEW-A13` | Web/Mobile 공통 SHA-256 hash와 `_w240`/`_w800` object path |
+
+로컬 전체 Gate는 다음 한 명령으로 실행한다.
+
+```bash
+supabase start
+pnpm test:production:p0
+```
+
+명령은 Supabase URL이 `localhost` 또는 `127.0.0.1`이 아니면 즉시 중단한다. CI도 원격 secret 대신
+고정 버전의 로컬 Supabase를 사용하고 Playwright HTML, trace, JUnit, 통합 로그를 SHA별 artifact로
+보존한다.
+
+## Asset 분류
+
+`place-photos`는 사용자 비공개 미디어가 아니라 Google 장소 사진을 캐시하는 public bucket이다.
+object byte 자체는 공개하되 업로드·수정·삭제와 `trip_asset_objects` metadata는 trip authority를
+따른다. `20260723000003_task058_place_photo_write_policy.sql`은 owner/editor, 활성 plan, 사용자
+폴더, trip/plan/hash/width path를 함께 검증하고 revoke 후 metadata 접근도 제거한다. 비공개 사용자
+미디어를 추가할 때는 별도 private bucket과 인증 delivery endpoint를 사용해야 한다.
+
+신규 migration은 로컬 reset에서 검증했으며 DEV/Production 적용은 이 작업에서 수행하지 않는다.
+TASK-059의 fingerprint·history 절차에서 forward migration으로 적용한다.
+
+## 로컬 검증 결과
+
+- `pnpm test:production:p0`: PASS
+  - Core, Web IndexedDB, Mobile SQLite authority 테스트
+  - TASK-046/049/053/054/055/056/058 SQL 테스트
+  - Playwright 23건
+- `pnpm typecheck`, `pnpm build:packages`, `pnpm build`: PASS
+- `pnpm lint:mobile`, `pnpm build:mobile`: PASS
+
+PR CI가 같은 release SHA에서 통과하면 TASK-058을 완료 처리한다.
 
 ## 제외 범위
 

--- a/docs/refactor/test-plans/TASK-057-production-integration-test-cases.md
+++ b/docs/refactor/test-plans/TASK-057-production-integration-test-cases.md
@@ -124,9 +124,9 @@ docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d po
   < supabase/tests/task056_production_gate.sql
 ```
 
-## 추가할 자동 테스트
+## 자동화 테스트 목록
 
-다음 테스트는 별도 구현 PR로 추가한다. P0를 닫기 전 `G1`은 GO가 아니다.
+`NEW-A01`~`NEW-A13`은 TASK-058에서 구현했다. PR CI artifact까지 PASS해야 `G1`을 닫을 수 있다.
 
 | ID | 우선순위 | 제안 위치 | 시나리오 | 핵심 검증 |
 |---|---|---|---|---|
@@ -137,7 +137,7 @@ docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d po
 | NEW-A05 | P0 | 같은 파일 | offline editor revoke 후 reconnect | stale outbox 거부, cache/outbox purge, 재시도 중단 |
 | NEW-A06 | P0 | `account-isolation.spec.ts` | A 로그아웃→B 로그인→A 재로그인 | A/B cache와 목록 교차 노출 0건 |
 | NEW-A07 | P0 | `template-authority.spec.ts` | 템플릿 CRUD·항목 교체·여행 적용 | template revision과 생성된 준비물 정합성 |
-| NEW-A08 | P0 | `asset-authority.spec.ts` + SQL | owner/editor/viewer/revoked asset 접근 | upload/download/delete RLS와 path 검증 |
+| NEW-A08 | P0 | `asset-authority.spec.ts` + SQL | owner/editor/viewer/revoked 장소 사진 접근 | write/delete·metadata RLS, public provider cache 분류, path 검증 |
 | NEW-A09 | P0 | `server-authority-product.spec.ts` | local 변경 재적용 선택 | 새 expected version으로 exactly-once 수렴 |
 | NEW-A10 | P0 | Core/store tests | flush 중 종료와 stale `sending` 복구 | 중복 row 없이 `retryable` 회수 |
 | NEW-A11 | P0 | SQL | command/resource ID 변조와 outsider RPC | 모든 direct/RPC 우회 차단 |
@@ -233,7 +233,7 @@ docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d po
 |---|---|---|---|
 | MAN-X01 | P0 | owner/editor가 사진 업로드 | binary가 command/RPC body를 통과하지 않고 Storage 직접 저장 |
 | MAN-X02 | P1 | 목록과 상세에서 같은 사진 확인 | 목록은 thumbnail, 상세는 필요한 크기만 요청 |
-| MAN-X03 | P0 | viewer/revoked/D가 upload/download/delete 시도 | 정책에 맞지 않는 모든 작업 차단 |
+| MAN-X03 | P0 | viewer/revoked/D가 upload/delete와 metadata 조회 시도 | write와 trip metadata 차단; public 장소 사진 byte는 공개 분류 유지 |
 | MAN-X04 | P1 | 업로드 취소·사진 교체·여행 삭제 후 cleanup | retention 전 사용 object 유지, orphan만 삭제 |
 | MAN-X05 | P1 | 일정 알림 생성·수정·삭제, 앱 재시작 | OS 알림 예약/취소와 일정 상태 일치 |
 | MAN-X06 | P1 | 초대 이메일 전송과 링크 열기 | DEV 발신 설정, redirect, 만료 UI 정상 |

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "start": "pnpm --filter nexvoy-web start",
     "lint:mobile": "pnpm --filter nexvoy-app lint",
     "typecheck": "pnpm --filter @nexvoy/types typecheck && pnpm --filter @nexvoy/design-tokens typecheck && pnpm --filter @nexvoy/core typecheck && pnpm --filter nexvoy-app typecheck",
+    "test:production:p0": "bash scripts/test-production-p0-local.sh",
+    "test:sql:local": "bash scripts/test-local-supabase-sql.sh",
     "test:e2e": "pnpm --filter nexvoy-web test:e2e",
     "test:e2e:ui": "pnpm --filter nexvoy-web test:e2e:ui",
     "test:e2e:report": "pnpm --filter nexvoy-web exec playwright show-report"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@nexvoy/types": "workspace:*",
+    "@noble/hashes": "^1.8.0",
     "date-fns": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/core/src/supabase/__tests__/storagePaths.test.ts
+++ b/packages/core/src/supabase/__tests__/storagePaths.test.ts
@@ -3,6 +3,7 @@ import {
   PLACE_PHOTO_ORIGINAL_WIDTH,
   PLACE_PHOTO_THUMB_WIDTH,
   derivePlacePhotoThumbUrl,
+  placeIdHash8,
   placePhotoObjectPath,
 } from '../storagePaths'
 
@@ -10,13 +11,17 @@ const userId = '00000000-0000-0000-0000-000000000001'
 const tripId = '00000000-0000-0000-0000-000000000002'
 const planId = '00000000-0000-0000-0000-000000000003'
 
+assert.equal(placeIdHash8('ChIJN1t_tDeuEmsRUsoyG83frY4'), '52791f4b')
+assert.equal(placeIdHash8('온여정-place-1'), '4a75843f')
+
+const placeHash = placeIdHash8('ChIJN1t_tDeuEmsRUsoyG83frY4')
 assert.equal(
-  placePhotoObjectPath(userId, tripId, planId, 'abcd1234', PLACE_PHOTO_ORIGINAL_WIDTH),
-  `${userId}/${tripId}/${planId}_abcd1234_w800.jpg`,
+  placePhotoObjectPath(userId, tripId, planId, placeHash, PLACE_PHOTO_ORIGINAL_WIDTH),
+  `${userId}/${tripId}/${planId}_52791f4b_w800.jpg`,
 )
 assert.equal(
-  placePhotoObjectPath(userId, tripId, planId, 'abcd1234', PLACE_PHOTO_THUMB_WIDTH),
-  `${userId}/${tripId}/${planId}_abcd1234_w240.jpg`,
+  placePhotoObjectPath(userId, tripId, planId, placeHash, PLACE_PHOTO_THUMB_WIDTH),
+  `${userId}/${tripId}/${planId}_52791f4b_w240.jpg`,
 )
 
 const publicUrl =

--- a/packages/core/src/supabase/storagePaths.ts
+++ b/packages/core/src/supabase/storagePaths.ts
@@ -1,3 +1,6 @@
+import { sha256 } from '@noble/hashes/sha256'
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils'
+
 // Storage 경로 규칙 — domain.md 기준
 // object path는 bucket 내부 경로다: [user_id]/[trip_id]/[filename]
 // place photo는 place 식별 hash + width suffix로 immutable content path를 만든다.
@@ -10,6 +13,10 @@ export const PLACE_PHOTO_THUMB_WIDTH = 240
 export type PlacePhotoWidth =
   | typeof PLACE_PHOTO_ORIGINAL_WIDTH
   | typeof PLACE_PHOTO_THUMB_WIDTH
+
+export function placeIdHash8(placeId: string): string {
+  return bytesToHex(sha256(utf8ToBytes(placeId))).slice(0, 8)
+}
 
 export function placePhotoObjectPath(
   userId: string,

--- a/packages/types/src/database.generated.ts
+++ b/packages/types/src/database.generated.ts
@@ -1708,6 +1708,10 @@ export type Database = {
         Args: { p_trip_id: string; p_user_id: string }
         Returns: boolean
       }
+      check_can_write_place_photo_object: {
+        Args: { p_object_name: string; p_user_id: string }
+        Returns: boolean
+      }
       check_is_document_editor: {
         Args: { _document_id: string; _user_id: string }
         Returns: boolean
@@ -2057,6 +2061,14 @@ export type Database = {
         Args: { p_role: string; p_trip_member_id: string }
         Returns: undefined
       }
+      template_authority_stale_batch_is_rebasable: {
+        Args: { p_commands: Json; p_template_id: string }
+        Returns: boolean
+      }
+      trip_authority_stale_batch_is_rebasable: {
+        Args: { p_commands: Json; p_trip_id: string }
+        Returns: boolean
+      }
       upsert_key_provisioning_requests_for_user: {
         Args: {
           p_document_id: string
@@ -2216,4 +2228,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@react-native/metro-config':
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.29.0)
+      '@types/node':
+        specifier: ^20.19.35
+        version: 20.19.35
       '@types/react':
         specifier: ~19.1.17
         version: 19.1.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       '@nexvoy/types':
         specifier: workspace:*
         version: link:../types
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       date-fns:
         specifier: ^4.0.0
         version: 4.1.0
@@ -1919,6 +1922,10 @@ packages:
     peerDependencies:
       next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
@@ -8999,6 +9006,8 @@ snapshots:
       react: 19.2.4
       third-party-capital: 1.0.20
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodable/entities@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -11600,9 +11609,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-expo: 1.0.3(eslint@9.39.4)(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
       globals: 16.5.0
@@ -11620,7 +11629,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11631,18 +11640,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -11655,7 +11664,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11666,7 +11675,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/scripts/test-local-supabase-sql.sh
+++ b/scripts/test-local-supabase-sql.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly container_name="${SUPABASE_DB_CONTAINER:-supabase_db_travel-pack}"
+
+if ! docker inspect "$container_name" >/dev/null 2>&1; then
+  echo "Local Supabase database container is not running: $container_name" >&2
+  exit 1
+fi
+
+for sql_file in supabase/tests/*.sql; do
+  echo "Running $sql_file"
+  docker exec -i "$container_name" \
+    psql -v ON_ERROR_STOP=1 -U postgres -d postgres < "$sql_file"
+done

--- a/scripts/test-production-p0-local.sh
+++ b/scripts/test-production-p0-local.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "Supabase CLI is required." >&2
+  exit 1
+fi
+
+eval "$(supabase status -o env)"
+
+case "${API_URL:-}" in
+  http://127.0.0.1:*|http://localhost:*) ;;
+  *)
+    echo "Production P0 tests require local Supabase; got ${API_URL:-unset}." >&2
+    exit 1
+    ;;
+esac
+
+export NEXT_PUBLIC_SUPABASE_URL="$API_URL"
+export NEXT_PUBLIC_SUPABASE_ANON_KEY="$ANON_KEY"
+export SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY"
+export NEXT_PUBLIC_GOOGLE_MAPS_API_KEY="${NEXT_PUBLIC_GOOGLE_MAPS_API_KEY:-e2e-dummy-key}"
+export NEXT_PUBLIC_APP_URL="${NEXT_PUBLIC_APP_URL:-http://localhost:3001}"
+
+pnpm --filter @nexvoy/core test
+pnpm --filter nexvoy-web test:authority
+pnpm --filter nexvoy-app test:authority
+pnpm test:sql:local
+pnpm --filter nexvoy-web test:e2e

--- a/supabase/migrations/20260723000003_task058_place_photo_write_policy.sql
+++ b/supabase/migrations/20260723000003_task058_place_photo_write_policy.sql
@@ -1,0 +1,149 @@
+-- TASK-058: bind place-photo writes to the canonical trip authority boundary.
+--
+-- The bucket caches public Google place imagery, so object bytes remain public.
+-- Upload/update/delete still require an authenticated owner/editor, an active
+-- plan in the trip encoded by the path, and the uploader's own user folder.
+
+CREATE OR REPLACE FUNCTION public.check_can_write_place_photo_object(
+  p_object_name text,
+  p_user_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  path_parts text[];
+  path_trip_id uuid;
+  path_plan_id uuid;
+BEGIN
+  IF p_user_id IS NULL
+    OR p_user_id IS DISTINCT FROM auth.uid()
+    OR NULLIF(p_object_name, '') IS NULL THEN
+    RETURN false;
+  END IF;
+
+  path_parts := string_to_array(p_object_name, '/');
+  IF array_length(path_parts, 1) <> 3
+    OR path_parts[1] <> p_user_id::text
+    OR path_parts[3] !~ '^[0-9a-f-]{36}_[0-9a-f]{8}_w(240|800)\.jpg$' THEN
+    RETURN false;
+  END IF;
+
+  BEGIN
+    path_trip_id := path_parts[2]::uuid;
+    path_plan_id := split_part(path_parts[3], '_', 1)::uuid;
+  EXCEPTION
+    WHEN invalid_text_representation THEN
+      RETURN false;
+  END;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.plans plan
+    WHERE plan.id = path_plan_id
+      AND plan.trip_id = path_trip_id
+      AND plan.deleted_at IS NULL
+  ) THEN
+    RETURN false;
+  END IF;
+
+  RETURN public.check_can_write_authority_trip(path_trip_id, p_user_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.check_can_write_place_photo_object(text, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.check_can_write_place_photo_object(text, uuid) TO authenticated;
+
+DROP POLICY IF EXISTS "trip_asset_objects_select_member" ON public.trip_asset_objects;
+CREATE POLICY "trip_asset_objects_select_member"
+ON public.trip_asset_objects FOR SELECT
+TO authenticated
+USING (
+  public.check_can_read_authority_trip(trip_id, (SELECT auth.uid()))
+);
+
+CREATE OR REPLACE FUNCTION public.register_place_photo_asset(
+  p_trip_id uuid,
+  p_plan_id uuid,
+  p_object_path text,
+  p_width integer,
+  p_bucket_id text DEFAULT 'place-photos'
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  asset_id uuid;
+  file_name text := split_part(p_object_path, '/', 3);
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_trip_id IS NULL
+    OR p_plan_id IS NULL
+    OR p_bucket_id IS DISTINCT FROM 'place-photos'
+    OR p_width IS NULL
+    OR p_width NOT IN (240, 800)
+    OR split_part(p_object_path, '/', 2) <> p_trip_id::text
+    OR split_part(file_name, '_', 1) <> p_plan_id::text
+    OR file_name !~ ('_w' || p_width::text || '\.jpg$')
+    OR NOT public.check_can_write_place_photo_object(p_object_path, auth.uid()) THEN
+    RAISE EXCEPTION 'asset_path_forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.trip_asset_objects (
+    trip_id, plan_id, user_id, bucket_id, object_path, width
+  ) VALUES (
+    p_trip_id, p_plan_id, auth.uid(), p_bucket_id, p_object_path, p_width
+  )
+  ON CONFLICT (bucket_id, object_path) DO UPDATE
+    SET plan_id = EXCLUDED.plan_id,
+        width = EXCLUDED.width
+  RETURNING id INTO asset_id;
+
+  RETURN asset_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.register_place_photo_asset(uuid, uuid, text, integer, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.register_place_photo_asset(uuid, uuid, text, integer, text) TO authenticated;
+
+DROP POLICY IF EXISTS "place_photos_insert_own" ON storage.objects;
+CREATE POLICY "place_photos_insert_own"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND public.check_can_write_place_photo_object(name, (SELECT auth.uid()))
+);
+
+DROP POLICY IF EXISTS "place_photos_update_own" ON storage.objects;
+CREATE POLICY "place_photos_update_own"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND public.check_can_write_place_photo_object(name, (SELECT auth.uid()))
+)
+WITH CHECK (
+  bucket_id = 'place-photos'
+  AND public.check_can_write_place_photo_object(name, (SELECT auth.uid()))
+);
+
+DROP POLICY IF EXISTS "place_photos_delete_own" ON storage.objects;
+CREATE POLICY "place_photos_delete_own"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'place-photos'
+  AND public.check_can_write_place_photo_object(name, (SELECT auth.uid()))
+);
+
+COMMENT ON FUNCTION public.check_can_write_place_photo_object(text, uuid) IS
+  'Validates canonical place-photo path ownership, active plan membership, and trip write authority.';

--- a/supabase/tests/task058_production_p0_automation.sql
+++ b/supabase/tests/task058_production_p0_automation.sql
@@ -1,0 +1,308 @@
+-- TASK-058 production P0 SQL gate.
+-- Verifies cross-resource command tampering, outsider access, invitation
+-- activation, and immediate revoke enforcement for read/write/Realtime.
+-- Run only against local Supabase:
+-- docker exec -i supabase_db_travel-pack psql -v ON_ERROR_STOP=1 -U postgres -d postgres < supabase/tests/task058_production_p0_automation.sql
+
+BEGIN;
+RESET ROLE;
+
+INSERT INTO auth.users (
+  id, instance_id, aud, role, email, encrypted_password, email_confirmed_at,
+  raw_app_meta_data, raw_user_meta_data, created_at, updated_at
+) VALUES
+  ('00000000-0000-0000-0000-000000000581', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'task058-owner@onvoy.local', crypt('password', gen_salt('bf')), now(), '{"provider":"email","providers":["email"]}', '{}', now(), now()),
+  ('00000000-0000-0000-0000-000000000582', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'task058-editor@onvoy.local', crypt('password', gen_salt('bf')), now(), '{"provider":"email","providers":["email"]}', '{}', now(), now()),
+  ('00000000-0000-0000-0000-000000000583', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'task058-outsider@onvoy.local', crypt('password', gen_salt('bf')), now(), '{"provider":"email","providers":["email"]}', '{}', now(), now());
+
+INSERT INTO public.profiles (id, email, nickname) VALUES
+  ('00000000-0000-0000-0000-000000000581', 'task058-owner@onvoy.local', 'owner'),
+  ('00000000-0000-0000-0000-000000000582', 'task058-editor@onvoy.local', 'editor'),
+  ('00000000-0000-0000-0000-000000000583', 'task058-outsider@onvoy.local', 'outsider')
+ON CONFLICT (id) DO UPDATE
+  SET email = EXCLUDED.email, nickname = EXCLUDED.nickname;
+
+CREATE TEMP TABLE task058_state (
+  key text PRIMARY KEY,
+  value text NOT NULL
+) ON COMMIT DROP;
+GRANT SELECT, INSERT, UPDATE ON task058_state TO authenticated;
+
+SET ROLE authenticated;
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000581';
+SET request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000581","email":"task058-owner@onvoy.local"}';
+
+DO $$
+DECLARE
+  result jsonb;
+BEGIN
+  result := public.apply_trip_commands(
+    '58000000-0000-0000-0000-000000000001',
+    jsonb_build_array(jsonb_build_object(
+      'operation_id', '58000000-0000-0000-0000-000000000011',
+      'entity_type', 'trip',
+      'entity_id', '58000000-0000-0000-0000-000000000001',
+      'action', 'upsert',
+      'payload', jsonb_build_object(
+        'destination', '서울',
+        'start_date', '2026-09-01',
+        'end_date', '2026-09-03'
+      )
+    )),
+    0
+  );
+  IF result ->> 'status' <> 'applied' THEN
+    RAISE EXCEPTION 'Expected trip A creation, got %', result;
+  END IF;
+
+  result := public.apply_trip_commands(
+    '58000000-0000-0000-0000-000000000002',
+    jsonb_build_array(jsonb_build_object(
+      'operation_id', '58000000-0000-0000-0000-000000000012',
+      'entity_type', 'trip',
+      'entity_id', '58000000-0000-0000-0000-000000000002',
+      'action', 'upsert',
+      'payload', jsonb_build_object(
+        'destination', '부산',
+        'start_date', '2026-09-05',
+        'end_date', '2026-09-07'
+      )
+    )),
+    0
+  );
+  IF result ->> 'status' <> 'applied' THEN
+    RAISE EXCEPTION 'Expected trip B creation, got %', result;
+  END IF;
+
+  result := public.apply_trip_commands(
+    '58000000-0000-0000-0000-000000000002',
+    jsonb_build_array(jsonb_build_object(
+      'operation_id', '58000000-0000-0000-0000-000000000013',
+      'entity_type', 'plan',
+      'entity_id', '58000000-0000-0000-0000-000000000102',
+      'action', 'upsert',
+      'payload', jsonb_build_object(
+        'title', '부산 일정',
+        'start_datetime_local', '2026-09-05 10:00:00',
+        'end_datetime_local', '2026-09-05 11:00:00',
+        'timezone_string', 'Asia/Seoul'
+      )
+    )),
+    1
+  );
+  IF result ->> 'status' <> 'applied' THEN
+    RAISE EXCEPTION 'Expected trip B plan creation, got %', result;
+  END IF;
+
+  result := public.create_document_invitation_link(
+    '58000000-0000-0000-0000-000000000001',
+    'editor',
+    NULL,
+    1,
+    'task058-editor@onvoy.local',
+    '서울',
+    '2026-09-01',
+    '2026-09-03'
+  );
+  IF result ->> 'token' IS NULL THEN
+    RAISE EXCEPTION 'Expected editor invitation token, got %', result;
+  END IF;
+  INSERT INTO task058_state (key, value) VALUES ('editor_token', result ->> 'token');
+END;
+$$;
+
+-- NEW-A12: acceptance grants canonical read and Realtime topic access.
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000582';
+SET request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000582","email":"task058-editor@onvoy.local"}';
+
+DO $$
+DECLARE
+  result jsonb;
+  invite_token text;
+BEGIN
+  SELECT value INTO invite_token FROM task058_state WHERE key = 'editor_token';
+  result := public.accept_document_invitation(invite_token, NULL);
+  IF result ->> 'status' <> 'accepted' OR result ->> 'role' <> 'editor' THEN
+    RAISE EXCEPTION 'Expected editor acceptance, got %', result;
+  END IF;
+
+  result := public.get_trip_authority_bundle('58000000-0000-0000-0000-000000000001');
+  IF result -> 'trip' ->> 'destination' <> '서울' THEN
+    RAISE EXCEPTION 'Expected accepted editor to read trip A, got %', result;
+  END IF;
+
+  IF NOT public.can_receive_authority_topic(
+    'trip:58000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000582'
+  ) THEN
+    RAISE EXCEPTION 'Expected accepted editor to receive trip A topic';
+  END IF;
+END;
+$$;
+
+-- NEW-A11: an editor cannot attach an entity owned by trip B to trip A.
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.apply_trip_commands(
+      '58000000-0000-0000-0000-000000000001',
+      jsonb_build_array(jsonb_build_object(
+        'operation_id', '58000000-0000-0000-0000-000000000021',
+        'entity_type', 'plan',
+        'entity_id', '58000000-0000-0000-0000-000000000102',
+        'action', 'upsert',
+        'payload', jsonb_build_object('title', '변조된 일정')
+      )),
+      public.get_trip_authority_revision('58000000-0000-0000-0000-000000000001')
+    );
+    RAISE EXCEPTION 'Expected cross-trip plan ID tampering to fail';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+END;
+$$;
+
+-- NEW-A11: an outsider cannot read or write through authority RPCs.
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000583';
+SET request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000583","email":"task058-outsider@onvoy.local"}';
+
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.get_trip_authority_bundle('58000000-0000-0000-0000-000000000001');
+    RAISE EXCEPTION 'Expected outsider bundle read to fail';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+
+  BEGIN
+    PERFORM public.apply_trip_commands(
+      '58000000-0000-0000-0000-000000000001',
+      jsonb_build_array(jsonb_build_object(
+        'operation_id', '58000000-0000-0000-0000-000000000022',
+        'entity_type', 'plan',
+        'entity_id', '58000000-0000-0000-0000-000000000103',
+        'action', 'upsert',
+        'payload', jsonb_build_object(
+          'title', '비회원 일정',
+          'start_datetime_local', '2026-09-02 10:00:00',
+          'end_datetime_local', '2026-09-02 11:00:00',
+          'timezone_string', 'Asia/Seoul'
+        )
+      )),
+      2
+    );
+    RAISE EXCEPTION 'Expected outsider command to fail';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+END;
+$$;
+
+-- Owner revokes the editor after the invitation has been accepted.
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000581';
+SET request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000581","email":"task058-owner@onvoy.local"}';
+
+DO $$
+DECLARE
+  member_id uuid;
+BEGIN
+  SELECT id INTO member_id
+  FROM public.document_members
+  WHERE document_id = '58000000-0000-0000-0000-000000000001'
+    AND user_id = '00000000-0000-0000-0000-000000000582'
+    AND status = 'accepted';
+
+  IF member_id IS NULL THEN
+    RAISE EXCEPTION 'Expected accepted editor membership before revoke';
+  END IF;
+  PERFORM public.revoke_document_member(member_id);
+END;
+$$;
+
+-- NEW-A12: revoke wins over stale clients immediately.
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000582';
+SET request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000582","email":"task058-editor@onvoy.local"}';
+
+DO $$
+DECLARE
+  invite_token text;
+BEGIN
+  IF public.can_receive_authority_topic(
+    'trip:58000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000582'
+  ) THEN
+    RAISE EXCEPTION 'Expected revoked editor to lose trip A topic';
+  END IF;
+
+  BEGIN
+    PERFORM public.get_trip_authority_bundle('58000000-0000-0000-0000-000000000001');
+    RAISE EXCEPTION 'Expected revoked editor bundle read to fail';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+
+  BEGIN
+    PERFORM public.apply_trip_commands(
+      '58000000-0000-0000-0000-000000000001',
+      jsonb_build_array(jsonb_build_object(
+        'operation_id', '58000000-0000-0000-0000-000000000023',
+        'entity_type', 'plan',
+        'entity_id', '58000000-0000-0000-0000-000000000104',
+        'action', 'upsert',
+        'payload', jsonb_build_object(
+          'title', '해지 후 stale 일정',
+          'start_datetime_local', '2026-09-02 12:00:00',
+          'end_datetime_local', '2026-09-02 13:00:00',
+          'timezone_string', 'Asia/Seoul'
+        )
+      )),
+      2
+    );
+    RAISE EXCEPTION 'Expected revoked stale command to fail';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+
+  SELECT value INTO invite_token FROM task058_state WHERE key = 'editor_token';
+  BEGIN
+    PERFORM public.accept_document_invitation(invite_token, NULL);
+    RAISE EXCEPTION 'Expected consumed invitation reuse after revoke to fail';
+  EXCEPTION
+    WHEN OTHERS THEN
+      IF SQLERRM = 'Expected consumed invitation reuse after revoke to fail' THEN
+        RAISE;
+      END IF;
+  END;
+END;
+$$;
+
+RESET ROLE;
+RESET request.jwt.claim.sub;
+RESET request.jwt.claims;
+
+DO $$
+BEGIN
+  IF (SELECT title FROM public.plans WHERE id = '58000000-0000-0000-0000-000000000102') <> '부산 일정' THEN
+    RAISE EXCEPTION 'Cross-resource tampering changed trip B plan';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.plans
+    WHERE id IN (
+      '58000000-0000-0000-0000-000000000103',
+      '58000000-0000-0000-0000-000000000104'
+    )
+  ) THEN
+    RAISE EXCEPTION 'Forbidden outsider or revoked command materialized rows';
+  END IF;
+END;
+$$;
+
+SELECT 'task058_production_p0_automation checks passed' AS result;
+
+ROLLBACK;

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,46 @@
+# Walkthrough: TASK-058 Production P0 통합 테스트 자동화
+
+## 요약
+
+Issue [#374](https://github.com/ysjee141/nexvoy-frontend/issues/374)에 따라 Production G1을 막던
+`NEW-A01`~`NEW-A13`을 로컬 Supabase 기반 자동 Gate로 구현했다. 원격 DEV/Production service role
+seed는 사용하지 않으며, URL guard가 원격 endpoint에서 즉시 실패한다.
+
+## 주요 변경
+
+- 초대, role 하향/revoke, 계정 전환, 템플릿 적용, 충돌 재적용을 실제 제품 UI와 canonical row로 검증한다.
+- Web IndexedDB와 Mobile SQLite에서 stale `sending` 회수와 중복 ACK 멱등성을 검증한다.
+- SQL에서 cross-trip entity ID 변조, outsider RPC, 초대 수락과 revoke 직후 read/write/Realtime 차단을 검증한다.
+- 장소 사진 hash를 공통 Core SHA-256으로 통일하고 Storage write와 metadata를 trip authority에 결합했다.
+- Realtime role 변경 시 일정 화면의 `userRole`도 다시 읽도록 제품 결함을 수정했다.
+- legacy direct trip E2E fixture를 authority command seed로 교체했다.
+- CI가 고정 Supabase CLI와 로컬 스택에서 `pnpm test:production:p0`를 실행하고 SHA별 artifact를 남긴다.
+
+## Asset 보안 경계
+
+`place-photos` byte는 Google 장소 사진 public cache다. owner/editor만 canonical
+`{user}/{trip}/{plan}_{sha256-8}_w{240|800}.jpg` path를 쓸 수 있고 viewer/outsider/revoked는
+write/delete와 `trip_asset_objects` metadata에 접근할 수 없다. 향후 비공개 사용자 미디어는 이
+bucket을 재사용하지 않고 private bucket과 인증 delivery endpoint로 분리한다.
+
+## 검증
+
+- `pnpm test:production:p0` PASS
+  - Core, Web IndexedDB, Mobile SQLite authority 테스트
+  - TASK-046~058 SQL smoke 7개
+  - `NEW-A01`~`NEW-A13`을 포함한 Playwright 23건
+- `pnpm typecheck`, `pnpm build:packages`, `pnpm build` PASS
+- `pnpm lint:mobile`, `pnpm build:mobile` PASS
+- PR CI 결과는 동일 release SHA의 GitHub Actions 증적으로 남긴다.
+
+## 배포 주의
+
+`20260723000003_task058_place_photo_write_policy.sql`은 로컬 reset에서 검증했다. TASK-058에서는 원격
+migration을 적용하지 않으며, TASK-059가 DEV/Production fingerprint와 history를 확인한 뒤 forward
+migration으로 적용한다. Production GO는 TASK-059~063 완료 전 선언하지 않는다.
+
+---
+
 # Walkthrough: TASK-057 Migration Ledger 판정 정정
 
 ## 결과

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -31,7 +31,8 @@ bucket을 재사용하지 않고 private bucket과 인증 delivery endpoint로 �
   - `NEW-A01`~`NEW-A13`을 포함한 Playwright 23건
 - `pnpm typecheck`, `pnpm build:packages`, `pnpm build` PASS
 - `pnpm lint:mobile`, `pnpm build:mobile` PASS
-- PR CI 결과는 동일 release SHA의 GitHub Actions 증적으로 남긴다.
+- PR [#375](https://github.com/ysjee141/nexvoy-frontend/pull/375)의 Quality, E2E, Vercel이 동일
+  release SHA에서 모두 PASS했다.
 
 ## 배포 주의
 


### PR DESCRIPTION
## 요약

- Production P0 `NEW-A01`~`NEW-A13`을 Local Supabase 기반 자동 Gate로 구현
- 초대, 권한 하향/revoke, 계정 격리, 템플릿, asset, 충돌·재시도 흐름을 제품 E2E/SQL/store 테스트로 고정
- Web/Mobile 장소 사진 경로를 공통 SHA-256 계약으로 통일하고 Storage write/metadata 권한을 trip authority에 결합
- Realtime role 변경 시 열린 일정 화면의 사용자 권한도 즉시 갱신
- GitHub Actions에서 원격 Supabase secret 없이 같은 release SHA의 전체 P0 Gate 실행

## 검증

- `pnpm test:production:p0`
  - Core, Web IndexedDB, Mobile SQLite authority 테스트
  - TASK-046/049/053/054/055/056/058 SQL 테스트
  - Playwright 23건
- `pnpm typecheck`
- `pnpm build:packages`
- `pnpm build`
- `pnpm lint:mobile`
- `pnpm build:mobile`

모두 로컬 PASS.

## 배포 주의

- `20260723000003_task058_place_photo_write_policy.sql`은 로컬 reset에서만 검증했습니다.
- DEV/Production 적용은 하지 않았으며 TASK-059의 schema fingerprint/history 정합화 후 forward migration으로 적용합니다.
- `place-photos`는 public Google 장소 사진 cache입니다. 비공개 사용자 미디어는 별도 private bucket과 인증 delivery endpoint가 필요합니다.

Closes #374
