### PR TITLE
fix(TASK-059): harden DEV authority migration gate

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:authority": "tsx lib/server-authority/__tests__/indexedDbStore.test.ts"
+    "test:authority": "tsx lib/server-authority/__tests__/indexedDbStore.test.ts",
+    "test:task059:dev-smoke": "node scripts/task059-remote-safe-smoke.mjs"
   },
   "dependencies": {
     "@next/third-parties": "^16.2.9",

--- a/apps/web/scripts/task059-remote-safe-smoke.mjs
+++ b/apps/web/scripts/task059-remote-safe-smoke.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto'
+import { writeFile } from 'node:fs/promises'
+import { createClient } from '@supabase/supabase-js'
+
+const DEV_PROJECT_REF = 'ivgkqzwosbjukonlpfdw'
+const DEV_URL = `https://${DEV_PROJECT_REF}.supabase.co`
+
+function requireEnv(name) {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`환경변수 누락: ${name}`)
+  return value
+}
+
+function assertRemoteSafety() {
+  if (requireEnv('TASK059_ALLOW_DEV_SMOKE') !== 'yes') {
+    throw new Error('TASK059_ALLOW_DEV_SMOKE=yes가 아니므로 DEV 스모크를 중단합니다.')
+  }
+  const url = requireEnv('TASK059_DEV_SUPABASE_URL').replace(/\/$/, '')
+  if (url !== DEV_URL) {
+    throw new Error(`TASK-059 스모크는 DEV ${DEV_PROJECT_REF}에서만 실행할 수 있습니다.`)
+  }
+  if (process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('service role 환경변수가 설정된 상태에서는 실행하지 않습니다.')
+  }
+  return url
+}
+
+function getQaCredentials(role) {
+  const prefix = `TASK059_QA_${role.toUpperCase()}`
+  const email = requireEnv(`${prefix}_EMAIL`).toLowerCase()
+  if (!email.includes('task059')) {
+    throw new Error(`${prefix}_EMAIL은 TASK-059 전용 계정이어야 합니다.`)
+  }
+  return { email, password: requireEnv(`${prefix}_PASSWORD`) }
+}
+
+async function signIn(url, anonKey, credentials) {
+  const client = createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+  const { data, error } = await client.auth.signInWithPassword(credentials)
+  if (error || !data.user || !data.session) {
+    throw new Error(`QA 계정 로그인 실패: ${credentials.email}: ${error?.message ?? '세션 없음'}`)
+  }
+  return { client, user: data.user }
+}
+
+async function rpc(client, name, parameters) {
+  const { data, error } = await client.rpc(name, parameters)
+  if (error) throw new Error(`${name} 실패 [${error.code ?? 'unknown'}]: ${error.message}`)
+  return data
+}
+
+async function expectRpcDenied(label, client, name, parameters) {
+  const { error } = await client.rpc(name, parameters)
+  if (!error) throw new Error(`${label}: 호출이 허용되었습니다.`)
+  if (
+    error.code !== '42501' &&
+    !/permission|forbidden|not_authenticated|schema cache|could not find/i.test(error.message)
+  ) {
+    throw new Error(`${label}: 예상하지 못한 오류 [${error.code ?? 'unknown'}]: ${error.message}`)
+  }
+}
+
+function dateOffset(days) {
+  const date = new Date()
+  date.setUTCDate(date.getUTCDate() + days)
+  return date.toISOString().slice(0, 10)
+}
+
+function tripCommand(tripId, ownerId, runId) {
+  return {
+    operation_id: randomUUID(),
+    entity_type: 'trip',
+    entity_id: tripId,
+    action: 'upsert',
+    payload: {
+      user_id: ownerId,
+      destination: `TASK-059 DEV SMOKE ${runId}`,
+      start_date: dateOffset(30),
+      end_date: dateOffset(31),
+      adults_count: 1,
+      children_count: 0,
+    },
+    created_at: new Date().toISOString(),
+  }
+}
+
+async function createTargetedInvitation(owner, tripId, role, email) {
+  const result = await rpc(owner, 'create_document_invitation_link', {
+    p_document_id: tripId,
+    p_role: role,
+    p_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    p_max_uses: 1,
+    p_target_email: email,
+    p_destination: 'TASK-059 DEV 스모크',
+    p_start_date: dateOffset(30),
+    p_end_date: dateOffset(31),
+  })
+  if (!result || typeof result.token !== 'string') {
+    throw new Error('create_document_invitation_link 응답에 token이 없습니다.')
+  }
+  return result.token
+}
+
+async function getRevision(client, tripId) {
+  const revision = await rpc(client, 'get_trip_authority_revision', {
+    p_trip_id: tripId,
+  })
+  if (!Number.isSafeInteger(Number(revision))) {
+    throw new Error(`유효하지 않은 revision: ${String(revision)}`)
+  }
+  return Number(revision)
+}
+
+async function applyPlan(client, tripId, runId) {
+  const revision = await getRevision(client, tripId)
+  const command = {
+    operation_id: randomUUID(),
+    entity_type: 'plan',
+    entity_id: randomUUID(),
+    action: 'upsert',
+    payload: {
+      title: `TASK-059 editor plan ${runId}`,
+      location: 'DEV QA',
+      start_datetime_local: `${dateOffset(30)}T10:00:00`,
+      end_datetime_local: `${dateOffset(30)}T11:00:00`,
+      timezone_string: 'Asia/Seoul',
+    },
+    created_at: new Date().toISOString(),
+  }
+  const first = await rpc(client, 'apply_trip_commands', {
+    p_trip_id: tripId,
+    p_commands: [command],
+    p_base_revision: revision,
+  })
+  if (first?.status !== 'applied') {
+    throw new Error(`editor command 상태가 applied가 아닙니다: ${JSON.stringify(first)}`)
+  }
+  const duplicate = await rpc(client, 'apply_trip_commands', {
+    p_trip_id: tripId,
+    p_commands: [command],
+    p_base_revision: revision,
+  })
+  if (duplicate?.status !== 'duplicate' || duplicate.revision !== first.revision) {
+    throw new Error(`멱등 재실행 결과가 올바르지 않습니다: ${JSON.stringify(duplicate)}`)
+  }
+  return { revisionBefore: revision, revisionAfter: Number(first.revision) }
+}
+
+async function findMember(owner, tripId, email) {
+  const rows = await rpc(owner, 'list_document_collaborators', {
+    p_document_id: tripId,
+  })
+  const member = Array.isArray(rows)
+    ? rows.find((row) => String(row.email).toLowerCase() === email)
+    : null
+  if (!member || typeof member.member_id !== 'string') {
+    throw new Error(`accepted collaborator를 찾지 못했습니다: ${email}`)
+  }
+  return member
+}
+
+async function bestEffortCleanup(owner, tripId, memberIds) {
+  for (const memberId of memberIds) {
+    try {
+      await rpc(owner, 'revoke_document_member', { p_member_id: memberId })
+    } catch {
+      // A member already revoked by the test needs no further cleanup.
+    }
+  }
+  try {
+    const revision = await getRevision(owner, tripId)
+    await rpc(owner, 'apply_trip_commands', {
+      p_trip_id: tripId,
+      p_commands: [{
+        operation_id: randomUUID(),
+        entity_type: 'trip',
+        entity_id: tripId,
+        action: 'delete',
+        created_at: new Date().toISOString(),
+      }],
+      p_base_revision: revision,
+    })
+  } catch {
+    // Preserve the original test failure; the report records cleanup status.
+    return false
+  }
+  return true
+}
+
+async function main() {
+  const startedAt = new Date()
+  const url = assertRemoteSafety()
+  const anonKey = requireEnv('TASK059_DEV_SUPABASE_ANON_KEY')
+  const credentials = {
+    owner: getQaCredentials('owner'),
+    editor: getQaCredentials('editor'),
+    viewer: getQaCredentials('viewer'),
+    outsider: getQaCredentials('outsider'),
+  }
+  const signedIn = Object.fromEntries(
+    await Promise.all(
+      Object.entries(credentials).map(async ([role, value]) => [
+        role,
+        await signIn(url, anonKey, value),
+      ]),
+    ),
+  )
+  const anon = createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+  const tripId = randomUUID()
+  const runId = startedAt.toISOString().replace(/\D/g, '').slice(0, 14)
+  const cleanupMemberIds = []
+  let cleanupPassed = false
+
+  try {
+    const createResult = await rpc(signedIn.owner.client, 'apply_trip_commands', {
+      p_trip_id: tripId,
+      p_commands: [tripCommand(tripId, signedIn.owner.user.id, runId)],
+      p_base_revision: 0,
+    })
+    if (createResult?.status !== 'applied') {
+      throw new Error(`여행 생성 결과가 applied가 아닙니다: ${JSON.stringify(createResult)}`)
+    }
+
+    const editorToken = await createTargetedInvitation(
+      signedIn.owner.client,
+      tripId,
+      'editor',
+      credentials.editor.email,
+    )
+    const viewerToken = await createTargetedInvitation(
+      signedIn.owner.client,
+      tripId,
+      'viewer',
+      credentials.viewer.email,
+    )
+    await rpc(signedIn.editor.client, 'accept_document_invitation', {
+      p_token: editorToken,
+      p_invite_code: null,
+    })
+    await rpc(signedIn.viewer.client, 'accept_document_invitation', {
+      p_token: viewerToken,
+      p_invite_code: null,
+    })
+
+    const editorMember = await findMember(
+      signedIn.owner.client,
+      tripId,
+      credentials.editor.email,
+    )
+    const viewerMember = await findMember(
+      signedIn.owner.client,
+      tripId,
+      credentials.viewer.email,
+    )
+    cleanupMemberIds.push(editorMember.member_id, viewerMember.member_id)
+
+    const revisionCheck = await applyPlan(signedIn.editor.client, tripId, runId)
+    if (revisionCheck.revisionAfter !== revisionCheck.revisionBefore + 1) {
+      throw new Error(`revision이 정확히 1 증가하지 않았습니다: ${JSON.stringify(revisionCheck)}`)
+    }
+
+    await rpc(signedIn.viewer.client, 'get_trip_authority_bundle', {
+      p_trip_id: tripId,
+    })
+    await expectRpcDenied(
+      'viewer write',
+      signedIn.viewer.client,
+      'apply_trip_commands',
+      {
+        p_trip_id: tripId,
+        p_commands: [{
+          operation_id: randomUUID(),
+          entity_type: 'trip',
+          entity_id: tripId,
+          action: 'delete',
+          created_at: new Date().toISOString(),
+        }],
+        p_base_revision: await getRevision(signedIn.viewer.client, tripId),
+      },
+    )
+    await expectRpcDenied(
+      'outsider read',
+      signedIn.outsider.client,
+      'get_trip_authority_bundle',
+      { p_trip_id: tripId },
+    )
+    await expectRpcDenied(
+      'anon public write wrapper',
+      anon,
+      'apply_trip_commands',
+      { p_trip_id: tripId, p_commands: [], p_base_revision: 0 },
+    )
+    await expectRpcDenied(
+      'anon internal command function',
+      anon,
+      'apply_one_trip_authority_command',
+      {
+        p_trip_id: tripId,
+        p_command: tripCommand(tripId, signedIn.owner.user.id, runId),
+        p_actor_id: signedIn.owner.user.id,
+      },
+    )
+
+    await rpc(signedIn.owner.client, 'set_document_member_role', {
+      p_member_id: editorMember.member_id,
+      p_role: 'viewer',
+    })
+    await expectRpcDenied(
+      'downgraded editor write',
+      signedIn.editor.client,
+      'apply_trip_commands',
+      {
+        p_trip_id: tripId,
+        p_commands: [{
+          operation_id: randomUUID(),
+          entity_type: 'trip',
+          entity_id: tripId,
+          action: 'delete',
+          created_at: new Date().toISOString(),
+        }],
+        p_base_revision: await getRevision(signedIn.editor.client, tripId),
+      },
+    )
+    await rpc(signedIn.owner.client, 'revoke_document_member', {
+      p_member_id: editorMember.member_id,
+    })
+    await expectRpcDenied(
+      'revoked editor read',
+      signedIn.editor.client,
+      'get_trip_authority_bundle',
+      { p_trip_id: tripId },
+    )
+
+    cleanupPassed = await bestEffortCleanup(
+      signedIn.owner.client,
+      tripId,
+      cleanupMemberIds,
+    )
+    const report = {
+      task: 'TASK-059',
+      projectRef: DEV_PROJECT_REF,
+      startedAt: startedAt.toISOString(),
+      finishedAt: new Date().toISOString(),
+      tripId,
+      status: cleanupPassed ? 'PASS' : 'PASS_WITH_CLEANUP_FAILURE',
+      checks: [
+        'owner trip bootstrap',
+        'targeted editor/viewer invitation acceptance',
+        'editor mutation and duplicate operation idempotency',
+        'viewer read and write denial',
+        'outsider read denial',
+        'anonymous wrapper/internal denial',
+        'editor downgrade and revoke propagation',
+        'revision increment',
+      ],
+      cleanup: cleanupPassed ? 'soft_deleted' : 'failed',
+    }
+    if (process.env.TASK059_SMOKE_REPORT) {
+      await writeFile(process.env.TASK059_SMOKE_REPORT, `${JSON.stringify(report, null, 2)}\n`)
+    }
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+    if (!cleanupPassed) process.exitCode = 1
+  } catch (error) {
+    cleanupPassed = await bestEffortCleanup(
+      signedIn.owner.client,
+      tripId,
+      cleanupMemberIds,
+    )
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(`${reason} (cleanup=${cleanupPassed ? 'soft_deleted' : 'failed'})`)
+  } finally {
+    await Promise.all(
+      Object.values(signedIn).map(({ client }) => client.auth.signOut()),
+    )
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -46,4 +46,6 @@ Production P0 자동 Gate는 로컬 Supabase를 시작한 뒤 `pnpm test:product
 DEV/Production에는 테스트 service role seed를 실행하지 않는다. TASK-059에서 DEV history repair와
 TASK-058/059 forward migration을 적용했고 strict fingerprint는 12/12 version, 185/185 객체가
 일치한다. 전용 임시 QA 네 계정의 authenticated remote-safe smoke도 PASS했으며 계정과 QA 데이터는
-정리했다. Production은 변경하지 않았다. 다음 작업은 TASK-060 실기기 검증이다.
+정리했다. 사용자 승인 후 Production에도 기존 history를 보존하는 target-only 방식으로
+TASK-058/059를 적용했으며 fingerprint는 183/185다. 남은 ledger와 nullability 차이는 TASK-063에서
+처리한다. 다음 작업은 TASK-060 실기기 검증이다.

--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -29,6 +29,9 @@
 - `docs/refactor/runbooks/TASK-051-mobile-sqlite-authority-smoke.md`
 - `docs/refactor/tasks/TASK-052-mobile-server-authority-product-cutover.md`
 - `docs/refactor/tasks/TASK-058-production-p0-integration-automation.md`
+- `docs/refactor/tasks/TASK-059-dev-migration-production-gate.md`
+- `docs/refactor/reports/TASK-059-dev-migration-ledger-audit.md`
+- `docs/refactor/runbooks/TASK-059-dev-migration-ledger.md`
 - `docs/refactor/runbooks/TASK-052-mobile-authority-product-smoke.md`
 - `docs/refactor/TECHNICAL-SPEC.md`
 - `docs/refactor/runbooks/TASK-055-legacy-runtime-retirement.md`
@@ -40,5 +43,7 @@ Mobile SQLite cache, durable command outbox, Realtime revision invalidation만 �
 document key, encrypted backup, 별도 다운로드 여행 번들은 새 구현에서 사용하지 않는다.
 
 Production P0 자동 Gate는 로컬 Supabase를 시작한 뒤 `pnpm test:production:p0`로 실행한다. 원격
-DEV/Production에는 테스트 service role seed를 실행하지 않는다. 다음 작업 기준은 `TASK-059`의 DEV
-schema fingerprint와 migration history 정합화다.
+DEV/Production에는 테스트 service role seed를 실행하지 않는다. TASK-059에서 DEV history repair와
+TASK-058/059 forward migration을 적용했고 strict fingerprint는 12/12 version, 185/185 객체가
+일치한다. 전용 임시 QA 네 계정의 authenticated remote-safe smoke도 PASS했으며 계정과 QA 데이터는
+정리했다. Production은 변경하지 않았다. 다음 작업은 TASK-060 실기기 검증이다.

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -17,16 +17,19 @@
   anonymous 차단과 cleanup을 포함했다.
 - `pnpm test:production:p0`의 Playwright 23건, 전체 SQL, typecheck, package/Web/Mobile build,
   Mobile lint를 통과했다.
-- Production은 읽기 전용으로만 감사했다. 원격 전용 history 4건과 두 checklist `is_private`
-  nullability 차이는 TASK-063 입력으로 유지한다.
+- Production은 처음에는 읽기 전용으로 감사한 뒤 사용자 추가 승인에 따라 기존 원격 history를
+  보존하는 target-only 방식으로 TASK-058/059를 적용했다.
 - 사용자 승인 후 DEV historical history 10건을 객체 재실행 없이 repair하고, dry-run에 남은
   TASK-058/059만 forward migration으로 적용했다.
-- 적용 후 migration drift는 0이고 `public,realtime,storage` strict fingerprint는 12/12 version,
-  185/185 객체가 일치한다. Production은 변경하지 않았다.
+- DEV 적용 후 migration drift는 0이고 `public,realtime,storage` strict fingerprint는 12/12 version,
+  185/185 객체가 일치한다.
 - DEV 임시 Auth 계정 네 개로 service-role 없는 authenticated remote-safe smoke를 실행해 초대,
   editor write·멱등성, viewer/outsider/anonymous 차단, role 하향·revoke와 revision을 검증했다.
 - QA 여행은 soft-delete됐고 임시 Auth 계정은 4/4 삭제됐다. 다음 단계는 TASK-060 Web·Mobile
   실기기 통합 검증이다.
+- Production target-only dry-run은 0건이고 fingerprint는 183/185다. 남은 두 checklist
+  nullability 차이, historical ledger gap, 원격 전용 history 4건과 rollout은 TASK-063 입력으로
+  유지한다.
 
 ## 2026-07-23 TASK-058 완료
 

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -4,6 +4,30 @@
 기준 브랜치: `refactoring/local-first-architecture`  
 현재 목표: **Supabase normalized row authority + account-scoped local cache + durable outbox + Realtime invalidation으로 Web/Mobile 전체 기능을 전환하고 Initial Production gate를 통과한다.**
 
+## 2026-07-27 TASK-059 완료
+
+- 12개 migration version의 185개 function/table/constraint/index/policy/trigger/RLS/grant fingerprint를
+  재현 가능한 manifest와 Node 도구로 고정했다.
+- DEV history 미등록 10건의 객체를 확인했으며, 67개 최종 차이는 TASK-058 asset policy와 TASK-059
+  identity/grant hardening으로 모두 설명된다.
+- authority internal 함수의 accidental Data API EXECUTE를 service role로 제한하고 공개 제품 RPC를
+  authenticated allowlist로 재구성했다.
+- authority helper와 Realtime topic helper는 전달된 user ID가 `auth.uid()`와 다르면 false를 반환한다.
+- service role 없는 DEV 스모크에 owner/editor/viewer/outsider, 초대, 멱등성, role/revoke, revision,
+  anonymous 차단과 cleanup을 포함했다.
+- `pnpm test:production:p0`의 Playwright 23건, 전체 SQL, typecheck, package/Web/Mobile build,
+  Mobile lint를 통과했다.
+- Production은 읽기 전용으로만 감사했다. 원격 전용 history 4건과 두 checklist `is_private`
+  nullability 차이는 TASK-063 입력으로 유지한다.
+- 사용자 승인 후 DEV historical history 10건을 객체 재실행 없이 repair하고, dry-run에 남은
+  TASK-058/059만 forward migration으로 적용했다.
+- 적용 후 migration drift는 0이고 `public,realtime,storage` strict fingerprint는 12/12 version,
+  185/185 객체가 일치한다. Production은 변경하지 않았다.
+- DEV 임시 Auth 계정 네 개로 service-role 없는 authenticated remote-safe smoke를 실행해 초대,
+  editor write·멱등성, viewer/outsider/anonymous 차단, role 하향·revoke와 revision을 검증했다.
+- QA 여행은 soft-delete됐고 임시 Auth 계정은 4/4 삭제됐다. 다음 단계는 TASK-060 Web·Mobile
+  실기기 통합 검증이다.
+
 ## 2026-07-23 TASK-058 완료
 
 - `NEW-A01`~`NEW-A13`을 초대, 권한 전이/revoke, 계정 격리, 템플릿, asset, 충돌 재적용,

--- a/docs/refactor/reports/TASK-059-dev-migration-ledger-audit.md
+++ b/docs/refactor/reports/TASK-059-dev-migration-ledger-audit.md
@@ -79,18 +79,33 @@ Supabase의 기본 함수 권한 때문에 `REVOKE ... FROM PUBLIC`만 사용한
 
 `task059_authority_rpc_grants.sql`은 역할별 EXECUTE와 타 사용자 ID 대입 차단을 검증한다.
 
-## Production 입력
+## Production Target-only 적용
 
-Production `runbcaegpefqnljsswhv`은 읽기 전용으로만 확인하고 DEV 연결로 복구했다.
+Production `runbcaegpefqnljsswhv`은 최초에는 읽기 전용으로 감사했으며, 이후 사용자 추가 승인에 따라
+TASK-058/059만 target-only 방식으로 적용했다.
 
 - 원격 history에는 로컬에 없는 version 4개만 존재한다:
   `20260403070821`, `20260423112332`, `20260427021704`, `20260427023948`
-- 동일 manifest 결과는 116/185 일치, 69개 불일치다.
-- DEV 차이 외에 `checklist_items.is_private`와 `checklist_template_items.is_private`가
-  Production에서 `NOT NULL`이 아니다.
+- 적용 전 동일 manifest 결과는 116/185 일치, 69개 불일치였다.
+- 기존 원격 history 4건의 placeholder와 TASK-058/059만 포함한 격리 workspace의 dry-run에서 두
+  target migration만 확인한 뒤 적용했다.
+- 적용 후 target-only dry-run은 0건이며 history에 `20260723000003`과 `20260727000001`이 등록됐다.
+- fingerprint는 11/12 version, 183/185 객체 일치다. TASK-058/059 대상 차이는 모두 해소됐다.
+- Production anon key로 public write wrapper와 internal command RPC가 모두 `42501`로 차단됨을
+  확인했다. 실제 사용자나 QA 계정·여행은 생성하지 않았다.
 
-Production repair나 migration은 수행하지 않는다. 원격 전용 version의 출처와 두 nullability 차이는
-TASK-063에서 독립적으로 분류·승인한다.
+| Production 증적 | SHA-256 |
+|---|---|
+| 적용 전 schema dump | `1ffa1c0676ff42b62c2fb34e9b696c158a85ba44aeeed681f1d187b8afa0465b` |
+| 적용 전 data dump | `c91dddbc77685d772e26aaec2bfd9b86e161e68cea1d205a81458723a949bcd6` |
+| 적용 전 migration list | `d7c7eb8cdacb0817c8df9d1de6ff677dce208dd46041edaa32bdc5a6989f03fc` |
+| 적용 후 schema dump | `385a89e4464f3931d3aafb007df24c17754723a34c06b217c6e24cd4f21d68ff` |
+| 적용 후 migration list | `66aba3fb19f25a54316be43a5525b8199ea9cd8e22a1c91b5aeeef594de3bf18` |
+| 적용 후 fingerprint 결과 | `7beafbdb40638840a094419a8a724bda1716a3dd0bbb360ad39cb131893bd727` |
+
+`checklist_items.is_private`와 `checklist_template_items.is_private`의 `NOT NULL` 차이, 로컬 historical
+version 미등록, 원격 전용 version 4건의 출처는 그대로 남아 있다. Production 전체 ledger repair와
+출시 승인은 TASK-063에서 독립적으로 처리한다.
 
 ## Authenticated Remote-safe Smoke
 
@@ -108,4 +123,4 @@ provisioning에만 DEV service role을 사용하고, smoke subprocess에는 anon
   `3f6305ba1ecba44420bde693330e11b45d9d3cc2e4f8a3d1d8fbe3900f6a78c4`
 
 이로써 DEV migration drift 0, strict fingerprint 12/12·185/185, authenticated smoke PASS의
-TASK-059 완료 조건을 모두 충족했다. Production에는 변경하지 않았다.
+TASK-059 완료 조건을 모두 충족했다. Production에는 사용자 승인 범위인 TASK-058/059만 적용했다.

--- a/docs/refactor/reports/TASK-059-dev-migration-ledger-audit.md
+++ b/docs/refactor/reports/TASK-059-dev-migration-ledger-audit.md
@@ -1,0 +1,111 @@
+# TASK-059 DEV Migration Ledger 감사
+
+작성일: 2026-07-27
+대상: DEV `ivgkqzwosbjukonlpfdw`
+상태: **완료**
+
+## 결론
+
+DEV에는 `20260712000001`~`20260723000002`의 결과 객체가 존재했지만 migration history 10건이
+등록되지 않았다. 누락 SQL은 재실행하지 않고 해당 version만 `repair --status applied`로 등록했다.
+dry-run에서 실제 미적용인 TASK-058과 TASK-059만 확인한 뒤 순서대로 적용했다.
+
+적용 후 DEV와 로컬 최종 schema는 12/12 version, 185/185 객체가 일치하며 migration drift는 0이다.
+적용 전 67개 차이는 다음 두 forward migration으로 모두 해소됐다.
+
+- TASK-058: 장소 사진 write helper, registry 함수, public/storage 정책 6개
+- TASK-059: authority helper 신원 결속과 함수 EXECUTE allowlist
+
+## Fingerprint 기준
+
+`supabase/audit/task059-object-manifest.json`과
+`scripts/audit-task059-schema-dump.mjs`가 function, table, PK/FK/UNIQUE constraint, index, policy,
+trigger, RLS, function/table grant를 비교한다. 테이블 컬럼 순서는 의미 없는 차이로 정규화한다.
+TASK-055의 퇴역 객체는 함수 본문이 아니라 revoke 결과를 판정한다.
+
+`supabase db diff`는 이번 감사에서 ACL 차이를 보고하지 않았으므로 migration history repair 근거로
+사용하지 않는다. `pg_dump` 기반 fingerprint와 SQL 권한 회귀 테스트를 기준으로 한다.
+
+## 적용 전 DEV 판정
+
+| Version | Task | 일치/전체 | 판정 및 조치 |
+|---|---|---:|---|
+| `20260712000001` | TASK-021 | 2/2 | 최종 정책 부재가 의도와 일치, history repair |
+| `20260713000001` | TASK-025 | 2/2 | 최종 정책 부재가 의도와 일치, history repair |
+| `20260714000001` | TASK-028 | 8/8 | 객체·권한 일치, history repair |
+| `20260716000003` | TASK-044 | 3/10 | 함수 정의 일치, 7개 grant는 TASK-059 변경 대상, history repair |
+| `20260717000001` | TASK-046 | 45/61 | 4개 helper 정의와 12개 grant만 TASK-059 변경 대상, history repair |
+| `20260717000002` | TASK-049 | 4/5 | topic helper 정의·grant만 TASK-059 변경 대상, history repair |
+| `20260718000001` | TASK-053 | 3/5 | 2개 grant만 TASK-059 변경 대상, history repair |
+| `20260718000002` | TASK-054 | 5/7 | asset 함수·정책만 TASK-058 변경 대상, history repair |
+| `20260723000001` | TASK-055 | 35/35 | 퇴역 runtime revoke 결과 일치, history repair |
+| `20260723000002` | TASK-056 | 0/4 | 함수 정의는 일치하고 4개 grant만 TASK-059 변경 대상, history repair |
+| `20260723000003` | TASK-058 | 0/6 | 실제 미적용, forward migration 적용 |
+| `20260727000001` | TASK-059 | 11/40 | 신규 grant hardening, forward migration 적용 |
+
+## DEV 적용 기록
+
+실행 시각은 2026-07-27 08:37 KST이며 연결 project ref가
+`ivgkqzwosbjukonlpfdw`임을 각 단계에서 확인했다.
+
+1. DEV schema, data, migration list를 `/tmp`의 접근 제한된 파일로 백업했다.
+2. 객체가 확인된 historical version 10건만 history에 applied로 repair했다.
+3. `supabase db push --linked --dry-run`에서 TASK-058/059 두 건만 남는 것을 확인했다.
+4. `supabase db push --linked --yes`로 TASK-058과 TASK-059를 적용했다.
+5. 재실행한 dry-run은 `Remote database is up to date`를 반환했다.
+6. `public,realtime,storage` dump strict fingerprint는 12/12 version, 185/185 객체 일치다.
+
+| 증적 | SHA-256 |
+|---|---|
+| 적용 전 schema dump | `ed1dc3d1ad68a527ecef427f564a276350f9ec4ae02b73975b3e2d3fc3075cac` |
+| 적용 전 data dump | `cdd2c11968d227c21608e87c9430d19a9fa76c2bc1891f64ae90f93a63964543` |
+| 적용 전 migration list | `6f79767e789dfe30be681cd33b38541a3b76cd402566e31b19d1d83117391bb3` |
+| 적용 후 schema dump | `eb211e76c2ccccc49c69535854daf5c27863ae249b16b3a9e7506a97a69c2c83` |
+| 적용 후 migration list | `630afb474374ca15eb060afd1e278abe3850ccd7cee3334831fc5a3c800393f8` |
+| 적용 후 fingerprint 결과 | `5507e7915d11b9b01cfb1947980c6ad0bf84b1449df891b31fa390b968bdbb4a` |
+
+## 권한 결함과 수정
+
+Supabase의 기본 함수 권한 때문에 `REVOKE ... FROM PUBLIC`만 사용한 함수에 `anon` 또는
+`authenticated`의 명시적 EXECUTE가 남아 있었다. 특히 actor ID를 인자로 받는 internal command
+함수의 Data API 노출은 권한 우회 위험이다.
+
+`20260727000001_task059_authority_rpc_grant_hardening.sql`은 다음을 적용한다.
+
+- internal command·batch·stale·trigger 함수는 `service_role`만 허용
+- 제품 write/read RPC는 `authenticated`와 `service_role`만 허용
+- 초대 요약만 로그인 전 `anon` 접근 유지
+- trip/template authority helper와 Realtime topic helper를 `auth.uid()`에 결속
+
+`task059_authority_rpc_grants.sql`은 역할별 EXECUTE와 타 사용자 ID 대입 차단을 검증한다.
+
+## Production 입력
+
+Production `runbcaegpefqnljsswhv`은 읽기 전용으로만 확인하고 DEV 연결로 복구했다.
+
+- 원격 history에는 로컬에 없는 version 4개만 존재한다:
+  `20260403070821`, `20260423112332`, `20260427021704`, `20260427023948`
+- 동일 manifest 결과는 116/185 일치, 69개 불일치다.
+- DEV 차이 외에 `checklist_items.is_private`와 `checklist_template_items.is_private`가
+  Production에서 `NOT NULL`이 아니다.
+
+Production repair나 migration은 수행하지 않는다. 원격 전용 version의 출처와 두 nullability 차이는
+TASK-063에서 독립적으로 분류·승인한다.
+
+## Authenticated Remote-safe Smoke
+
+2026-07-27 10:37 KST에 DEV Auth에 임시 owner/editor/viewer/outsider 계정을 생성했다. 계정
+provisioning에만 DEV service role을 사용하고, smoke subprocess에는 anon key와 네 사용자
+자격증명만 전달했다.
+
+- owner 여행 bootstrap과 targeted editor/viewer 초대 수락 PASS
+- editor write, duplicate operation 멱등성, revision 1 증가 PASS
+- viewer write, outsider read, anonymous wrapper/internal RPC 차단 PASS
+- editor role 하향과 revoke 직후 read/write 차단 PASS
+- QA 여행 soft-delete cleanup PASS
+- 임시 Auth 계정 Admin API 삭제 4/4 성공
+- smoke report SHA-256:
+  `3f6305ba1ecba44420bde693330e11b45d9d3cc2e4f8a3d1d8fbe3900f6a78c4`
+
+이로써 DEV migration drift 0, strict fingerprint 12/12·185/185, authenticated smoke PASS의
+TASK-059 완료 조건을 모두 충족했다. Production에는 변경하지 않았다.

--- a/docs/refactor/runbooks/TASK-059-dev-migration-ledger.md
+++ b/docs/refactor/runbooks/TASK-059-dev-migration-ledger.md
@@ -1,0 +1,140 @@
+# TASK-059 DEV Migration Ledger Runbook
+
+## 목적과 경계
+
+DEV `ivgkqzwosbjukonlpfdw`의 실제 객체와 migration history를 정합화한다. Production에는 이 절차를
+실행하지 않는다. 원격 SQL 변경은 사용자 승인 후 DB operator가 수행한다.
+
+## 1. Preflight
+
+```bash
+test "$(cat supabase/.temp/project-ref)" = "ivgkqzwosbjukonlpfdw"
+git status --short
+supabase migration list --linked
+```
+
+다음 조건이면 즉시 중단한다.
+
+- project ref가 DEV가 아니다.
+- 아래 10개 repair 대상 외에 설명되지 않은 history 차이가 있다.
+- 최신 schema fingerprint가 감사 보고서와 다르다.
+- 실행 승인·실행자·시각을 기록하지 않았다.
+
+## 2. 변경 전 증적과 Backup
+
+덤프에는 사용자 데이터가 포함될 수 있으므로 저장소에 커밋하지 않고 접근 제한된 경로에 보관한다.
+Storage object byte는 이 dump에 포함되지 않지만 TASK-058/059는 object byte를 변경하지 않는다.
+
+```bash
+umask 077
+supabase db dump --linked --schema public,realtime,storage \
+  --file /tmp/task059-dev-schema-before.sql
+supabase db dump --linked --data-only --use-copy --schema public,storage \
+  --file /tmp/task059-dev-data-before.sql
+supabase migration list --linked \
+  > /tmp/task059-dev-migration-list-before.txt
+```
+
+로컬 기준과 DEV를 다시 비교한다.
+
+```bash
+supabase db reset --local
+supabase db dump --local --schema public,realtime,storage \
+  --file /tmp/task059-local-expected.sql
+node scripts/audit-task059-schema-dump.mjs \
+  --expected /tmp/task059-local-expected.sql \
+  --actual /tmp/task059-dev-schema-before.sql \
+  --output /tmp/task059-dev-fingerprint-before.json
+```
+
+## 3. History Repair
+
+다음 명령은 SQL을 재실행하지 않고 검증된 historical version만 등록한다.
+
+```bash
+supabase migration repair --linked --status applied --yes \
+  20260712000001 20260713000001 20260714000001 \
+  20260716000003 20260717000001 20260717000002 \
+  20260718000001 20260718000002 20260723000001 \
+  20260723000002
+```
+
+repair 후 dry-run에는 아래 두 파일만 나와야 한다.
+
+```bash
+supabase db push --linked --dry-run
+```
+
+- `20260723000003_task058_place_photo_write_policy.sql`
+- `20260727000001_task059_authority_rpc_grant_hardening.sql`
+
+다른 파일이 보이면 push하지 않는다.
+
+## 4. Forward Migration
+
+```bash
+supabase db push --linked --yes
+```
+
+TASK-058과 TASK-059는 각각 transaction으로 적용된다. 오류가 발생하면 반복 실행하지 말고 출력과
+schema dump를 보존한다.
+
+## 5. 사후 검증
+
+```bash
+supabase migration list --linked \
+  > /tmp/task059-dev-migration-list-after.txt
+supabase db push --linked --dry-run
+supabase db dump --linked --schema public,realtime,storage \
+  --file /tmp/task059-dev-schema-after.sql
+node scripts/audit-task059-schema-dump.mjs \
+  --expected /tmp/task059-local-expected.sql \
+  --actual /tmp/task059-dev-schema-after.sql \
+  --output /tmp/task059-dev-fingerprint-after.json \
+  --strict
+```
+
+합격 기준은 migration dry-run 대상 0개와 fingerprint 12/12다.
+
+## 6. Authenticated Remote-safe Smoke
+
+service role은 사용하지 않는다. 기존 TASK-059 전용 owner/editor/viewer/outsider 계정을 환경변수로
+주입한다. 이메일에는 `task059` 문자열이 포함되어야 한다.
+
+```bash
+TASK059_ALLOW_DEV_SMOKE=yes \
+TASK059_DEV_SUPABASE_URL=https://ivgkqzwosbjukonlpfdw.supabase.co \
+TASK059_DEV_SUPABASE_ANON_KEY="$DEV_ANON_KEY" \
+TASK059_QA_OWNER_EMAIL="$QA_OWNER_EMAIL" \
+TASK059_QA_OWNER_PASSWORD="$QA_OWNER_PASSWORD" \
+TASK059_QA_EDITOR_EMAIL="$QA_EDITOR_EMAIL" \
+TASK059_QA_EDITOR_PASSWORD="$QA_EDITOR_PASSWORD" \
+TASK059_QA_VIEWER_EMAIL="$QA_VIEWER_EMAIL" \
+TASK059_QA_VIEWER_PASSWORD="$QA_VIEWER_PASSWORD" \
+TASK059_QA_OUTSIDER_EMAIL="$QA_OUTSIDER_EMAIL" \
+TASK059_QA_OUTSIDER_PASSWORD="$QA_OUTSIDER_PASSWORD" \
+TASK059_SMOKE_REPORT=/tmp/task059-dev-smoke.json \
+pnpm test:task059:dev-smoke
+```
+
+PASS 기준:
+
+- owner bootstrap, targeted invite/accept
+- editor write와 duplicate operation 멱등성
+- viewer write·outsider read·anonymous internal/wrapper 차단
+- role 하향과 revoke 직후 차단
+- revision 정확히 1 증가
+- QA 여행 soft-delete cleanup
+
+## 7. 실패와 복구
+
+- **repair 후 push 전 실패:** history는 검증된 실제 객체를 기록하므로 되돌리지 않는다. dry-run 원인을
+  해결한 뒤 재승인한다.
+- **forward migration 실패:** 재실행하지 않는다. 변경 전/후 dump를 비교하고 transaction 상태를
+  확인한다. 필요하면 변경 전 함수·policy·grant 정의만 복원한다.
+- **smoke 실패:** migration을 임의 rollback하지 않는다. DEV를 NO-GO로 유지하고 결함을 수정한 새
+  forward migration을 만든다.
+- repair를 되돌려야 한다는 독립 감사 결론이 있을 때만 해당 version에
+  `migration repair --status reverted`를 실행한다.
+
+DB password, anon key, QA password, dump와 access token은 Git·PR·로그에 남기지 않는다.

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -127,7 +127,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-056-production-data-integrity-and-cost-gate.md` | 구현 완료, 운영 gate 대기 | 코드 gate PASS; DEV/Production/legacy 삭제 NO-GO, PR [#369](https://github.com/ysjee141/nexvoy-frontend/pull/369) |
 | `TASK-057-production-final-validation.md` | 문서화 완료 | Production 마스터 Gate, 자동·수동 통합 테스트, 증적·출시 Runbook, Issue [#370](https://github.com/ysjee141/nexvoy-frontend/issues/370) |
 | `TASK-058-production-p0-integration-automation.md` | 완료 | `NEW-A01`~`A13`, 로컬 Supabase 단일 Gate, asset write/path hardening, Issue [#374](https://github.com/ysjee141/nexvoy-frontend/issues/374), PR [#375](https://github.com/ysjee141/nexvoy-frontend/pull/375) |
-| `TASK-059-dev-migration-production-gate.md` | 완료 | 185개 객체 fingerprint, grant hardening, migration drift 0, authenticated remote-safe smoke PASS |
+| `TASK-059-dev-migration-production-gate.md` | 완료 | DEV drift 0·authenticated smoke PASS, Production TASK-058/059 target-only 적용 |
 | `TASK-060-cross-platform-device-validation.md` | 대기 | Web·Android·iOS 실기기, 다중 계정, asset 전체 회귀 |
 | `TASK-061-dev-stability-cost-soak.md` | 대기 | DEV 연속 7일 안정성·비용 관측 |
 | `TASK-062-disaster-recovery-rehearsal.md` | 대기 | DB·Storage 격리 복구와 RTO/RPO 검증 |
@@ -234,7 +234,7 @@ rotating room secret 보안 하드닝을 완료했다.
 ### Phase 10: Production Final Validation
 
 - [x] `TASK-058-production-p0-integration-automation.md`: Production P0 통합 테스트 자동화
-- [x] `TASK-059-dev-migration-production-gate.md`: DEV repair·forward migration·fingerprint·authenticated smoke 완료
+- [x] `TASK-059-dev-migration-production-gate.md`: DEV 전체 Gate와 Production TASK-058/059 target-only 적용 완료
 - [ ] `TASK-060-cross-platform-device-validation.md`: Web·Mobile 실기기 통합 검증
 - [ ] `TASK-061-dev-stability-cost-soak.md`: DEV 안정성·비용 7일 관측
 - [ ] `TASK-062-disaster-recovery-rehearsal.md`: DB·Storage 재해 복구 rehearsal

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -127,7 +127,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-056-production-data-integrity-and-cost-gate.md` | 구현 완료, 운영 gate 대기 | 코드 gate PASS; DEV/Production/legacy 삭제 NO-GO, PR [#369](https://github.com/ysjee141/nexvoy-frontend/pull/369) |
 | `TASK-057-production-final-validation.md` | 문서화 완료 | Production 마스터 Gate, 자동·수동 통합 테스트, 증적·출시 Runbook, Issue [#370](https://github.com/ysjee141/nexvoy-frontend/issues/370) |
 | `TASK-058-production-p0-integration-automation.md` | 완료 | `NEW-A01`~`A13`, 로컬 Supabase 단일 Gate, asset write/path hardening, Issue [#374](https://github.com/ysjee141/nexvoy-frontend/issues/374), PR [#375](https://github.com/ysjee141/nexvoy-frontend/pull/375) |
-| `TASK-059-dev-migration-production-gate.md` | 대기 | DEV 객체 fingerprint, migration history 정합화, remote-safe smoke |
+| `TASK-059-dev-migration-production-gate.md` | 완료 | 185개 객체 fingerprint, grant hardening, migration drift 0, authenticated remote-safe smoke PASS |
 | `TASK-060-cross-platform-device-validation.md` | 대기 | Web·Android·iOS 실기기, 다중 계정, asset 전체 회귀 |
 | `TASK-061-dev-stability-cost-soak.md` | 대기 | DEV 연속 7일 안정성·비용 관측 |
 | `TASK-062-disaster-recovery-rehearsal.md` | 대기 | DB·Storage 격리 복구와 RTO/RPO 검증 |
@@ -234,7 +234,7 @@ rotating room secret 보안 하드닝을 완료했다.
 ### Phase 10: Production Final Validation
 
 - [x] `TASK-058-production-p0-integration-automation.md`: Production P0 통합 테스트 자동화
-- [ ] `TASK-059-dev-migration-production-gate.md`: DEV 객체·migration history 정합화와 원격 Gate
+- [x] `TASK-059-dev-migration-production-gate.md`: DEV repair·forward migration·fingerprint·authenticated smoke 완료
 - [ ] `TASK-060-cross-platform-device-validation.md`: Web·Mobile 실기기 통합 검증
 - [ ] `TASK-061-dev-stability-cost-soak.md`: DEV 안정성·비용 7일 관측
 - [ ] `TASK-062-disaster-recovery-rehearsal.md`: DB·Storage 재해 복구 rehearsal

--- a/docs/refactor/tasks/TASK-059-dev-migration-production-gate.md
+++ b/docs/refactor/tasks/TASK-059-dev-migration-production-gate.md
@@ -20,6 +20,7 @@ DEV `ivgkqzwosbjukonlpfdw`의 migration history와 실제 DB object를 일치시
 - service role 없는 authenticated remote-safe smoke
 - 전·후 migration list, 실행자, 시간, SQL 결과 증적
 - Production 원격 전용 version 4건과 실제 `public` schema 차이를 TASK-063 입력으로 정리
+- 사용자 추가 승인에 따른 Production TASK-058/059 target-only migration 적용과 익명 차단 smoke
 
 ## 완료 조건
 
@@ -34,7 +35,7 @@ DEV `ivgkqzwosbjukonlpfdw`의 migration history와 실제 DB object를 일치시
 
 ## 제외 범위
 
-- Production migration
+- Production 전체 migration ledger repair와 단계적 rollout
 - 실제 사용자 데이터 cleanup
 - legacy table·function 물리 삭제
 
@@ -51,6 +52,10 @@ DEV `ivgkqzwosbjukonlpfdw`의 migration history와 실제 DB object를 일치시
 - 사용자 승인 후 DEV의 검증된 historical version 10건을 `repair --status applied`로 등록하고,
   dry-run에 실제 미적용 TASK-058/059만 남는 것을 확인한 뒤 두 forward migration을 적용했다.
 - 적용 후 migration drift는 0이며, strict fingerprint는 12/12 version과 185/185 객체가 일치한다.
-- Production에는 변경을 수행하지 않았다.
 - DEV에 임시 owner/editor/viewer/outsider Auth 계정을 생성해 service role 없는 authenticated
   remote-safe smoke를 실행했다. 모든 검사가 PASS했고 QA 여행은 soft-delete, 계정은 4/4 삭제됐다.
+- 사용자 추가 승인 후 Production의 기존 원격 history 4건을 보존하는 격리 workspace에서
+  TASK-058/059만 적용했다. target-only dry-run은 0건이고 anonymous wrapper/internal RPC 차단이
+  PASS했다.
+- Production fingerprint는 적용 전 116/185에서 183/185로 개선됐다. 남은 두 checklist
+  `is_private NOT NULL` 차이와 전체 ledger 정합화·출시는 TASK-063 범위다.

--- a/docs/refactor/tasks/TASK-059-dev-migration-production-gate.md
+++ b/docs/refactor/tasks/TASK-059-dev-migration-production-gate.md
@@ -1,6 +1,6 @@
 # TASK-059: DEV 객체·Migration History 정합화
 
-- 상태: 대기
+- 상태: 완료
 - 선행 작업: `TASK-058`
 - 해소 대상: `B-01`, `B-02`
 
@@ -37,3 +37,20 @@ DEV `ivgkqzwosbjukonlpfdw`의 migration history와 실제 DB object를 일치시
 - Production migration
 - 실제 사용자 데이터 cleanup
 - legacy table·function 물리 삭제
+
+## 2026-07-27 구현 결과
+
+- 12개 version의 최종 function/table/constraint/index/policy/trigger/RLS/grant를 다루는 185개
+  fingerprint manifest와 dump 비교 도구를 추가했다.
+- DEV의 history 미등록 10건은 실제 객체가 존재하며, 최종 차이는 TASK-058/059 forward migration으로
+  전부 설명됨을 확인했다.
+- accidental `anon`/`authenticated` EXECUTE를 명시적 allowlist로 바꾸고 authority helper 인자를
+  `auth.uid()`에 결속하는 TASK-059 migration과 SQL 회귀 테스트를 구현했다.
+- service role 없는 DEV remote-safe smoke를 project ref·전용 계정·실행 플래그로 보호했다.
+- 로컬 Production P0 23건, 전체 SQL, typecheck, Web/Mobile build와 Mobile lint가 PASS했다.
+- 사용자 승인 후 DEV의 검증된 historical version 10건을 `repair --status applied`로 등록하고,
+  dry-run에 실제 미적용 TASK-058/059만 남는 것을 확인한 뒤 두 forward migration을 적용했다.
+- 적용 후 migration drift는 0이며, strict fingerprint는 12/12 version과 185/185 객체가 일치한다.
+- Production에는 변경을 수행하지 않았다.
+- DEV에 임시 owner/editor/viewer/outsider Auth 계정을 생성해 service role 없는 authenticated
+  remote-safe smoke를 실행했다. 모든 검사가 PASS했고 QA 여행은 soft-delete, 계정은 4/4 삭제됐다.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:mobile": "pnpm --filter nexvoy-app lint",
     "typecheck": "pnpm --filter @nexvoy/types typecheck && pnpm --filter @nexvoy/design-tokens typecheck && pnpm --filter @nexvoy/core typecheck && pnpm --filter nexvoy-app typecheck",
     "test:production:p0": "bash scripts/test-production-p0-local.sh",
+    "test:task059:dev-smoke": "pnpm --filter nexvoy-web test:task059:dev-smoke",
     "test:sql:local": "bash scripts/test-local-supabase-sql.sh",
     "test:e2e": "pnpm --filter nexvoy-web test:e2e",
     "test:e2e:ui": "pnpm --filter nexvoy-web test:e2e:ui",

--- a/scripts/audit-task059-schema-dump.mjs
+++ b/scripts/audit-task059-schema-dump.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { readFile, writeFile } from 'node:fs/promises'
+import process from 'node:process'
+
+function parseArguments(argv) {
+  const options = {
+    manifest: 'supabase/audit/task059-object-manifest.json',
+    strict: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--strict') {
+      options.strict = true
+      continue
+    }
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unknown argument: ${argument}`)
+    }
+    const value = argv[index + 1]
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${argument}`)
+    }
+    options[argument.slice(2)] = value
+    index += 1
+  }
+
+  for (const required of ['expected', 'actual']) {
+    if (!options[required]) {
+      throw new Error(`--${required} is required`)
+    }
+  }
+  return options
+}
+
+function normalizeDefinition(value) {
+  return value
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+function normalizeTableDefinition(value) {
+  const normalized = normalizeDefinition(value)
+  const firstNewline = normalized.indexOf('\n')
+  const lastClose = normalized.lastIndexOf('\n)')
+  if (firstNewline === -1 || lastClose === -1) return normalized
+
+  const heading = normalized.slice(0, firstNewline)
+  const entries = normalized
+    .slice(firstNewline + 1, lastClose)
+    .split('\n')
+    .map((line) => line.trim().replace(/,$/, ''))
+    .filter(Boolean)
+    .sort()
+  return `${heading}\n${entries.join('\n')}\n)`
+}
+
+function hash(value) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function objectKey(object) {
+  const table = object.table ? `.${object.table}` : ''
+  return `${object.type}:${object.schema}${table}.${object.name}`
+}
+
+function addStatement(map, key, definition) {
+  if (map.has(key)) {
+    // The managed Supabase schemas contain overloaded functions. TASK-059
+    // deliberately fingerprints app-owned, non-overloaded function names.
+    return
+  }
+  map.set(key, {
+    definition: key.startsWith('table:')
+      ? normalizeTableDefinition(definition)
+      : normalizeDefinition(definition),
+    grants: [],
+  })
+}
+
+function extractStatements(dump) {
+  const objects = new Map()
+  const functionStartPattern =
+    /^CREATE OR REPLACE FUNCTION "([^"]+)"\."([^"]+)"\(/gm
+  for (const match of dump.matchAll(functionStartPattern)) {
+    const alterPrefix = `\n\n\nALTER FUNCTION "${match[1]}"."${match[2]}"`
+    const alterOffset = dump.indexOf(alterPrefix, match.index)
+    if (alterOffset === -1) {
+      throw new Error(`Could not find ALTER FUNCTION terminator for ${match[1]}.${match[2]}`)
+    }
+    addStatement(
+      objects,
+      `function:${match[1]}.${match[2]}`,
+      dump.slice(match.index, alterOffset),
+    )
+  }
+
+  const tablePattern =
+    /^CREATE TABLE(?: IF NOT EXISTS)? "([^"]+)"\."([^"]+)" \([^]*?^\);\s*$/gm
+  for (const match of dump.matchAll(tablePattern)) {
+    addStatement(objects, `table:${match[1]}.${match[2]}`, match[0])
+  }
+
+  const indexPattern =
+    /^CREATE (?:UNIQUE )?INDEX "([^"]+)" ON "([^"]+)"\."([^"]+)"[^;]+;\s*$/gm
+  for (const match of dump.matchAll(indexPattern)) {
+    addStatement(objects, `index:${match[2]}.${match[1]}`, match[0])
+  }
+
+  const policyPattern =
+    /^CREATE POLICY "([^"]+)" ON "([^"]+)"\."([^"]+)"[^;]+;\s*$/gm
+  for (const match of dump.matchAll(policyPattern)) {
+    addStatement(objects, `policy:${match[2]}.${match[3]}.${match[1]}`, match[0])
+  }
+
+  const triggerPattern =
+    /^CREATE (?:OR REPLACE )?TRIGGER "([^"]+)"[^;]+ ON "([^"]+)"\."([^"]+)"[^;]+;\s*$/gm
+  for (const match of dump.matchAll(triggerPattern)) {
+    addStatement(objects, `trigger:${match[2]}.${match[3]}.${match[1]}`, match[0])
+  }
+
+  const functionGrantPattern =
+    /^GRANT ([A-Z, ]+) ON FUNCTION "([^"]+)"\."([^"]+)"\([^;]+\) TO (.+);$/gm
+  for (const match of dump.matchAll(functionGrantPattern)) {
+    appendGrant(objects, `function:${match[2]}.${match[3]}`, match[1], match[4])
+  }
+
+  const tableGrantPattern =
+    /^GRANT ([A-Z, ]+) ON TABLE "([^"]+)"\."([^"]+)" TO (.+);$/gm
+  for (const match of dump.matchAll(tableGrantPattern)) {
+    appendGrant(objects, `table:${match[2]}.${match[3]}`, match[1], match[4])
+  }
+
+  const constraintPattern =
+    /^ALTER TABLE ONLY "([^"]+)"\."([^"]+)"\n\s+ADD CONSTRAINT [^;]+;\s*$/gm
+  for (const match of dump.matchAll(constraintPattern)) {
+    const object = objects.get(`table:${match[1]}.${match[2]}`)
+    if (!object) continue
+    object.constraints ??= []
+    object.constraints.push(normalizeDefinition(match[0]))
+  }
+
+  for (const [key, object] of objects) {
+    if (!key.startsWith('table:')) continue
+    const [, qualifiedName] = key.split(':')
+    const [schema, name] = qualifiedName.split('.')
+    object.rlsEnabled = new RegExp(
+      `^ALTER TABLE "${escapeRegExp(schema)}"\\."${escapeRegExp(name)}" ENABLE ROW LEVEL SECURITY;$`,
+      'm',
+    ).test(dump)
+  }
+
+  return objects
+}
+
+function appendGrant(objects, key, privilege, recipients) {
+  const object = objects.get(key)
+  if (!object) return
+  for (const recipient of recipients.split(',').map((value) => value.trim())) {
+    object.grants.push({
+      privilege: privilege.trim(),
+      role: recipient.replace(/^"|"$/g, ''),
+    })
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function fingerprint(object) {
+  if (!object) return { present: false }
+  const grants = object.grants
+    .map(({ privilege, role }) => `${privilege}:${role}`)
+    .sort()
+  const constraints = [...(object.constraints ?? [])].sort()
+  const material = {
+    definition: object.definition,
+    grants,
+    ...(constraints.length === 0 ? {} : { constraints }),
+    ...(object.rlsEnabled === undefined ? {} : { rlsEnabled: object.rlsEnabled }),
+  }
+  return {
+    present: true,
+    definitionHash: hash(object.definition),
+    grants,
+    ...(constraints.length === 0
+      ? {}
+      : {
+          constraintCount: constraints.length,
+          constraintsHash: hash(constraints.join('\n\n')),
+        }),
+    ...(object.rlsEnabled === undefined ? {} : { rlsEnabled: object.rlsEnabled }),
+    fingerprint: hash(JSON.stringify(material)),
+  }
+}
+
+function compareManifest(manifest, expectedObjects, actualObjects) {
+  return manifest.versions.map((version) => {
+    const objects = version.objects.map((object) => {
+      const key = objectKey(object)
+      const compare = object.compare ?? version.defaultCompare ?? [
+        'definition',
+        'constraints',
+        'grants',
+        'rls',
+      ]
+      const expected = object.present === false
+        ? { present: false }
+        : fingerprint(expectedObjects.get(key))
+      const actual = fingerprint(actualObjects.get(key))
+      const differences = []
+
+      if (expected.present !== actual.present) {
+        differences.push(expected.present ? 'missing' : 'unexpected')
+      } else if (expected.present) {
+        if (
+          compare.includes('definition') &&
+          expected.definitionHash !== actual.definitionHash
+        ) {
+          differences.push('definition')
+        }
+        if (
+          compare.includes('grants') &&
+          JSON.stringify(expected.grants) !== JSON.stringify(actual.grants)
+        ) {
+          differences.push('grants')
+        }
+        if (
+          compare.includes('constraints') &&
+          expected.constraintsHash !== actual.constraintsHash
+        ) {
+          differences.push('constraints')
+        }
+        if (compare.includes('rls') && expected.rlsEnabled !== actual.rlsEnabled) {
+          differences.push('rls')
+        }
+      }
+
+      if (object.present !== false && !expected.present) {
+        differences.push('missing_from_expected_dump')
+      }
+
+      return {
+        key,
+        compare,
+        status: differences.length === 0 ? 'match' : 'mismatch',
+        differences: [...new Set(differences)],
+        expected,
+        actual,
+      }
+    })
+
+    const mismatchCount = objects.filter(({ status }) => status === 'mismatch').length
+    return {
+      version: version.version,
+      task: version.task,
+      status: mismatchCount === 0 ? 'match' : 'mismatch',
+      objectCount: objects.length,
+      mismatchCount,
+      objects,
+    }
+  })
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2))
+  const [manifestText, expectedDump, actualDump] = await Promise.all([
+    readFile(options.manifest, 'utf8'),
+    readFile(options.expected, 'utf8'),
+    readFile(options.actual, 'utf8'),
+  ])
+  const manifest = JSON.parse(manifestText)
+  const versions = compareManifest(
+    manifest,
+    extractStatements(expectedDump),
+    extractStatements(actualDump),
+  )
+  const summary = {
+    versionCount: versions.length,
+    matchingVersions: versions.filter(({ status }) => status === 'match').length,
+    mismatchingVersions: versions.filter(({ status }) => status === 'mismatch').length,
+    objectCount: versions.reduce((total, version) => total + version.objectCount, 0),
+    mismatchCount: versions.reduce((total, version) => total + version.mismatchCount, 0),
+  }
+  const report = {
+    generatedAt: new Date().toISOString(),
+    manifest: options.manifest,
+    expectedDump: options.expected,
+    actualDump: options.actual,
+    summary,
+    versions,
+  }
+  const serialized = `${JSON.stringify(report, null, 2)}\n`
+
+  if (options.output) {
+    await writeFile(options.output, serialized)
+  } else {
+    process.stdout.write(serialized)
+  }
+
+  process.stderr.write(
+    `TASK-059 fingerprint: ${summary.matchingVersions}/${summary.versionCount} versions match; ` +
+      `${summary.mismatchCount}/${summary.objectCount} object checks differ.\n`,
+  )
+  for (const version of versions.filter(({ status }) => status === 'mismatch')) {
+    const keys = version.objects
+      .filter(({ status }) => status === 'mismatch')
+      .map(({ key, differences }) => `${key} (${differences.join(',')})`)
+    process.stderr.write(`${version.version} ${version.task}: ${keys.join(', ')}\n`)
+  }
+
+  if (options.strict && summary.mismatchCount > 0) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/supabase/audit/task059-object-manifest.json
+++ b/supabase/audit/task059-object-manifest.json
@@ -1,0 +1,334 @@
+{
+  "schemaVersion": 1,
+  "description": "TASK-059 final-state object manifest for the DEV migration ledger audit.",
+  "versions": [
+    {
+      "version": "20260712000001",
+      "task": "TASK-021",
+      "objects": [
+        {
+          "type": "policy",
+          "schema": "realtime",
+          "table": "messages",
+          "name": "accepted document members can receive signaling broadcast",
+          "present": false
+        },
+        {
+          "type": "policy",
+          "schema": "realtime",
+          "table": "messages",
+          "name": "accepted non-viewer document members can send signaling broadcast",
+          "present": false
+        }
+      ]
+    },
+    {
+      "version": "20260713000001",
+      "task": "TASK-025",
+      "objects": [
+        {
+          "type": "policy",
+          "schema": "realtime",
+          "table": "messages",
+          "name": "accepted document members can receive signaling broadcast",
+          "present": false
+        },
+        {
+          "type": "policy",
+          "schema": "realtime",
+          "table": "messages",
+          "name": "accepted non-viewer document members can send signaling broadcast",
+          "present": false
+        }
+      ]
+    },
+    {
+      "version": "20260714000001",
+      "task": "TASK-028",
+      "objects": [
+        { "type": "table", "schema": "public", "name": "document_signaling_room_topics" },
+        { "type": "index", "schema": "public", "name": "document_signaling_room_topics_document_active_idx" },
+        { "type": "index", "schema": "public", "name": "document_signaling_room_topics_room_topic_idx" },
+        { "type": "function", "schema": "public", "name": "issue_document_signaling_room_topic" },
+        { "type": "function", "schema": "public", "name": "can_receive_document_signaling_topic" },
+        { "type": "function", "schema": "public", "name": "can_send_document_signaling_topic" },
+        {
+          "type": "policy",
+          "schema": "public",
+          "table": "document_signaling_room_topics",
+          "name": "deny direct signaling topic reads"
+        },
+        {
+          "type": "policy",
+          "schema": "public",
+          "table": "document_signaling_room_topics",
+          "name": "deny direct signaling topic writes"
+        }
+      ]
+    },
+    {
+      "version": "20260716000003",
+      "task": "TASK-044",
+      "objects": [
+        { "type": "index", "schema": "public", "name": "document_invitation_links_target_email_idx" },
+        { "type": "function", "schema": "public", "name": "create_document_invitation_link" },
+        { "type": "function", "schema": "public", "name": "assert_targeted_invitation_recipient" },
+        { "type": "function", "schema": "public", "name": "accept_document_invitation" },
+        { "type": "function", "schema": "public", "name": "get_document_invitation_summary" },
+        { "type": "function", "schema": "public", "name": "list_my_pending_document_invitations" },
+        { "type": "function", "schema": "public", "name": "accept_my_document_invitation" },
+        { "type": "function", "schema": "public", "name": "decline_my_document_invitation" },
+        { "type": "function", "schema": "public", "name": "list_document_collaborators" },
+        { "type": "function", "schema": "public", "name": "list_document_pending_invitations" }
+      ]
+    },
+    {
+      "version": "20260717000001",
+      "task": "TASK-046",
+      "objects": [
+        { "type": "table", "schema": "public", "name": "trips" },
+        { "type": "table", "schema": "public", "name": "plans" },
+        { "type": "table", "schema": "public", "name": "plan_urls" },
+        { "type": "table", "schema": "public", "name": "checklists" },
+        { "type": "table", "schema": "public", "name": "checklist_items" },
+        { "type": "table", "schema": "public", "name": "checklist_item_assignees" },
+        { "type": "table", "schema": "public", "name": "checklist_item_user_checks" },
+        { "type": "table", "schema": "public", "name": "checklist_templates" },
+        { "type": "table", "schema": "public", "name": "checklist_template_items" },
+        { "type": "table", "schema": "public", "name": "checklist_template_shares" },
+        { "type": "table", "schema": "public", "name": "trip_authority_state" },
+        { "type": "table", "schema": "public", "name": "template_authority_state" },
+        { "type": "table", "schema": "public", "name": "applied_operations" },
+        { "type": "index", "schema": "public", "name": "applied_operations_resource_idx" },
+        { "type": "index", "schema": "public", "name": "applied_operations_actor_applied_idx" },
+        { "type": "function", "schema": "public", "name": "set_authority_row_metadata" },
+        { "type": "function", "schema": "public", "name": "check_can_read_authority_trip" },
+        { "type": "function", "schema": "public", "name": "check_can_write_authority_trip" },
+        { "type": "function", "schema": "public", "name": "check_can_read_authority_template" },
+        { "type": "function", "schema": "public", "name": "check_can_write_authority_template" },
+        { "type": "function", "schema": "public", "name": "is_trip_authority_resource" },
+        { "type": "function", "schema": "public", "name": "is_trip_authority_plan" },
+        { "type": "function", "schema": "public", "name": "is_trip_authority_checklist" },
+        { "type": "function", "schema": "public", "name": "is_trip_authority_checklist_item" },
+        { "type": "function", "schema": "public", "name": "is_template_authority_resource" },
+        { "type": "function", "schema": "public", "name": "get_trip_authority_revision" },
+        { "type": "function", "schema": "public", "name": "get_template_authority_revision" },
+        { "type": "function", "schema": "public", "name": "get_trip_authority_bundle" },
+        { "type": "function", "schema": "public", "name": "get_template_authority_bundle" },
+        { "type": "function", "schema": "public", "name": "get_trip_authority_changes" },
+        { "type": "function", "schema": "public", "name": "get_template_authority_changes" },
+        { "type": "function", "schema": "public", "name": "list_my_trip_authority_summaries" },
+        { "type": "function", "schema": "public", "name": "list_my_template_authority_summaries" },
+        { "type": "function", "schema": "public", "name": "apply_one_trip_authority_command" },
+        { "type": "function", "schema": "public", "name": "apply_one_template_authority_command" },
+        { "type": "function", "schema": "public", "name": "apply_trip_authority_commands" },
+        { "type": "function", "schema": "public", "name": "apply_template_authority_commands" },
+        { "type": "function", "schema": "public", "name": "apply_trip_commands" },
+        { "type": "function", "schema": "public", "name": "apply_template_commands" },
+        { "type": "trigger", "schema": "public", "table": "trips", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "plans", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "plan_urls", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "checklists", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "checklist_items", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "checklist_item_assignees", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "checklist_item_user_checks", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "checklist_templates", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "checklist_template_items", "name": "set_authority_row_metadata" },
+        { "type": "trigger", "schema": "public", "table": "checklist_template_shares", "name": "set_authority_row_metadata" },
+        { "type": "policy", "schema": "public", "table": "trips", "name": "authority trips require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "plans", "name": "authority plans require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "plan_urls", "name": "authority plan urls require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "checklists", "name": "authority checklists require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "checklist_items", "name": "authority checklist items require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "checklist_item_assignees", "name": "authority checklist assignees require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "checklist_item_user_checks", "name": "authority checklist checks require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "checklist_templates", "name": "authority templates require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "checklist_template_items", "name": "authority template items require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "checklist_template_shares", "name": "authority template shares require canonical RPC" },
+        { "type": "policy", "schema": "public", "table": "trip_authority_state", "name": "authority members can read trip state" },
+        { "type": "policy", "schema": "public", "table": "template_authority_state", "name": "authority readers can read template state" }
+      ]
+    },
+    {
+      "version": "20260717000002",
+      "task": "TASK-049",
+      "objects": [
+        { "type": "function", "schema": "public", "name": "can_receive_authority_topic" },
+        { "type": "function", "schema": "public", "name": "broadcast_authority_state_invalidation" },
+        { "type": "trigger", "schema": "public", "table": "trip_authority_state", "name": "broadcast_trip_authority_invalidation" },
+        { "type": "trigger", "schema": "public", "table": "template_authority_state", "name": "broadcast_template_authority_invalidation" },
+        { "type": "policy", "schema": "realtime", "table": "messages", "name": "authority readers can receive revision invalidations" }
+      ]
+    },
+    {
+      "version": "20260718000001",
+      "task": "TASK-053",
+      "objects": [
+        { "type": "function", "schema": "public", "name": "bump_authority_revision_for_membership" },
+        { "type": "function", "schema": "public", "name": "accept_document_invitation_unchecked" },
+        { "type": "function", "schema": "public", "name": "accept_my_document_invitation" },
+        { "type": "function", "schema": "public", "name": "set_document_member_role" },
+        { "type": "function", "schema": "public", "name": "revoke_document_member" }
+      ]
+    },
+    {
+      "version": "20260718000002",
+      "task": "TASK-054",
+      "objects": [
+        { "type": "table", "schema": "public", "name": "trip_asset_objects" },
+        { "type": "index", "schema": "public", "name": "trip_asset_objects_bucket_path_key" },
+        { "type": "index", "schema": "public", "name": "trip_asset_objects_trip_id_idx" },
+        { "type": "index", "schema": "public", "name": "trip_asset_objects_plan_id_idx" },
+        { "type": "policy", "schema": "public", "table": "trip_asset_objects", "name": "trip_asset_objects_select_member" },
+        { "type": "function", "schema": "public", "name": "register_place_photo_asset" },
+        { "type": "function", "schema": "public", "name": "list_orphan_place_photo_assets" }
+      ]
+    },
+    {
+      "version": "20260723000001",
+      "task": "TASK-055",
+      "defaultCompare": ["grants"],
+      "objects": [
+        {
+          "type": "function",
+          "schema": "public",
+          "name": "revoke_document_member",
+          "compare": ["definition", "grants"]
+        },
+        { "type": "function", "schema": "public", "name": "sanitize_key_provisioning_error_code" },
+        { "type": "function", "schema": "public", "name": "has_active_document_key_for_device" },
+        { "type": "function", "schema": "public", "name": "enqueue_key_provisioning_notification" },
+        { "type": "function", "schema": "public", "name": "upsert_key_provisioning_requests_for_user" },
+        { "type": "function", "schema": "public", "name": "register_user_key_material" },
+        { "type": "function", "schema": "public", "name": "revoke_user_key_material" },
+        { "type": "function", "schema": "public", "name": "request_document_key_provisioning" },
+        { "type": "function", "schema": "public", "name": "get_my_document_key_provisioning_status" },
+        { "type": "function", "schema": "public", "name": "list_pending_document_key_provisioning_requests" },
+        { "type": "function", "schema": "public", "name": "begin_document_key_provisioning" },
+        { "type": "function", "schema": "public", "name": "complete_document_key_provisioning" },
+        { "type": "function", "schema": "public", "name": "mark_document_key_provisioning_failed" },
+        { "type": "function", "schema": "public", "name": "get_my_active_document_key" },
+        { "type": "function", "schema": "public", "name": "upsert_owner_document_key" },
+        { "type": "function", "schema": "public", "name": "issue_document_signaling_room_topic" },
+        { "type": "function", "schema": "public", "name": "can_receive_document_signaling_topic" },
+        { "type": "function", "schema": "public", "name": "can_send_document_signaling_topic" },
+        { "type": "function", "schema": "public", "name": "generate_invitation_link" },
+        { "type": "function", "schema": "public", "name": "get_trip_summary_by_token" },
+        { "type": "function", "schema": "public", "name": "join_trip_via_token" },
+        { "type": "function", "schema": "public", "name": "set_trip_document_member_role" },
+        { "type": "function", "schema": "public", "name": "revoke_trip_document_member" },
+        { "type": "table", "schema": "public", "name": "documents" },
+        { "type": "table", "schema": "public", "name": "document_members" },
+        { "type": "table", "schema": "public", "name": "document_updates" },
+        { "type": "table", "schema": "public", "name": "document_devices" },
+        { "type": "table", "schema": "public", "name": "legacy_row_map" },
+        { "type": "table", "schema": "public", "name": "document_keys" },
+        { "type": "table", "schema": "public", "name": "user_key_materials" },
+        { "type": "table", "schema": "public", "name": "document_key_provisioning_requests" },
+        { "type": "table", "schema": "public", "name": "document_signaling_room_topics" },
+        { "type": "table", "schema": "public", "name": "trip_members" },
+        { "type": "table", "schema": "public", "name": "trip_shares" },
+        {
+          "type": "policy",
+          "schema": "realtime",
+          "table": "messages",
+          "name": "authority readers can receive revision invalidations"
+        }
+      ]
+    },
+    {
+      "version": "20260723000002",
+      "task": "TASK-056",
+      "objects": [
+        { "type": "function", "schema": "public", "name": "trip_authority_stale_batch_is_rebasable" },
+        { "type": "function", "schema": "public", "name": "template_authority_stale_batch_is_rebasable" },
+        { "type": "function", "schema": "public", "name": "apply_trip_commands" },
+        { "type": "function", "schema": "public", "name": "apply_template_commands" }
+      ]
+    },
+    {
+      "version": "20260723000003",
+      "task": "TASK-058",
+      "objects": [
+        { "type": "function", "schema": "public", "name": "check_can_write_place_photo_object" },
+        { "type": "function", "schema": "public", "name": "register_place_photo_asset" },
+        { "type": "policy", "schema": "public", "table": "trip_asset_objects", "name": "trip_asset_objects_select_member" },
+        { "type": "policy", "schema": "storage", "table": "objects", "name": "place_photos_insert_own" },
+        { "type": "policy", "schema": "storage", "table": "objects", "name": "place_photos_update_own" },
+        { "type": "policy", "schema": "storage", "table": "objects", "name": "place_photos_delete_own" }
+      ]
+    },
+    {
+      "version": "20260727000001",
+      "task": "TASK-059",
+      "defaultCompare": ["grants"],
+      "objects": [
+        {
+          "type": "function",
+          "schema": "public",
+          "name": "check_can_read_authority_trip",
+          "compare": ["definition", "grants"]
+        },
+        {
+          "type": "function",
+          "schema": "public",
+          "name": "check_can_write_authority_trip",
+          "compare": ["definition", "grants"]
+        },
+        {
+          "type": "function",
+          "schema": "public",
+          "name": "check_can_read_authority_template",
+          "compare": ["definition", "grants"]
+        },
+        {
+          "type": "function",
+          "schema": "public",
+          "name": "check_can_write_authority_template",
+          "compare": ["definition", "grants"]
+        },
+        {
+          "type": "function",
+          "schema": "public",
+          "name": "can_receive_authority_topic",
+          "compare": ["definition", "grants"]
+        },
+        { "type": "function", "schema": "public", "name": "apply_one_trip_authority_command" },
+        { "type": "function", "schema": "public", "name": "apply_one_template_authority_command" },
+        { "type": "function", "schema": "public", "name": "apply_trip_authority_commands" },
+        { "type": "function", "schema": "public", "name": "apply_template_authority_commands" },
+        { "type": "function", "schema": "public", "name": "trip_authority_stale_batch_is_rebasable" },
+        { "type": "function", "schema": "public", "name": "template_authority_stale_batch_is_rebasable" },
+        { "type": "function", "schema": "public", "name": "broadcast_authority_state_invalidation" },
+        { "type": "function", "schema": "public", "name": "bump_authority_revision_for_membership" },
+        { "type": "function", "schema": "public", "name": "assert_targeted_invitation_recipient" },
+        { "type": "function", "schema": "public", "name": "accept_document_invitation_unchecked" },
+        { "type": "function", "schema": "public", "name": "create_document_invitation_link_legacy" },
+        { "type": "function", "schema": "public", "name": "bootstrap_owner_document" },
+        { "type": "function", "schema": "public", "name": "create_document_invitation_link" },
+        { "type": "function", "schema": "public", "name": "accept_document_invitation" },
+        { "type": "function", "schema": "public", "name": "get_document_invitation_summary" },
+        { "type": "function", "schema": "public", "name": "list_my_pending_document_invitations" },
+        { "type": "function", "schema": "public", "name": "accept_my_document_invitation" },
+        { "type": "function", "schema": "public", "name": "decline_my_document_invitation" },
+        { "type": "function", "schema": "public", "name": "list_document_collaborators" },
+        { "type": "function", "schema": "public", "name": "list_document_pending_invitations" },
+        { "type": "function", "schema": "public", "name": "set_document_member_role" },
+        { "type": "function", "schema": "public", "name": "revoke_document_member" },
+        { "type": "function", "schema": "public", "name": "get_trip_authority_revision" },
+        { "type": "function", "schema": "public", "name": "get_template_authority_revision" },
+        { "type": "function", "schema": "public", "name": "get_trip_authority_bundle" },
+        { "type": "function", "schema": "public", "name": "get_template_authority_bundle" },
+        { "type": "function", "schema": "public", "name": "get_trip_authority_changes" },
+        { "type": "function", "schema": "public", "name": "get_template_authority_changes" },
+        { "type": "function", "schema": "public", "name": "list_my_trip_authority_summaries" },
+        { "type": "function", "schema": "public", "name": "list_my_template_authority_summaries" },
+        { "type": "function", "schema": "public", "name": "apply_trip_commands" },
+        { "type": "function", "schema": "public", "name": "apply_template_commands" },
+        { "type": "function", "schema": "public", "name": "check_can_write_place_photo_object" },
+        { "type": "function", "schema": "public", "name": "register_place_photo_asset" },
+        { "type": "function", "schema": "public", "name": "list_orphan_place_photo_assets" }
+      ]
+    }
+  ]
+}

--- a/supabase/migrations/20260727000001_task059_authority_rpc_grant_hardening.sql
+++ b/supabase/migrations/20260727000001_task059_authority_rpc_grant_hardening.sql
@@ -1,0 +1,315 @@
+-- TASK-059: make the PostgREST RPC surface an explicit allowlist.
+--
+-- Supabase grants new public-schema functions to API roles through default
+-- privileges. REVOKE FROM PUBLIC alone therefore leaves explicit anon and
+-- authenticated grants in place. Internal SECURITY DEFINER functions must
+-- never be callable as RPCs.
+
+CREATE OR REPLACE FUNCTION public.check_can_read_authority_trip(
+  p_trip_id uuid,
+  p_user_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT p_user_id IS NOT DISTINCT FROM auth.uid()
+    AND p_trip_id IS NOT NULL
+    AND (
+      public.check_is_document_member(p_trip_id, p_user_id)
+      OR public.check_is_public_trip(p_trip_id)
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_can_write_authority_trip(
+  p_trip_id uuid,
+  p_user_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT p_user_id IS NOT DISTINCT FROM auth.uid()
+    AND p_trip_id IS NOT NULL
+    AND p_user_id IS NOT NULL
+    AND public.check_is_document_editor(p_trip_id, p_user_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_can_read_authority_template(
+  p_template_id uuid,
+  p_user_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT p_user_id IS NOT DISTINCT FROM auth.uid()
+    AND p_template_id IS NOT NULL
+    AND (
+      public.check_is_document_member(p_template_id, p_user_id)
+      OR EXISTS (
+        SELECT 1
+        FROM public.checklist_templates template
+        WHERE template.id = p_template_id
+          AND template.deleted_at IS NULL
+          AND template.user_id IS NULL
+      )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_can_write_authority_template(
+  p_template_id uuid,
+  p_user_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT p_user_id IS NOT DISTINCT FROM auth.uid()
+    AND p_template_id IS NOT NULL
+    AND p_user_id IS NOT NULL
+    AND public.check_is_document_editor(p_template_id, p_user_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_receive_authority_topic(
+  p_topic text,
+  p_user_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  resource_id uuid;
+BEGIN
+  IF p_topic IS NULL
+    OR p_user_id IS NULL
+    OR p_user_id IS DISTINCT FROM auth.uid() THEN
+    RETURN false;
+  END IF;
+
+  IF p_topic ~ '^trip:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+    resource_id := split_part(p_topic, ':', 2)::uuid;
+    RETURN public.check_can_read_authority_trip(resource_id, p_user_id);
+  END IF;
+
+  IF p_topic ~ '^template:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+    resource_id := split_part(p_topic, ':', 2)::uuid;
+    RETURN public.check_can_read_authority_template(resource_id, p_user_id);
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+-- Trigger and command internals are executable only by the database owner and
+-- service role. Product clients must use the public wrappers below.
+REVOKE ALL ON FUNCTION public.set_authority_row_metadata()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_one_trip_authority_command(uuid, jsonb, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_one_template_authority_command(uuid, jsonb, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_trip_authority_commands(uuid, jsonb, bigint)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_template_authority_commands(uuid, jsonb, bigint)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.trip_authority_stale_batch_is_rebasable(uuid, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.template_authority_stale_batch_is_rebasable(uuid, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.broadcast_authority_state_invalidation()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.bump_authority_revision_for_membership(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.assert_targeted_invitation_recipient(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.accept_document_invitation_unchecked(text, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.create_document_invitation_link_legacy(
+  uuid, text, timestamp with time zone, integer
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.set_authority_row_metadata() TO service_role;
+GRANT EXECUTE ON FUNCTION public.apply_one_trip_authority_command(uuid, jsonb, uuid)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.apply_one_template_authority_command(uuid, jsonb, uuid)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.apply_trip_authority_commands(uuid, jsonb, bigint)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.apply_template_authority_commands(uuid, jsonb, bigint)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.trip_authority_stale_batch_is_rebasable(uuid, jsonb)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.template_authority_stale_batch_is_rebasable(uuid, jsonb)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.broadcast_authority_state_invalidation() TO service_role;
+GRANT EXECUTE ON FUNCTION public.bump_authority_revision_for_membership(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.assert_targeted_invitation_recipient(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.accept_document_invitation_unchecked(text, text)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.create_document_invitation_link_legacy(
+  uuid, text, timestamp with time zone, integer
+) TO service_role;
+
+-- RLS helpers remain executable by the roles whose policies call them. The
+-- identity-bound helpers above prevent callers from probing another user.
+REVOKE ALL ON FUNCTION public.check_can_read_authority_trip(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.check_can_read_authority_template(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.check_can_write_authority_trip(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.check_can_write_authority_template(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.is_trip_authority_resource(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.is_trip_authority_plan(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.is_trip_authority_checklist(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.is_trip_authority_checklist_item(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.is_template_authority_resource(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.check_can_read_authority_trip(uuid, uuid)
+  TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.check_can_read_authority_template(uuid, uuid)
+  TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.check_can_write_authority_trip(uuid, uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.check_can_write_authority_template(uuid, uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.is_trip_authority_resource(uuid)
+  TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.is_trip_authority_plan(uuid)
+  TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.is_trip_authority_checklist(uuid)
+  TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.is_trip_authority_checklist_item(uuid)
+  TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.is_template_authority_resource(uuid)
+  TO anon, authenticated, service_role;
+
+-- Authenticated product RPCs. Explicitly clear anon grants inherited from
+-- Supabase default privileges before rebuilding the allowlist.
+REVOKE ALL ON FUNCTION public.bootstrap_owner_document(uuid, text, integer)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.create_document_invitation_link(
+  uuid, text, timestamp with time zone, integer, text, text, date, date
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.accept_document_invitation(text, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_my_pending_document_invitations()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.accept_my_document_invitation(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.decline_my_document_invitation(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_document_collaborators(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_document_pending_invitations(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.set_document_member_role(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.revoke_document_member(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_trip_authority_revision(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_template_authority_revision(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_trip_authority_bundle(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_template_authority_bundle(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_trip_authority_changes(uuid, jsonb, bigint)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_template_authority_changes(uuid, jsonb, bigint)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_my_trip_authority_summaries()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_my_template_authority_summaries()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_trip_commands(uuid, jsonb, bigint)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_template_commands(uuid, jsonb, bigint)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.can_receive_authority_topic(text, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.check_can_write_place_photo_object(text, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.register_place_photo_asset(
+  uuid, uuid, text, integer, text
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.bootstrap_owner_document(uuid, text, integer)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.create_document_invitation_link(
+  uuid, text, timestamp with time zone, integer, text, text, date, date
+) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.accept_document_invitation(text, text)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.list_my_pending_document_invitations()
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.accept_my_document_invitation(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.decline_my_document_invitation(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.list_document_collaborators(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.list_document_pending_invitations(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.set_document_member_role(uuid, text)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.revoke_document_member(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_trip_authority_revision(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_template_authority_revision(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_trip_authority_bundle(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_template_authority_bundle(uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_trip_authority_changes(uuid, jsonb, bigint)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_template_authority_changes(uuid, jsonb, bigint)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.list_my_trip_authority_summaries()
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.list_my_template_authority_summaries()
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.apply_trip_commands(uuid, jsonb, bigint)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.apply_template_commands(uuid, jsonb, bigint)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.can_receive_authority_topic(text, uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.check_can_write_place_photo_object(text, uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.register_place_photo_asset(
+  uuid, uuid, text, integer, text
+) TO authenticated, service_role;
+
+-- Invitation summary is the only TASK-043~059 product RPC intentionally
+-- available before login.
+REVOKE ALL ON FUNCTION public.get_document_invitation_summary(text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_document_invitation_summary(text, text)
+  TO anon, authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.list_orphan_place_photo_assets(interval)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.list_orphan_place_photo_assets(interval)
+  TO service_role;

--- a/supabase/tests/task049_realtime_authority_invalidation.sql
+++ b/supabase/tests/task049_realtime_authority_invalidation.sql
@@ -62,19 +62,6 @@ BEGIN
     RAISE EXCEPTION 'Invalidation payload exceeds 1KB: %', octet_length(message.payload::text);
   END IF;
 
-  IF NOT public.can_receive_authority_topic(
-    message.topic,
-    '00000000-0000-0000-0000-000000000492'
-  ) THEN
-    RAISE EXCEPTION 'Expected accepted viewer to receive invalidation';
-  END IF;
-
-  IF public.can_receive_authority_topic(
-    message.topic,
-    '00000000-0000-0000-0000-000000000493'
-  ) THEN
-    RAISE EXCEPTION 'Expected outsider to be denied invalidation';
-  END IF;
 END $$;
 
 SET ROLE authenticated;
@@ -84,6 +71,13 @@ SET realtime.topic = 'trip:49000000-0000-0000-0000-000000000001';
 DO $$
 DECLARE visible_messages integer;
 BEGIN
+  IF NOT public.can_receive_authority_topic(
+    'trip:49000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000492'
+  ) THEN
+    RAISE EXCEPTION 'Expected accepted viewer to receive invalidation';
+  END IF;
+
   SELECT count(*) INTO visible_messages
   FROM realtime.messages
   WHERE topic = 'trip:49000000-0000-0000-0000-000000000001'
@@ -99,6 +93,28 @@ SET status = 'revoked'
 WHERE document_id = '49000000-0000-0000-0000-000000000001'
   AND user_id = '00000000-0000-0000-0000-000000000492';
 
+SET ROLE authenticated;
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000493';
+DO $$
+DECLARE visible_messages integer;
+BEGIN
+  IF public.can_receive_authority_topic(
+    'trip:49000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000493'
+  ) THEN
+    RAISE EXCEPTION 'Expected outsider to be denied invalidation';
+  END IF;
+
+  SELECT count(*) INTO visible_messages
+  FROM realtime.messages
+  WHERE topic = 'trip:49000000-0000-0000-0000-000000000001'
+    AND event = 'authority_changed';
+  IF visible_messages <> 0 THEN
+    RAISE EXCEPTION 'Expected outsider RLS to hide authority invalidations';
+  END IF;
+END $$;
+
+SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000492';
 DO $$
 BEGIN
   IF public.can_receive_authority_topic(
@@ -106,20 +122,6 @@ BEGIN
     '00000000-0000-0000-0000-000000000492'
   ) THEN
     RAISE EXCEPTION 'Expected revoked viewer to be denied invalidations';
-  END IF;
-END $$;
-
-SET ROLE authenticated;
-SET request.jwt.claim.sub = '00000000-0000-0000-0000-000000000493';
-DO $$
-DECLARE visible_messages integer;
-BEGIN
-  SELECT count(*) INTO visible_messages
-  FROM realtime.messages
-  WHERE topic = 'trip:49000000-0000-0000-0000-000000000001'
-    AND event = 'authority_changed';
-  IF visible_messages <> 0 THEN
-    RAISE EXCEPTION 'Expected outsider RLS to hide authority invalidations';
   END IF;
 END $$;
 

--- a/supabase/tests/task059_authority_rpc_grants.sql
+++ b/supabase/tests/task059_authority_rpc_grants.sql
@@ -1,0 +1,251 @@
+-- TASK-059: explicit API role allowlist and identity-bound helper regression.
+BEGIN;
+
+DO $$
+DECLARE
+  denied_signature text;
+  allowed_signature text;
+BEGIN
+  FOREACH denied_signature IN ARRAY ARRAY[
+    'public.set_authority_row_metadata()',
+    'public.apply_one_trip_authority_command(uuid,jsonb,uuid)',
+    'public.apply_one_template_authority_command(uuid,jsonb,uuid)',
+    'public.apply_trip_authority_commands(uuid,jsonb,bigint)',
+    'public.apply_template_authority_commands(uuid,jsonb,bigint)',
+    'public.trip_authority_stale_batch_is_rebasable(uuid,jsonb)',
+    'public.template_authority_stale_batch_is_rebasable(uuid,jsonb)',
+    'public.broadcast_authority_state_invalidation()',
+    'public.bump_authority_revision_for_membership(uuid)',
+    'public.assert_targeted_invitation_recipient(uuid)',
+    'public.accept_document_invitation_unchecked(text,text)',
+    'public.create_document_invitation_link_legacy(uuid,text,timestamp with time zone,integer)',
+    'public.list_orphan_place_photo_assets(interval)'
+  ]
+  LOOP
+    IF has_function_privilege('anon', denied_signature, 'EXECUTE')
+      OR has_function_privilege('authenticated', denied_signature, 'EXECUTE') THEN
+      RAISE EXCEPTION 'Internal function remains exposed: %', denied_signature;
+    END IF;
+    IF NOT has_function_privilege('service_role', denied_signature, 'EXECUTE') THEN
+      RAISE EXCEPTION 'Service role cannot execute internal function: %', denied_signature;
+    END IF;
+  END LOOP;
+
+  FOREACH allowed_signature IN ARRAY ARRAY[
+    'public.bootstrap_owner_document(uuid,text,integer)',
+    'public.create_document_invitation_link(uuid,text,timestamp with time zone,integer,text,text,date,date)',
+    'public.accept_document_invitation(text,text)',
+    'public.list_my_pending_document_invitations()',
+    'public.accept_my_document_invitation(uuid)',
+    'public.decline_my_document_invitation(uuid)',
+    'public.list_document_collaborators(uuid)',
+    'public.list_document_pending_invitations(uuid)',
+    'public.set_document_member_role(uuid,text)',
+    'public.revoke_document_member(uuid)',
+    'public.get_trip_authority_revision(uuid)',
+    'public.get_template_authority_revision(uuid)',
+    'public.get_trip_authority_bundle(uuid)',
+    'public.get_template_authority_bundle(uuid)',
+    'public.get_trip_authority_changes(uuid,jsonb,bigint)',
+    'public.get_template_authority_changes(uuid,jsonb,bigint)',
+    'public.list_my_trip_authority_summaries()',
+    'public.list_my_template_authority_summaries()',
+    'public.apply_trip_commands(uuid,jsonb,bigint)',
+    'public.apply_template_commands(uuid,jsonb,bigint)',
+    'public.can_receive_authority_topic(text,uuid)',
+    'public.check_can_write_place_photo_object(text,uuid)',
+    'public.register_place_photo_asset(uuid,uuid,text,integer,text)'
+  ]
+  LOOP
+    IF has_function_privilege('anon', allowed_signature, 'EXECUTE') THEN
+      RAISE EXCEPTION 'Authenticated RPC remains exposed to anon: %', allowed_signature;
+    END IF;
+    IF NOT has_function_privilege('authenticated', allowed_signature, 'EXECUTE') THEN
+      RAISE EXCEPTION 'Authenticated RPC is unavailable: %', allowed_signature;
+    END IF;
+  END LOOP;
+
+  IF NOT has_function_privilege(
+    'anon',
+    'public.get_document_invitation_summary(text,text)',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'Invitation summary must remain available before login';
+  END IF;
+
+  IF NOT has_function_privilege(
+    'anon',
+    'public.check_can_read_authority_trip(uuid,uuid)',
+    'EXECUTE'
+  ) OR has_function_privilege(
+    'anon',
+    'public.check_can_write_authority_trip(uuid,uuid)',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'Authority RLS helper role split is invalid';
+  END IF;
+END;
+$$;
+
+INSERT INTO auth.users (
+  id, instance_id, aud, role, email, encrypted_password,
+  email_confirmed_at, raw_app_meta_data, raw_user_meta_data,
+  created_at, updated_at
+) VALUES
+  (
+    '00000000-0000-0000-0000-000000000591',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'task059-owner-a@onvoy.local',
+    crypt('password', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  ),
+  (
+    '00000000-0000-0000-0000-000000000592',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'task059-owner-b@onvoy.local',
+    crypt('password', gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  );
+
+INSERT INTO public.profiles (id, email, nickname)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000591',
+    'task059-owner-a@onvoy.local',
+    'TASK-059 A'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000592',
+    'task059-owner-b@onvoy.local',
+    'TASK-059 B'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.documents (id, owner_id, type, schema_version)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000005591',
+    '00000000-0000-0000-0000-000000000591',
+    'trip',
+    1
+  ),
+  (
+    '00000000-0000-0000-0000-000000005592',
+    '00000000-0000-0000-0000-000000000592',
+    'trip',
+    1
+  );
+
+INSERT INTO public.document_members (
+  document_id, user_id, role, status
+) VALUES
+  (
+    '00000000-0000-0000-0000-000000005591',
+    '00000000-0000-0000-0000-000000000591',
+    'owner',
+    'accepted'
+  ),
+  (
+    '00000000-0000-0000-0000-000000005592',
+    '00000000-0000-0000-0000-000000000592',
+    'owner',
+    'accepted'
+  );
+
+INSERT INTO public.trips (
+  id, user_id, destination, start_date, end_date
+) VALUES
+  (
+    '00000000-0000-0000-0000-000000005591',
+    '00000000-0000-0000-0000-000000000591',
+    'TASK-059 A',
+    current_date,
+    current_date + 1
+  ),
+  (
+    '00000000-0000-0000-0000-000000005592',
+    '00000000-0000-0000-0000-000000000592',
+    'TASK-059 B',
+    current_date,
+    current_date + 1
+  );
+
+INSERT INTO public.trip_authority_state (trip_id, revision)
+VALUES
+  ('00000000-0000-0000-0000-000000005591', 1),
+  ('00000000-0000-0000-0000-000000005592', 1);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-000000000591","role":"authenticated","email":"task059-owner-a@onvoy.local"}',
+  true
+);
+SELECT set_config(
+  'request.jwt.claim.sub',
+  '00000000-0000-0000-0000-000000000591',
+  true
+);
+
+DO $$
+BEGIN
+  IF NOT public.check_can_write_authority_trip(
+    '00000000-0000-0000-0000-000000005591',
+    '00000000-0000-0000-0000-000000000591'
+  ) THEN
+    RAISE EXCEPTION 'Caller lost write authority for its own trip';
+  END IF;
+
+  IF public.check_can_write_authority_trip(
+    '00000000-0000-0000-0000-000000005592',
+    '00000000-0000-0000-0000-000000000592'
+  ) THEN
+    RAISE EXCEPTION 'Caller can probe another user write authority';
+  END IF;
+
+  IF public.check_can_read_authority_trip(
+    '00000000-0000-0000-0000-000000005592',
+    '00000000-0000-0000-0000-000000000592'
+  ) THEN
+    RAISE EXCEPTION 'Caller can probe another user read authority';
+  END IF;
+
+  IF public.can_receive_authority_topic(
+    'trip:00000000-0000-0000-0000-000000005592',
+    '00000000-0000-0000-0000-000000000592'
+  ) THEN
+    RAISE EXCEPTION 'Caller can probe another user Realtime authority';
+  END IF;
+
+  BEGIN
+    PERFORM public.apply_one_trip_authority_command(
+      '00000000-0000-0000-0000-000000005592',
+      jsonb_build_object(
+        'operation_id', '00000000-0000-0000-0000-000000009591',
+        'entity_type', 'trip',
+        'entity_id', '00000000-0000-0000-0000-000000005592',
+        'action', 'delete'
+      ),
+      '00000000-0000-0000-0000-000000000592'
+    );
+    RAISE EXCEPTION 'Internal command RPC unexpectedly executed';
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;
+  END;
+END;
+$$;
+
+RESET ROLE;
+ROLLBACK;

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -5,7 +5,8 @@
 Issue [#376](https://github.com/ysjee141/nexvoy-frontend/issues/376)에 따라 SQL Editor로 적용된 DEV 객체와
 미등록 migration history를 재현 가능하게 판정했다. 원본 historical SQL을 다시 실행하지 않고,
 검증된 version은 repair하고 실제 누락된 TASK-058/059만 forward migration으로 적용하는 절차를
-확정했다. 사용자 승인 후 DEV에 해당 절차를 실행했으며 Production은 변경하지 않았다.
+확정했다. 사용자 승인 후 DEV에 전체 절차를 실행하고, 추가 승인 후 Production에는 TASK-058/059만
+target-only 방식으로 적용했다.
 
 ## 주요 변경
 
@@ -28,8 +29,14 @@ Issue [#376](https://github.com/ysjee141/nexvoy-frontend/issues/376)에 따라 S
 - 임시 owner/editor/viewer/outsider 네 계정의 authenticated smoke PASS
 - QA 여행 soft-delete와 임시 Auth 계정 4/4 삭제
 
-Production은 읽기 전용으로만 확인했다. 로컬 history 대부분이 미등록이며 원격 전용 version 4건과
-두 checklist `is_private NOT NULL` 차이가 있어 TASK-063에서 독립 처리한다.
+## Production 적용
+
+- 기존 원격 전용 history 4건을 보존하는 격리 workspace 사용
+- dry-run에서 TASK-058/059만 확인한 뒤 두 migration 적용
+- 적용 후 target-only dry-run 0건, fingerprint 11/12 version·183/185 객체 일치
+- anonymous public write wrapper와 internal command RPC `42501` 차단 PASS
+- 실제 사용자, QA 계정과 여행 데이터 생성 없음
+- 남은 historical ledger gap과 두 checklist `is_private NOT NULL` 차이는 TASK-063에서 처리
 
 ## 검증
 
@@ -39,7 +46,7 @@ Production은 읽기 전용으로만 확인했다. 로컬 history 대부분이 �
 - fingerprint 자기 비교 12/12, 185/185 PASS
 - DEV 적용 후 fingerprint 12/12, 185/185와 migration drift 0 PASS
 - authenticated remote-safe smoke PASS
-- Production 변경 없음
+- Production TASK-058/059 target-only 적용과 anonymous denial smoke PASS
 
 ## 다음 단계
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,53 @@
+# Walkthrough: TASK-059 DEV Migration Ledger 정합화
+
+## 요약
+
+Issue [#376](https://github.com/ysjee141/nexvoy-frontend/issues/376)에 따라 SQL Editor로 적용된 DEV 객체와
+미등록 migration history를 재현 가능하게 판정했다. 원본 historical SQL을 다시 실행하지 않고,
+검증된 version은 repair하고 실제 누락된 TASK-058/059만 forward migration으로 적용하는 절차를
+확정했다. 사용자 승인 후 DEV에 해당 절차를 실행했으며 Production은 변경하지 않았다.
+
+## 주요 변경
+
+- 12개 version, 185개 객체의 function/table/constraint/index/policy/trigger/RLS/grant manifest와
+  `pg_dump` 비교 도구를 추가했다.
+- Supabase 기본 함수 권한에서 남은 internal authority RPC의 `anon`/`authenticated` EXECUTE를
+  `service_role`로 제한했다.
+- 제품 RPC는 authenticated allowlist로 재구성하고, trip/template/topic helper를 `auth.uid()`에
+  결속해 타 사용자 ID 대입을 차단했다.
+- SQL 회귀 테스트는 internal RPC 접근, 역할별 공개 RPC, 초대 요약 익명 접근과 신원 결속을 검증한다.
+- remote-safe smoke는 service role 없이 전용 QA 네 계정으로 초대, 권한, revision, 멱등성과 revoke를
+  검증하고 QA 여행을 soft-delete한다.
+
+## DEV 적용
+
+- 적용 전 history 미등록: `20260712000001`~`20260723000002` 중 10건, TASK-058, TASK-059
+- historical 10건은 객체 재실행 없이 history만 repair
+- dry-run에서 TASK-058/059만 확인한 뒤 두 forward migration 적용
+- 적용 후 migration drift 0, strict fingerprint 12/12 version·185/185 객체 일치
+- 임시 owner/editor/viewer/outsider 네 계정의 authenticated smoke PASS
+- QA 여행 soft-delete와 임시 Auth 계정 4/4 삭제
+
+Production은 읽기 전용으로만 확인했다. 로컬 history 대부분이 미등록이며 원격 전용 version 4건과
+두 checklist `is_private NOT NULL` 차이가 있어 TASK-063에서 독립 처리한다.
+
+## 검증
+
+- `pnpm test:production:p0` PASS: Core, Web/Mobile store, 전체 SQL, Playwright 23건
+- `pnpm typecheck`, `pnpm build:packages`, `pnpm build:web` PASS
+- `pnpm build:mobile`, `pnpm lint:mobile` PASS
+- fingerprint 자기 비교 12/12, 185/185 PASS
+- DEV 적용 후 fingerprint 12/12, 185/185와 migration drift 0 PASS
+- authenticated remote-safe smoke PASS
+- Production 변경 없음
+
+## 다음 단계
+
+TASK-059 Gate를 모두 통과했다. TASK-060에서 DEV 기준 Web·Android·iOS 실기기, 다중 계정과 asset
+통합 매트릭스를 검증한다.
+
+---
+
 # Walkthrough: TASK-058 Production P0 통합 테스트 자동화
 
 ## 요약


### PR DESCRIPTION
## 변경 내용

- TASK-021~059 대상 12개 migration version과 185개 DB 객체의 재현 가능한 fingerprint 감사 도구를 추가했습니다.
- authority helper를 `auth.uid()`에 결속하고 internal RPC는 `service_role`, 제품 RPC는 `authenticated` allowlist로 제한했습니다.
- 역할별 SQL 회귀 테스트와 service-role 없는 DEV authenticated remote-safe smoke를 추가했습니다.
- DEV migration history 10건을 실제 객체 기준으로 repair하고 TASK-058/059 forward migration을 적용했습니다.

## DEV 적용 결과

- 대상: `ivgkqzwosbjukonlpfdw`
- migration drift: 0
- strict fingerprint: 12/12 version, 185/185 객체 일치
- owner/editor/viewer/outsider authenticated smoke: PASS
- QA 여행 soft-delete 및 임시 Auth 계정 4/4 삭제

## Production 적용 결과

- 대상: `runbcaegpefqnljsswhv`
- 기존 Production 전용 history 4건을 보존하는 target-only workspace 사용
- TASK-058/059 두 migration만 적용, 후속 target-only dry-run 0건
- fingerprint: 적용 전 116/185 → 적용 후 183/185
- anonymous public write wrapper/internal command RPC 차단 PASS
- 실제 사용자, QA 계정과 여행 데이터 생성 없음
- 남은 두 `is_private NOT NULL` 차이와 전체 ledger 정합화·rollout은 TASK-063 범위

## 검증

- `pnpm test:production:p0`
- `pnpm typecheck`
- `pnpm build:packages`
- `pnpm build:web`
- `pnpm build:mobile`
- `pnpm lint:mobile`
- 전체 SQL smoke와 Playwright 23건
- DEV migration dry-run 및 strict schema fingerprint
- DEV authenticated remote-safe smoke
- Production target-only dry-run, schema fingerprint, anonymous denial smoke

Resolves #376
