### PR TITLE
fix(TASK-060): restore Android invitation and offline checklist flow

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -18,6 +18,10 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRouter, useFocusEffect } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
 import { formatDate } from '@nexvoy/core'
+import {
+  createInvitationRepository,
+  type PendingDocumentInvitation,
+} from '@nexvoy/core/supabase/invitationRepository'
 import type { TripWithProgress } from '@nexvoy/types'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/lib/auth-context'
@@ -62,6 +66,10 @@ export default function HomeScreen() {
   const router = useRouter()
   const [trips, setTrips] = useState<TripWithProgress[]>([])
   const [loading, setLoading] = useState(true)
+  const [invitations, setInvitations] = useState<PendingDocumentInvitation[]>([])
+  const [invitationsLoading, setInvitationsLoading] = useState(true)
+  const [invitationError, setInvitationError] = useState<string | null>(null)
+  const [processingInvitationId, setProcessingInvitationId] = useState<string | null>(null)
   const [openSections, setOpenSections] = useState<Record<TripStatus, boolean>>({
     ongoing: true,
     upcoming: true,
@@ -87,11 +95,72 @@ export default function HomeScreen() {
     }
   }, [session?.user])
 
+  const loadInvitations = useCallback(async () => {
+    if (!session?.user) return
+    setInvitationsLoading(true)
+    setInvitationError(null)
+    try {
+      const rows = await createInvitationRepository(supabase).listMyPendingDocumentInvitations()
+      setInvitations(rows)
+    } catch {
+      setInvitationError('초대 목록을 불러오지 못했어요.')
+    } finally {
+      setInvitationsLoading(false)
+    }
+  }, [session?.user])
+
+  const processInvitation = useCallback(async (
+    invitationId: string,
+    action: 'accept' | 'decline',
+  ) => {
+    if (processingInvitationId) return
+    setProcessingInvitationId(invitationId)
+    setInvitationError(null)
+    try {
+      const repository = createInvitationRepository(supabase)
+      if (action === 'decline') {
+        await repository.declineMyDocumentInvitation(invitationId)
+        setInvitations((current) => current.filter((invitation) => invitation.id !== invitationId))
+        return
+      }
+
+      const accepted = await repository.acceptMyDocumentInvitation(invitationId)
+      setInvitations((current) => current.filter((invitation) => invitation.id !== invitationId))
+      try {
+        await refreshMobileProductList(supabase, 'trip')
+        await loadTrips(false)
+      } catch {
+        setInvitationError('초대는 수락했지만 여행 데이터를 준비하지 못했어요. 다시 시도해 주세요.')
+        return
+      }
+      router.push({ pathname: '/trip/[id]', params: { id: accepted.documentId } })
+    } catch {
+      setInvitationError(action === 'accept'
+        ? '초대를 수락하지 못했어요.'
+        : '초대를 거절하지 못했어요.')
+    } finally {
+      setProcessingInvitationId(null)
+    }
+  }, [loadTrips, processingInvitationId, router])
+
+  const retryInvitationState = useCallback(async () => {
+    setInvitationError(null)
+    await Promise.all([
+      loadInvitations(),
+      refreshMobileProductList(supabase, 'trip')
+        .then(() => loadTrips(false))
+        .catch(() => {
+          setInvitationError('여행 데이터를 준비하지 못했어요. 연결 상태를 확인해 주세요.')
+        }),
+    ])
+  }, [loadInvitations, loadTrips])
+
   useFocusEffect(
     useCallback(() => {
       let disposed = false
       let unsubscribe: () => void = () => undefined
       void loadTrips()
+      void loadInvitations()
       void subscribeMobileProductAccount(supabase, 'trip', () => {
         if (!disposed) void loadTrips(false)
       }).then((next) => {
@@ -103,7 +172,7 @@ export default function HomeScreen() {
         disposed = true
         unsubscribe()
       }
-    }, [loadTrips])
+    }, [loadInvitations, loadTrips])
   )
 
   const sections = useMemo<TripSection[]>(() => {
@@ -213,6 +282,16 @@ export default function HomeScreen() {
         <Text style={styles.heading}>어디로 떠나볼까요?</Text>
       </View>
 
+      <InvitationInbox
+        invitations={invitations}
+        loading={invitationsLoading}
+        processingId={processingInvitationId}
+        error={invitationError}
+        onAccept={(invitationId) => { void processInvitation(invitationId, 'accept') }}
+        onDecline={(invitationId) => { void processInvitation(invitationId, 'decline') }}
+        onRetry={() => { void retryInvitationState() }}
+      />
+
       {loading ? (
         <View style={styles.centerFill}>
           <ActivityIndicator size="large" color={colors.brand.primary} />
@@ -285,6 +364,111 @@ export default function HomeScreen() {
   )
 }
 
+function InvitationInbox({
+  invitations,
+  loading,
+  processingId,
+  error,
+  onAccept,
+  onDecline,
+  onRetry,
+}: {
+  invitations: PendingDocumentInvitation[]
+  loading: boolean
+  processingId: string | null
+  error: string | null
+  onAccept: (invitationId: string) => void
+  onDecline: (invitationId: string) => void
+  onRetry: () => void
+}) {
+  if (loading || (invitations.length === 0 && !error)) return null
+
+  return (
+    <View style={styles.invitationBand} accessibilityRole="summary">
+      <View style={styles.invitationHeader}>
+        <View style={styles.invitationTitleRow}>
+          <Ionicons name="mail-outline" size={18} color={colors.brand.primary} />
+          <Text style={styles.invitationTitle}>새로운 여행 초대</Text>
+          {invitations.length > 0 ? (
+            <Text style={styles.invitationCount}>{invitations.length}</Text>
+          ) : null}
+        </View>
+        {error ? (
+          <Pressable
+            onPress={onRetry}
+            accessibilityRole="button"
+            accessibilityLabel="초대 목록 다시 불러오기"
+            hitSlop={8}
+            style={({ pressed }) => [styles.invitationRetry, pressed && styles.invitationButtonPressed]}
+          >
+            <Ionicons name="refresh" size={18} color={colors.brand.primary} />
+          </Pressable>
+        ) : null}
+      </View>
+
+      {invitations.length > 0 ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.invitationList}
+        >
+          {invitations.map((invitation) => {
+            const processing = processingId === invitation.id
+            return (
+              <View key={invitation.id} style={styles.invitationCard}>
+                <View style={styles.invitationBody}>
+                  <Text style={styles.invitationDestination} numberOfLines={1}>
+                    {invitation.destination || '새 여행'}
+                  </Text>
+                  <Text style={styles.invitationMeta} numberOfLines={1}>
+                    {invitation.ownerNickname || '동행자'} · {invitation.role === 'editor' ? '편집 가능' : '조회 전용'}
+                  </Text>
+                </View>
+                <View style={styles.invitationActions}>
+                  <Pressable
+                    onPress={() => onAccept(invitation.id)}
+                    disabled={Boolean(processingId)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${invitation.destination || '여행'} 초대 수락`}
+                    style={({ pressed }) => [
+                      styles.invitationActionButton,
+                      styles.invitationAcceptButton,
+                      pressed && styles.invitationButtonPressed,
+                      processingId && styles.invitationButtonDisabled,
+                    ]}
+                  >
+                    {processing ? (
+                      <ActivityIndicator size="small" color={colors.bg.canvas} />
+                    ) : (
+                      <Ionicons name="checkmark" size={18} color={colors.bg.canvas} />
+                    )}
+                  </Pressable>
+                  <Pressable
+                    onPress={() => onDecline(invitation.id)}
+                    disabled={Boolean(processingId)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${invitation.destination || '여행'} 초대 거절`}
+                    style={({ pressed }) => [
+                      styles.invitationActionButton,
+                      styles.invitationDeclineButton,
+                      pressed && styles.invitationButtonPressed,
+                      processingId && styles.invitationButtonDisabled,
+                    ]}
+                  >
+                    <Ionicons name="close" size={18} color={colors.brand.muted} />
+                  </Pressable>
+                </View>
+              </View>
+            )
+          })}
+        </ScrollView>
+      ) : null}
+
+      {error ? <Text style={styles.invitationError}>{error}</Text> : null}
+    </View>
+  )
+}
+
 const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: colors.bg.canvas },
   header: {
@@ -302,6 +486,111 @@ const styles = StyleSheet.create({
     fontWeight: fontWeights.bold,
     color: colors.brand.ink,
     letterSpacing: -0.5,
+  },
+  invitationBand: {
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: colors.brand.border,
+    backgroundColor: colors.bg.surfaceSoft,
+    paddingVertical: spacing.sm,
+  },
+  invitationHeader: {
+    minHeight: 36,
+    paddingHorizontal: spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  invitationTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  invitationTitle: {
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+  },
+  invitationCount: {
+    minWidth: 22,
+    height: 22,
+    borderRadius: radii.full,
+    overflow: 'hidden',
+    textAlign: 'center',
+    lineHeight: 22,
+    fontSize: fontSizes.xs,
+    fontWeight: fontWeights.bold,
+    color: colors.brand.primary,
+    backgroundColor: colors.bg.canvas,
+  },
+  invitationRetry: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  invitationList: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xs,
+    gap: spacing.sm,
+  },
+  invitationCard: {
+    width: 292,
+    minHeight: 72,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.brand.border,
+    borderRadius: radii.sm,
+    backgroundColor: colors.bg.canvas,
+  },
+  invitationBody: {
+    flex: 1,
+    minWidth: 0,
+  },
+  invitationDestination: {
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
+    color: colors.brand.ink,
+  },
+  invitationMeta: {
+    marginTop: spacing.xs,
+    fontSize: fontSizes.xs,
+    color: colors.brand.muted,
+  },
+  invitationActions: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+  },
+  invitationActionButton: {
+    width: 36,
+    height: 36,
+    borderRadius: radii.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  invitationAcceptButton: {
+    backgroundColor: colors.brand.primary,
+  },
+  invitationDeclineButton: {
+    borderWidth: 1,
+    borderColor: colors.brand.border,
+    backgroundColor: colors.bg.canvas,
+  },
+  invitationButtonPressed: {
+    opacity: 0.72,
+  },
+  invitationButtonDisabled: {
+    opacity: 0.5,
+  },
+  invitationError: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xs,
+    fontSize: fontSizes.xs,
+    fontWeight: fontWeights.semibold,
+    color: colors.brand.error,
   },
   centerFill: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   listBody: {

--- a/apps/mobile/app/trip/[id].tsx
+++ b/apps/mobile/app/trip/[id].tsx
@@ -42,9 +42,7 @@ import { NativeMapView, NativeMarker } from '@/components/map/NativeMap'
 import { AuthoritySyncStatusBadge } from '@/components/trip/AuthoritySyncStatusBadge'
 import { AuthorityConflictModal } from '@/components/trip/AuthorityConflictModal'
 import {
-  getChecklistCategories,
   getChecklistItemStatus,
-  createChecklistCategory,
   createUuid,
   formatDate,
   formatCurrency,
@@ -96,6 +94,11 @@ import {
   resolveMobileProductConflict,
   subscribeMobileProductResource,
 } from '@/lib/data/repositoryFactory'
+import {
+  mergeChecklistCategories,
+  persistChecklistCategory,
+  readChecklistCategoryCatalog,
+} from '@/lib/data/checklistCategoryCatalog'
 import {
   getInviteApiErrorMessage,
   getInviteFunctionErrorMessage,
@@ -882,12 +885,22 @@ export default function TripDetailScreen() {
       const result = await repositories.checklists.getChecklist(id)
       if (!isMounted.current) return
       const snapshot = toChecklistSnapshotRows(result, id)
-      const categoryData = session?.user.id ? await getChecklistCategories(supabase, session.user.id) : []
       setChecklist(snapshot.checklist)
       setItems(snapshot.items)
       setItemAssignees(snapshot.itemAssignees)
       setUserChecks(snapshot.userChecks)
-      setChecklistCategories(categoryData)
+      const categoryNames = snapshot.items.map((item) => item.category)
+      const userId = session?.user.id ?? null
+      setChecklistCategories((current) => mergeChecklistCategories(current, categoryNames, userId))
+      if (userId) {
+        void readChecklistCategoryCatalog(supabase, userId)
+          .then((categoryData) => {
+            if (isMounted.current) {
+              setChecklistCategories(mergeChecklistCategories(categoryData, categoryNames, userId))
+            }
+          })
+          .catch(() => undefined)
+      }
     } catch {
       // 빈 상태 유지
     } finally {
@@ -1282,16 +1295,6 @@ export default function TripDetailScreen() {
       const normalizedCategory = input.category.trim() || '기타'
       const shouldCreateCategory = Boolean(session?.user.id)
         && !checklistCategories.some((category) => category.name.trim().toLowerCase() === normalizedCategory.toLowerCase())
-      if (shouldCreateCategory && session?.user.id) {
-        const createdCategory = await createChecklistCategory(supabase, {
-          user_id: session.user.id,
-          name: normalizedCategory,
-          sort_order: checklistCategories.length > 0
-            ? Math.max(...checklistCategories.map((category) => category.sort_order ?? 0)) + 10
-            : 10,
-        })
-        setChecklistCategories((prev) => [...prev, createdCategory])
-      }
       const finalAssigneeIds = input.is_private
         ? (session?.user.id ? [session.user.id] : [])
         : input.assignment_type === 'specific'
@@ -1330,6 +1333,35 @@ export default function TripDetailScreen() {
           sourceTemplateName: null,
           assigneeIds: finalAssigneeIds,
         })
+      }
+      const userId = session?.user.id ?? null
+      setChecklistCategories((current) => mergeChecklistCategories(
+        current,
+        [normalizedCategory],
+        userId,
+      ))
+      if (shouldCreateCategory && userId) {
+        const sortOrder = checklistCategories.length > 0
+          ? Math.max(...checklistCategories.map((category) => category.sort_order ?? 0)) + 10
+          : 10
+        void persistChecklistCategory({
+          supabase,
+          userId,
+          name: normalizedCategory,
+          sortOrder,
+        }).then((createdCategory) => {
+          if (!isMounted.current) return
+          setChecklistCategories((current) => mergeChecklistCategories(
+            [
+              ...current.filter((category) => (
+                category.name.trim().toLowerCase() !== normalizedCategory.toLowerCase()
+              )),
+              createdCategory,
+            ],
+            [normalizedCategory],
+            userId,
+          ))
+        }).catch(() => undefined)
       }
       setEditingItem(null)
       setIsItemSheetOpen(false)

--- a/apps/mobile/lib/data/checklistCategoryCatalog.ts
+++ b/apps/mobile/lib/data/checklistCategoryCatalog.ts
@@ -1,0 +1,63 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  createChecklistCategory,
+  getChecklistCategories,
+} from '@nexvoy/core'
+import type { ChecklistCategory } from '@nexvoy/types'
+
+const LOCAL_CATEGORY_TIMESTAMP = '1970-01-01T00:00:00.000Z'
+
+export function readChecklistCategoryCatalog(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<ChecklistCategory[]> {
+  return getChecklistCategories(supabase, userId)
+}
+
+export function persistChecklistCategory(input: {
+  supabase: SupabaseClient
+  userId: string
+  name: string
+  sortOrder: number
+}): Promise<ChecklistCategory> {
+  return createChecklistCategory(input.supabase, {
+    user_id: input.userId,
+    name: input.name,
+    sort_order: input.sortOrder,
+  })
+}
+
+export function mergeChecklistCategories(
+  categories: ChecklistCategory[],
+  categoryNames: string[],
+  userId: string | null,
+): ChecklistCategory[] {
+  const merged: ChecklistCategory[] = []
+  const seen = new Set<string>()
+  const add = (category: ChecklistCategory) => {
+    const key = category.name.trim().toLowerCase()
+    if (!key || seen.has(key)) return
+    seen.add(key)
+    merged.push(category)
+  }
+
+  categories.forEach(add)
+  const baseSortOrder = categories.reduce(
+    (maximum, category) => Math.max(maximum, category.sort_order ?? 0),
+    0,
+  )
+  const localCategoryNames = ['기타', ...categoryNames]
+  localCategoryNames.forEach((name, index) => {
+    const normalizedName = name.trim()
+    if (!normalizedName) return
+    add({
+      id: `local:${encodeURIComponent(normalizedName.toLowerCase())}`,
+      user_id: userId,
+      name: normalizedName,
+      sort_order: baseSortOrder + ((index + 1) * 10),
+      created_at: LOCAL_CATEGORY_TIMESTAMP,
+      updated_at: LOCAL_CATEGORY_TIMESTAMP,
+    })
+  })
+  return merged
+}

--- a/apps/mobile/lib/data/server-authority/__tests__/checklistCategoryCatalog.test.ts
+++ b/apps/mobile/lib/data/server-authority/__tests__/checklistCategoryCatalog.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { ChecklistCategory } from '@nexvoy/types'
+import { mergeChecklistCategories } from '../../checklistCategoryCatalog'
+
+const REMOTE_CATEGORY: ChecklistCategory = {
+  id: 'category-1',
+  user_id: 'user-1',
+  name: '서류',
+  sort_order: 10,
+  created_at: '2026-08-01T00:00:00.000Z',
+  updated_at: '2026-08-01T00:00:00.000Z',
+}
+
+test('merges canonical item categories into an offline catalog', () => {
+  const categories = mergeChecklistCategories(
+    [REMOTE_CATEGORY],
+    ['서류', '의류', '의류'],
+    'user-1',
+  )
+
+  assert.deepEqual(categories.map((category) => category.name), ['서류', '기타', '의류'])
+  assert.equal(categories[0]?.id, 'category-1')
+  assert.equal(categories[2]?.id.startsWith('local:'), true)
+})
+
+test('provides a stable fallback category without a network catalog', () => {
+  const first = mergeChecklistCategories([], [], 'user-1')
+  const second = mergeChecklistCategories([], [], 'user-1')
+
+  assert.equal(first[0]?.name, '기타')
+  assert.equal(first[0]?.id, second[0]?.id)
+})

--- a/docs/refactor/reports/TASK-060-cross-platform-device-validation.md
+++ b/docs/refactor/reports/TASK-060-cross-platform-device-validation.md
@@ -55,12 +55,20 @@ Android Production Gate는 완료 처리하지 않는다.
    `[object Object]`를 표시했다. Mobile 초대를 동일 Supabase 프로젝트의 JWT 인증 Edge Function으로
    전환하고 구조화 오류 파서를 추가했다. DEV 인증 스모크에서 초대 생성, 이메일 전송, owner 조회와
    취소를 확인했다.
+6. 실제 Android 기기에서 초대받은 계정의 수락 UI가 없음을 확인했다. Core invitation repository의
+   수신 목록·수락·거절 경로를 Mobile 홈 인박스에 연결하고, 수락 후 trip authority hydration을
+   완료한 다음 상세로 이동하도록 수정했다.
+7. 오프라인 준비물 저장은 SQLite authority commit 이후 원격 category 조회에서 화면 갱신이
+   중단됐고, 신규 category insert는 commit 자체보다 먼저 실행됐다. 준비물 snapshot을 즉시 표시하고
+   category catalog 요청을 비차단 보조 동기화로 분리했다.
 
 ## 잔여 위험
 
 - Expo Doctor는 dynamic config, Metro 기본값, 직접 `expo-modules-core` 의존성 경고를 남긴다.
 - Android 실제 기기의 airplane mode, background/force-stop, push, 역할 변경·revoke, 초대 수락과
   Google/Kakao 로그인이 미검증이다.
+- 초대 수락 인박스와 오프라인 준비물 수정은 코드·단위 Gate를 통과했지만 Android 실제 기기 재검증이
+  필요하다.
 - `send-document-invitation`은 DEV에만 배포했다. Production secret과 함수 배포는 TASK-063
   preflight 전까지 출시 차단 항목이다.
 - iOS EAS cleanup 경고, icon, Firebase/RNFirebase deprecation과 심사 범위는 `TASK-064` 입력으로

--- a/docs/refactor/runbooks/TASK-060-cross-platform-device-validation.md
+++ b/docs/refactor/runbooks/TASK-060-cross-platform-device-validation.md
@@ -115,6 +115,10 @@ Android Simulator 성공은 `PREPASS`로만 기록한다. iOS build·launch 실�
 - Web에서 생성한 대상 이메일 초대가 같은 owner의 Android에서 `수락 대기`로 보이는지 확인한다.
 - Android에서 생성한 이메일 초대가 Web에서도 `수락 대기`로 보이고 Alert에 객체 문자열이
   노출되지 않는지 확인한다.
+- 초대받은 Android 계정의 홈에서 수신 초대가 표시되고 수락·거절할 수 있는지 확인한다. 수락하면
+  해당 여행이 목록에 나타나고 상세 데이터가 복구돼야 한다.
+- airplane mode에서 준비물 추가·수정·삭제·체크가 즉시 화면에 반영되는지 확인한다. reconnect 후
+  `동기화 완료`가 되고 다른 Web/Android 기기의 canonical 결과와 일치해야 한다.
 - Android Google/Kakao OAuth, invitation deep link, 실제 초대 이메일 수락, push·일정 알림을
   별도 판정한다.
 

--- a/docs/refactor/tasks/TASK-060-cross-platform-device-validation.md
+++ b/docs/refactor/tasks/TASK-060-cross-platform-device-validation.md
@@ -41,4 +41,6 @@
 - 검증 중 발견한 Mobile 비표준 entity ID와 plan 저장 전 Storage upload race를 수정했다.
 - iOS simulator release archive 설치·실행은 비차단 회귀 검사로 유지한다.
 - 실제 Android 다중 역할, offline/lifecycle과 Web/Android 매트릭스가 남아 있다.
+- 실제 기기 점검에서 Mobile 수신 초대 UI 누락과 오프라인 준비물 표시 차단을 발견해 Issue #380에서
+  수정·재검증 중이다.
 - 현재 판정은 Simulator `PREPASS`, Android 실기기 `BLOCKED`, Android Production `NO-GO`다.

--- a/packages/core/src/repositories/__tests__/serverAuthorityProductRepository.test.ts
+++ b/packages/core/src/repositories/__tests__/serverAuthorityProductRepository.test.ts
@@ -103,6 +103,23 @@ async function runServerAuthorityProductRepositoryTest(): Promise<void> {
     throw new Error('Authority trip bootstrap should enqueue trip and checklist commands together.')
   }
 
+  await repositories.checklists.createItem(tripId, {
+    id: 'checklist-item-offline-1',
+    checklistId: initial.checklists[0].id,
+    name: 'Offline passport',
+    categoryName: 'Documents',
+    legacyIsChecked: false,
+    isPrivate: false,
+    assignmentType: 'anyone',
+    assignedUserId: null,
+    sourceTemplateName: null,
+    assigneeIds: [],
+  })
+  const offlineChecklist = await repositories.checklists.getChecklist(tripId)
+  if (offlineChecklist[0]?.items[0]?.name !== 'Offline passport') {
+    throw new Error('Offline checklist mutations should be immediately readable from local state.')
+  }
+
   await repositories.plans.createPlan(tripId, {
     id: 'plan-1',
     title: 'Hanok Village',

--- a/packages/core/src/supabase/__tests__/invitationRepository.test.ts
+++ b/packages/core/src/supabase/__tests__/invitationRepository.test.ts
@@ -14,6 +14,9 @@ const responses: Record<string, unknown> = {
     start_date: '2026-07-20', end_date: '2026-07-24', owner_nickname: 'owner',
     expires_at: null, created_at: '2026-07-16T00:00:00.000Z',
   }],
+  accept_my_document_invitation: {
+    document_id: 'document-1', role: 'editor', status: 'accepted', already_member: false,
+  },
   list_document_collaborators: [{
     member_id: 'member-1', user_id: 'user-1', invited_email: null, nickname: 'owner',
     email: 'owner@example.com', role: 'owner', status: 'accepted',
@@ -49,6 +52,20 @@ async function main(): Promise<void> {
   const pending = await repository.listMyPendingDocumentInvitations()
   assert.equal(pending[0]?.destination, '전주')
   assert.equal(pending[0]?.ownerNickname, 'owner')
+
+  const accepted = await repository.acceptMyDocumentInvitation('invite-1')
+  assert.equal(accepted.documentId, 'document-1')
+  assert.equal(accepted.alreadyMember, false)
+  assert.deepEqual(calls.at(-1), {
+    name: 'accept_my_document_invitation',
+    params: { p_invitation_id: 'invite-1' },
+  })
+
+  await repository.declineMyDocumentInvitation('invite-2')
+  assert.deepEqual(calls.at(-1), {
+    name: 'decline_my_document_invitation',
+    params: { p_invitation_id: 'invite-2' },
+  })
 
   const collaborators = await repository.listDocumentCollaborators('document-1')
   assert.equal(collaborators[0]?.role, 'owner')

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,31 @@
+# Walkthrough: TASK-060 Android 초대 수락·오프라인 준비물 회귀
+
+## 발견 원인
+
+- Core에는 대상 이메일 초대 조회와 수락·거절 RPC가 있었지만 Mobile 홈에서 호출하지 않아 초대받은
+  계정이 응답할 UI가 없었다.
+- 준비물 authority mutation은 SQLite와 outbox에 낙관적으로 commit할 수 있었지만, 화면 reload가
+  원격 `checklist_categories` 조회를 기다렸다. 오프라인에서는 로컬 저장 결과를 다시 읽고도 화면에
+  반영하지 못했다.
+- 신규 카테고리 insert도 준비물 commit보다 먼저 실행돼 네트워크 오류가 핵심 데이터 저장을
+  차단했다.
+
+## 조치
+
+- Mobile 홈에 수신 초대 인박스를 추가하고 수락·거절, 오류 재시도를 연결했다. 수락 후에는 새 멤버
+  권한으로 trip authority 목록을 hydrate한 뒤 여행 상세로 이동한다.
+- 준비물 snapshot은 로컬 repository에서 읽은 즉시 화면에 적용한다. 원격 카테고리 catalog 조회와
+  생성은 비차단 보조 동기화로 분리했다.
+- 오프라인에서 만든 카테고리명은 준비물 canonical 데이터에서 로컬 선택지로 복원하므로 catalog
+  요청 실패와 무관하게 추가·수정 결과를 즉시 확인할 수 있다.
+
+## 검증
+
+- Core invitation 수락·거절 RPC와 offline checklist 낙관적 read 회귀 테스트를 추가했다.
+- Mobile typecheck와 lint, Core 전체 테스트를 통과했다.
+- Android 실기기에서는 초대받은 계정의 수락/거절, airplane mode 준비물 추가·수정·삭제·체크,
+  reconnect 후 다른 기기 수렴을 다시 확인해야 한다.
+
 # Walkthrough: TASK-060 Android 동행자 초대 정합성
 
 ## 문제와 원인


### PR DESCRIPTION
## 요약

- Android 홈에 수신 초대 인박스와 수락·거절·재시도 흐름을 연결했습니다.
- 초대 수락 후 authority 여행 목록을 복구한 뒤 해당 여행 상세로 이동합니다.
- 준비물 로컬 스냅샷을 원격 카테고리 조회보다 먼저 반영하고, 카테고리 동기화가 offline 저장을 차단하지 않도록 분리했습니다.
- 초대 RPC와 offline checklist local read 회귀 테스트를 추가했습니다.

## 검증

- `pnpm --filter @nexvoy/core test` PASS
- `pnpm --filter nexvoy-app test:authority` PASS (14/14)
- `pnpm --filter nexvoy-app typecheck` PASS
- `pnpm --filter nexvoy-app lint` PASS
- `pnpm typecheck` PASS
- `pnpm build:packages` PASS
- `pnpm build` PASS
- `pnpm build:mobile` PASS
- `pnpm test:production:p0` PASS (Playwright 23/23)
- Android preview native release APK build/install/launch PASS
- AndroidRuntime/ReactNativeJS fatal log 0건

## 실기기 재검증

- 초대받은 계정에서 수락/거절 UI와 수락 후 여행 복구
- 비행기 모드 준비물 추가·수정·체크·삭제 및 앱 재시작 보존
- reconnect 후 server revision과 다른 기기의 데이터 수렴

Closes #380