### PR TITLE
docs: defer TASK-062 recovery gate until Supabase Pro

### DIFF
--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -3,9 +3,9 @@
 ## 결론
 
 현재 OnVoy는 **Web·Android Production NO-GO**다. Authority-only 제품 코드, 로컬 자동 Gate와
-Android 실기기 Gate는 통과했지만 7일 관측, DB와 Storage 복구, 운영·법무·출시 책임 증적이 남아 있다.
+Android 실기기 Gate는 통과했지만 7일 관측과 운영·법무·출시 책임 증적이 남아 있다.
 최종 판정은 [TASK-057 마스터 계획](refactor/reports/TASK-057-production-final-validation-plan.md)의
-`G0`~`G7`을 따른다.
+초기 출시 필수 Gate `G0`~`G4`, `G6`, `G7`을 따른다. `G5` 복구는 초기 출시 비차단으로 보류한다.
 
 ## 출시 플랫폼
 
@@ -25,7 +25,8 @@ Android 실기기 Gate는 통과했지만 7일 관측, DB와 Storage 복구, 운
 | 비용 기준 | [TASK-056 초기 Production 비용](refactor/reports/TASK-056-initial-production-cost-baseline.md) |
 
 실제 실행은 `TASK-058` 자동화, `TASK-059` DEV migration, `TASK-060` Web·Android 실기기,
-`TASK-061` 관측, `TASK-062` 복구, `TASK-063` Web·Android Production 출시 순서로 진행한다.
+`TASK-061` 관측, `TASK-063` Web·Android Production 출시 순서로 진행한다. `TASK-062` 복구는
+Supabase Pro 전환 시 재개한다.
 iOS는 Android 안정화 이후 `TASK-064`에서 진행한다.
 
 ## 목표 아키텍처
@@ -46,8 +47,8 @@ iOS는 Android 안정화 이후 `TASK-064`에서 진행한다.
 | G2 DEV schema | migration history drift 0, strict fingerprint와 authenticated smoke | PASS |
 | G3 DEV 제품 | Web/Web·Web/Android·Android/Android P0/P1 100% PASS | PASS |
 | G4 관측 | 연속 7일 무사고와 지표 임계치 충족 | NO-GO |
-| G5 복구 | DB+Storage 격리 복구와 RTO/RPO 검증 | NO-GO |
-| G6 Production preflight | 독립 history 감사, backup, 환경·법무·alert 승인 | NO-GO |
+| G5 복구 | Pro 전환 시 DB+Storage 격리 복구와 RTO/RPO 검증 | 보류 (초기 출시 비차단) |
+| G6 Production preflight | 독립 history 감사, 환경·법무·alert·위험 승인 | NO-GO |
 | G7 Rollout | 내부→5%→25%→100% 단계별 Hold 통과 | NO-GO |
 
 ## Web/Vercel 준비
@@ -93,8 +94,8 @@ iOS는 Android 안정화 이후 `TASK-064`에서 진행한다.
 | RLS/RPC | owner/editor/viewer/revoked/outsider 정책 PASS | SQL과 제품 smoke |
 | Realtime | private invalidation과 gap recovery PASS | Supabase report와 client log |
 | Storage | 플랫폼 공통 path, RLS, thumbnail, orphan cleanup scheduler PASS | object manifest, scheduler와 network log |
-| Backup | Managed DB backup과 별도 Storage export | 위치·시각·checksum |
-| Recovery | 격리 프로젝트 복구와 앱 smoke PASS | RTO/RPO 보고서 |
+| Backup | 현재 plan의 제공 범위와 초기 복구 미보장 위험 승인; Pro 전환 시 managed backup 확인 | plan·승인 기록 |
+| Recovery | Pro 전환 시 격리 프로젝트 복구와 앱 smoke PASS | RTO/RPO 보고서 |
 | Capacity | Usage/Realtime/egress 월 예상 70% 미만 | 7일 관측 보고서 |
 
 ## 외부 연동과 운영 관측
@@ -127,7 +128,8 @@ iOS는 Android 안정화 이후 `TASK-064`에서 진행한다.
 
 - Support 문의 접수와 P0/P1 escalation 경로를 정한다.
 - Release manager와 on-call 담당자가 단계별 GO/NO-GO 회의 시간을 정한다.
-- 데이터 incident 발생 시 쓰기 동결, 영향 범위 확인, backup 보호, 사용자 통지 순서를 rehearsal한다.
+- 데이터 incident 발생 시 쓰기 동결, 영향 범위 확인, 사용 가능한 backup 보호와 사용자 통지 순서를
+  rehearsal한다.
 - 월별 비용·quota와 주간 sync 품질 지표 검토 owner를 지정한다.
 - PITR 도입 조건과 legacy 물리 삭제 조건을 별도 Gate로 유지한다.
 
@@ -137,7 +139,7 @@ iOS는 Android 안정화 이후 `TASK-064`에서 진행한다.
 2. 계정 간 cache, row, Realtime, asset이 노출된다.
 3. viewer, revoked, outsider가 허용되지 않은 작업을 수행한다.
 4. migration history drift, 원격 전용 version 미분류 또는 미승인 object 변경이 있다.
-5. DB와 Storage 복구가 같은 기준 시점으로 완료되지 않는다.
+5. Supabase Pro 전환 후 실행한 DB와 Storage 복구가 같은 기준 시점으로 완료되지 않는다.
 6. 미해결 P0/P1 결함이 있다.
 7. Rollback과 on-call 담당자가 지정되지 않았다.
 8. 약관·개인정보·store 필수 항목이 승인되지 않았다.
@@ -145,5 +147,5 @@ iOS는 Android 안정화 이후 `TASK-064`에서 진행한다.
 ## 최종 승인
 
 Release manager, DB operator, QA, Web, Android, Security/Privacy, on-call 담당자가 각 Gate의 증적을
-확인한다. Production migration 실행자와 최종 GO 승인자는 분리한다. 모든 Gate가 GO일 때만 Android
-100% rollout을 승인한다. iOS 승인은 TASK-064에서 별도로 수행한다.
+확인한다. Production migration 실행자와 최종 GO 승인자는 분리한다. 초기 출시 필수 Gate가 GO일
+때만 Android 100% rollout을 승인한다. iOS 승인은 TASK-064에서 별도로 수행한다.

--- a/docs/refactor/README.md
+++ b/docs/refactor/README.md
@@ -60,6 +60,7 @@ TASK-058/059 forward migration을 적용했고 strict fingerprint는 12/12 versi
 정리했다. 사용자 승인 후 Production에도 기존 history를 보존하는 target-only 방식으로
 TASK-058/059를 적용했으며 fingerprint는 183/185다. 초기 Production 범위는 Web·Android다.
 TASK-060의 Web/Web·Web/Android·Android/Android 실제 기기 Gate를 통과해 `G3`는 `GO`다.
-TASK-061의 DEV 7일 관측과 TASK-062의 격리 복구를 병렬 착수했으며, 두 Gate와 TASK-063
-preflight·rollout 전까지 Android Production은 `NO-GO`다. iOS 실기기와 App Store 출시는
-TASK-064로 이관하고 남은 ledger와 nullability 차이는 TASK-063에서 처리한다.
+TASK-061의 DEV 7일 관측을 통과한 뒤 TASK-063 preflight·rollout으로 진행한다. TASK-062의 격리
+복구는 초기 출시 비차단으로 보류하고 Supabase Pro 전환 시 재개한다. 초기 운영 기간에는 DB·Storage
+복구 미보장 위험을 수용한다. iOS 실기기와 App Store 출시는 TASK-064로 이관하고 남은 ledger와
+nullability 차이는 TASK-063에서 처리한다.

--- a/docs/refactor/progress.md
+++ b/docs/refactor/progress.md
@@ -4,6 +4,15 @@
 기준 브랜치: `refactoring/local-first-architecture`  
 현재 목표: **Supabase normalized row authority + account-scoped local cache + durable outbox + Realtime invalidation으로 Web/Mobile 전체 기능을 전환하고 Initial Production gate를 통과한다.**
 
+## 2026-08-05 TASK-062 초기 출시 비차단 전환
+
+- 초기 운영 규모와 비용 우선순위를 재평가해 TASK-062 격리 복구 rehearsal을 보류했다.
+- 초기 Web·Android 출시는 TASK-061 7일 관측 통과 후 TASK-063으로 진행한다.
+- 초기 운영 기간에는 DB·Storage 복구 미보장 위험을 명시적으로 수용한다.
+- Supabase Pro 전환 시 managed DB backup을 실제 복구 원본으로 확인하고 TASK-062를 재개한다.
+- Storage object byte는 DB backup과 별개이므로 Pro 전환 시 자산 중요도와 별도 보관 필요성을
+  재평가한다.
+
 ## 2026-08-01 TASK-060 완료 및 TASK-061/062 착수
 
 - Android 실제 기기에서 Web/Web, Web/Android, Android/Android의 여행·일정·준비물·템플릿·초대,
@@ -12,7 +21,8 @@
 - TASK-060을 `PASS`, 마스터 계획 `G3`를 `GO`로 변경했다.
 - TASK-061 Issue #382와 TASK-062 Issue #383을 등록했다.
 - 7일 일별 증적·임계치 validator와 DEV→Recovery checksum/digest 비교 도구를 준비한다.
-- `G4` 7일 관측과 `G5` 격리 복구가 남아 Web·Android Production은 `NO-GO`다.
+- `G4` 7일 관측과 `G6` Production preflight가 남아 Web·Android Production은 `NO-GO`다. `G5`는
+  2026-08-05 결정으로 초기 출시 비차단 보류 상태다.
 
 ## 2026-07-29 Android 우선 출시 결정
 

--- a/docs/refactor/reports/TASK-056-production-go-no-go.md
+++ b/docs/refactor/reports/TASK-056-production-go-no-go.md
@@ -1,6 +1,7 @@
 # TASK-056 Production 출시 판정
 
 - 평가일: 2026-07-23
+- 복구 Gate 범위 결정: 2026-08-05
 - 코드 Gate: **PASS**
 - DEV 배포 Gate: **NO-GO**
 - Production 배포 Gate: **NO-GO**
@@ -9,9 +10,9 @@
 
 ## 결론
 
-코드와 로컬 자동화는 통과했다. 원격 객체·migration history 정합화, 실기기 통합 테스트, 7일 관측,
-DB와 Storage 복구, Production preflight 증적이 없으므로 출시할 수 없다. TASK-058~063을 실행해
-TASK-057의 `G0`~`G7`을 모두 통과해야 Production Gate를 GO로 변경한다.
+코드와 로컬 자동화는 통과했다. 원격 객체·migration history 정합화, 실기기 통합 테스트, 7일 관측과
+Production preflight 증적이 없으므로 출시할 수 없다. 초기 출시 필수 Gate인 `G0`~`G4`, `G6`,
+`G7`을 통과해야 Production Gate를 GO로 변경한다. `G5` 복구는 초기 출시 비차단으로 보류한다.
 
 ## 통과한 근거
 
@@ -34,8 +35,8 @@ TASK-057의 `G0`~`G7`을 모두 통과해야 Production Gate를 GO로 변경한�
 | B-03 | 초대·권한·계정·템플릿·asset P0 자동화 공백 보완 | TASK-058 로컬 PASS, PR CI 증적 대기 | [통합 테스트 케이스](../test-plans/TASK-057-production-integration-test-cases.md#자동화-테스트-목록) |
 | B-04 | Web/Android·Android/Android 실기기 매트릭스 | TASK-060 PASS, G3 GO | release SHA마다 핵심 smoke 유지 |
 | B-05 | DEV 7일 운영 지표 | 미실행 | TASK-057 Runbook 5단계 |
-| B-06 | DB와 `place-photos` Storage 복구 rehearsal | 미실행 | TASK-057 Runbook 6단계 |
-| B-07 | Production 원격 전용 history·실제 schema drift 독립 감사와 backup | 미실행 | TASK-057 Runbook 7단계 |
+| B-06 | DB와 `place-photos` Storage 복구 rehearsal | 초기 출시 비차단 보류, Pro 전환 시 재개 | TASK-062 Runbook |
+| B-07 | Production 원격 전용 history·실제 schema drift 독립 감사 | 미실행 | TASK-057 Runbook 7단계 |
 | B-08 | 최소 Mobile 버전, rollout, on-call 책임자 | 미지정 | [마스터 계획](TASK-057-production-final-validation-plan.md#역할과-책임) |
 | B-09 | 환경변수·OAuth·이메일·push·법무·alert 운영 준비 | 미완료 | TASK-057 Runbook 7단계 |
 | B-10 | 내부→5%→25%→100% 단계적 rollout | 미실행 | TASK-057 Runbook 8단계 |
@@ -46,7 +47,8 @@ TASK-057의 `G0`~`G7`을 모두 통과해야 Production Gate를 GO로 변경한�
 - 각 항목에는 실행자, 검토자, 시각, project ref, release SHA, 원시 결과 링크가 필요하다.
 - SQL Editor로 직접 실행된 migration은 객체 적용과 history 등록을 별도로 판정한다.
 - TASK-055/056은 양쪽 환경에 핵심 적용 결과가 있으므로 원본 SQL을 다시 실행하지 않는다.
-- 데이터 손실, 계정 간 노출, 권한 우회, duplicate canonical row, 복구 실패는 한 건도 허용하지 않는다.
+- 데이터 손실, 계정 간 노출, 권한 우회와 duplicate canonical row는 한 건도 허용하지 않는다.
+- Pro 전환 후 TASK-062를 실행했을 때 복구가 실패하면 해당 운영 강화 Gate는 NO-GO다.
 - 필수 자동 테스트와 수동 P0/P1은 100% PASS여야 한다.
 - DEV 7일 관측에서 임계치를 넘으면 수정 release로 기간을 다시 시작한다.
 - Legacy 삭제는 Production GO와 별개이며 별도 destructive migration과 승인이 필요하다.

--- a/docs/refactor/reports/TASK-057-production-final-validation-plan.md
+++ b/docs/refactor/reports/TASK-057-production-final-validation-plan.md
@@ -3,15 +3,17 @@
 ## 결론
 
 현재 OnVoy는 **코드 게이트 PASS, Web·Android Production 운영 게이트 NO-GO**다. Android
-Production GO는 코드 병합이 아니라 `G0`~`G7`의 증적 완료로 판정한다. 데이터 손실, 계정 간 노출,
-권한 우회, 복구 실패 중 하나라도 발생하면 즉시 NO-GO를 유지한다.
+Production GO는 코드 병합이 아니라 초기 출시 필수 Gate인 `G0`~`G4`, `G6`, `G7`의 증적으로
+판정한다. 데이터 손실, 계정 간 노출 또는 권한 우회가 발생하면 즉시 NO-GO를 유지한다. `G5` 복구
+rehearsal은 초기 출시 비차단으로 보류하고 Supabase Pro 전환 시 재개한다.
 
 ## 초기 출시 플랫폼 결정
 
 - 초기 Production 지원 범위는 Web과 Android다.
 - iOS 실기기, TestFlight/App Store, iOS OAuth·push·lifecycle 검증은 `TASK-064`로 이관한다.
 - iOS typecheck, Expo export와 simulator launch는 공유 코드 파손을 막는 비차단 회귀 Gate로 유지한다.
-- `G0`~`G7`과 100% rollout은 Android 지원 대상만 의미하며 iOS 지원 또는 출시 완료를 의미하지 않는다.
+- Gate 번호와 100% rollout은 Android 지원 대상만 의미하며 iOS 지원 또는 출시 완료를 의미하지
+  않는다. 초기 출시에 `G5`는 요구하지 않는다.
 
 ## 목차
 
@@ -37,8 +39,8 @@ Production GO는 코드 병합이 아니라 `G0`~`G7`의 증적 완료로 판정
 | Web·Android 실기기 | GO | TASK-060 실제 기기 Gate PASS, PR #381 회귀 재검증 | release SHA마다 핵심 smoke 유지 |
 | iOS | 후속 출시 | simulator build·launch PREPASS | TASK-064에서 실기기·스토어 검증 |
 | 운영 관측 | NO-GO | 7일 지표 없음 | 임계치 기반 관찰 |
-| 복구 | NO-GO | DB+Storage 동시 복구 증적 없음 | 격리 프로젝트 rehearsal |
-| Production preflight | NO-GO | history·backup·책임자 미확정 | 독립 감사와 승인 |
+| 복구 | 보류 | 초기 운영 기간 복구 미보장 위험 수용 | Supabase Pro 전환 시 격리 프로젝트 rehearsal |
+| Production preflight | NO-GO | history·운영 설정·책임자 미확정 | 독립 감사와 승인 |
 
 ## Gate 흐름
 
@@ -48,14 +50,14 @@ flowchart TD
     G1 --> G2["G2 DEV schema/history 정합화"]
     G2 --> G3["G3 DEV Web·Android 실기기 PASS"]
     G3 --> G4["G4 7일 관측 PASS"]
-    G4 --> G5["G5 DB+Storage 복구 PASS"]
-    G5 --> G6["G6 Production preflight GO"]
+    G4 --> G6["G6 Production preflight GO"]
     G6 --> G7["G7 단계적 출시 완료"]
+    G7 -. "Supabase Pro 전환" .-> G5["G5 DB+Storage 복구 PASS"]
     G1 -. "실패" .-> NOGO["NO-GO / 결함 수정"]
     G2 -. "실패" .-> NOGO
     G3 -. "실패" .-> NOGO
     G4 -. "임계치 초과" .-> NOGO
-    G5 -. "복구 불일치" .-> NOGO
+    G5 -. "Pro 전환 후 복구 불일치" .-> NOGO
     G6 -. "승인 누락" .-> NOGO
     G7 --> I64["TASK-064 iOS 별도 검증·출시"]
 ```
@@ -69,8 +71,8 @@ flowchart TD
 | B-03 (완료) | 제품 E2E 자동화 공백 | TASK-058과 Production P0 23건 PASS | CI URL과 리포트 | G1 |
 | B-04 (완료) | Android 실기기·플랫폼 조합 | TASK-060에서 Web/Web, Web/Android, Android/Android P0/P1 PASS | Android 기기/OS/build와 사용자 확인 기록 | G3 |
 | B-05 | 7일 운영 지표 없음 | 연속 7일 동안 임계치와 무사고 기준 충족 | GA4/Firebase/Supabase 대시보드 export | G4 |
-| B-06 | DB+Storage 복구 미검증 | 격리 프로젝트에서 동일 기준 시점 데이터와 object 복구 검증 | dump/checksum, object manifest, row count, RTO/RPO | G5 |
-| B-07 | Production history·schema drift·backup 미확정 | 원격 전용 version 4건과 `public` schema 차이 분류·승인, ledger 정합화, pre-deploy DB/Storage backup 완료 | 독립 감사 기록, schema diff, backup 위치·checksum | G6 |
+| B-06 (보류) | DB+Storage 복구 미검증 | Supabase Pro 전환 시 managed DB backup과 Storage 정책을 확정하고 격리 복구 검증 | backup 상태, object 정책, digest, RTO/RPO | G5 (초기 출시 비차단) |
+| B-07 | Production history·schema drift 미확정 | 원격 전용 version 4건과 `public` schema 차이 분류·승인, ledger 정합화 | 독립 감사 기록, schema diff | G6 |
 | B-08 | Android 최소 버전·출시 책임 미확정 | Android 최소 지원 버전과 강제 업데이트 정책, 배포·on-call 담당자 승인 | release ticket, 연락망, Google Play 설정 | G6 |
 | B-09 | 제품 운영 준비 미확정 | Web·Android 환경변수, OAuth, 이메일, Android push, 도메인, 약관·개인정보, alert test PASS | 설정 inventory와 각 검증 링크 | G6 |
 | B-10 | Android 단계적 rollout 미실행 | 내부→5%→25%→100% 각 hold 구간 통과 | 단계별 지표와 GO 승인 | G7 |
@@ -87,8 +89,8 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 | `TASK-059` | DEV 객체 fingerprint와 migration history 정합화 | B-01, B-02 | TASK-058 |
 | `TASK-060` | Web·Android 실기기·다중 계정·asset 검증 | B-04, B-11의 실환경 검증 부분 | TASK-059 |
 | `TASK-061` | Web·Android DEV 7일 안정성·비용 관측 | B-05 | TASK-060 |
-| `TASK-062` | DB+Storage 복구와 Web·Android smoke | B-06 | TASK-060 |
-| `TASK-063` | Web·Android Production preflight와 단계적 출시 | B-07~B-10, B-11 운영 설정 | TASK-061, TASK-062 |
+| `TASK-062` | Pro 전환 시 DB+Storage 복구와 Web·Android smoke | B-06 | Supabase Pro 전환 |
+| `TASK-063` | Web·Android Production preflight와 단계적 출시 | B-07~B-10, B-11 운영 설정 | TASK-061 |
 | `TASK-064` | iOS 실기기·TestFlight/App Store 검증과 출시 | iOS 지원 선언에 필요한 별도 Gate | TASK-063 |
 
 ## 단계별 실행 계획
@@ -137,12 +139,14 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 - 데이터 손실, 계정 간 노출, 권한 우회, 중복 row incident는 허용하지 않는다.
 - 임계치 초과는 원인과 재검증 기간을 새로 시작한다.
 
-### G5. 복구 Gate
+### G5. 복구 Gate (초기 출시 비차단)
 
-- DEV와 분리된 복구 프로젝트를 사용한다.
-- 같은 release 시점의 DB dump와 `place-photos` object export를 복구한다.
-- row count, membership, revision, operation receipt, asset metadata와 object manifest를 비교한다.
-- Web과 Android가 복구 프로젝트에서 핵심 여행을 읽고 수정할 수 있는지 확인한다.
+- 초기 Web·Android 출시에서는 실행하지 않고 DB·Storage 복구 미보장 위험을 수용한다.
+- Supabase Pro 전환 시 managed DB backup을 실제 복구 원본으로 확인하고 DEV/Production과 분리된
+  Recovery 프로젝트에서 실행한다.
+- 같은 기준 시점의 DB와 `place-photos` object를 복구하고 row count, membership, revision,
+  operation receipt, asset metadata와 object manifest를 비교한다.
+- Storage object byte는 DB backup에 포함되지 않으므로 Pro 전환 시 별도 보관 필요성을 결정한다.
 
 ### G6. Production Preflight
 
@@ -151,7 +155,7 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
   `20260427023948`의 출처와 객체를 보존·분류한다.
 - Production 전용 `public` 객체와 DEV 전용 객체가 의도된 차이인지 migration 누락인지 판정한다.
 - migration dry-run이 승인 대상만 표시되는지 확인한다.
-- DB와 Storage backup을 생성하고 checksum과 보관 위치를 기록한다.
+- 현재 Supabase plan과 backup 제공 범위, 초기 복구 미보장 위험의 승인자를 기록한다.
 - Web·Android release SHA, 환경변수, OAuth redirect, 이메일, Android push, 약관·개인정보 URL을
   검증한다.
 - asset cleanup scheduler와 `ASSET_CLEANUP_SECRET`을 설정하고 실패 alert를 시험한다.
@@ -171,7 +175,7 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 | 역할 | 주요 책임 | 승인 대상 |
 |---|---|---|
 | Release manager | 일정, Gate 상태, 최종 GO/NO-GO 회의 | G0, G6, G7 |
-| DB operator | fingerprint, repair, migration, backup, restore | G2, G5, G6 |
+| DB operator | fingerprint, repair, migration, plan/backup 범위 확인 | G2, G6, Pro 전환 후 G5 |
 | Web 담당 | Web build, 브라우저 E2E, Vercel·OAuth | G1, G3, G6 |
 | Android 담당 | Android build, 설치, Logcat, Google Play rollout | G1, G3, G6, G7 |
 | iOS 담당 | 공통 변경의 typecheck/export/simulator 회귀, TASK-064 준비 | G1, TASK-064 |
@@ -189,7 +193,7 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 - 계정 간 cache·row·asset 노출
 - owner/editor/viewer/revoked 권한 우회
 - duplicate operation으로 canonical row 중복 생성
-- DB 또는 Storage 복구 불일치
+- Pro 전환 후 실행한 DB 또는 Storage 복구의 불일치
 - migration history drift 또는 미승인 migration 발견
 - 미해결 P0/P1 결함
 
@@ -215,8 +219,8 @@ TASK-057은 검증 기준과 실행 절차를 확정하는 문서 작업이다. 
 | DEV schema/history | 1영업일 | migration ledger 증적 |
 | Android 실기기 통합 테스트 | 2~3영업일 | 케이스별 증적, 결함 목록 |
 | DEV 관측 | 연속 7일 | 일별 지표와 최종 요약 |
-| 복구 rehearsal | 1~2영업일 | RTO/RPO와 정합성 보고서 |
-| Production preflight | 1영업일 | 최종 승인서와 backup 증적 |
+| 복구 rehearsal | Supabase Pro 전환 시 1~2영업일 | RTO/RPO와 정합성 보고서 |
+| Production preflight | 1영업일 | 최종 승인서와 plan·복구 위험 승인 기록 |
 | Web·Android 단계적 rollout | 최소 4영업일 | 단계별 GO 기록 |
 | iOS 검증·rollout | TASK-063 이후 별도 산정 | TASK-064 증적과 GO 기록 |
 

--- a/docs/refactor/reports/TASK-060-cross-platform-device-validation.md
+++ b/docs/refactor/reports/TASK-060-cross-platform-device-validation.md
@@ -9,7 +9,8 @@
 Android 시뮬레이터 사전 검증과 실제 기기 Gate를 모두 통과했다. Web/Web, Web/Android,
 Android/Android에서 여행·일정·준비물·템플릿·초대·권한·asset과 offline/reconnect 결과가 동일한
 canonical 데이터로 수렴했다. TASK-060과 `G3`는 완료한다. iOS는 초기 출시 범위에서 제외하며,
-Android Production은 7일 관측, 복구 rehearsal과 Production preflight가 남아 `NO-GO`다.
+Android Production은 7일 관측과 Production preflight가 남아 `NO-GO`다. 복구 rehearsal은
+2026-08-05 결정으로 초기 출시 비차단 보류 상태다.
 
 ## 출시 범위 결정
 
@@ -76,4 +77,5 @@ Android Production은 7일 관측, 복구 rehearsal과 Production preflight가 �
 
 Android 실기기 필수 조합과 P0/P1 수동 케이스를 통과했고 데이터 손실, 계정 노출, 권한 우회,
 canonical 중복이 보고되지 않았다. TASK-060과 `G3`를 `GO`로 종료한다. 다음 Gate는 TASK-061의 DEV
-7일 관측과 TASK-062의 격리 복구 rehearsal이며 두 작업은 병렬 수행한다.
+7일 관측이다. 통과 후 TASK-063 Production preflight로 진행한다. TASK-062는 Supabase Pro 전환 시
+재개한다.

--- a/docs/refactor/reports/TASK-062-disaster-recovery-rehearsal.md
+++ b/docs/refactor/reports/TASK-062-disaster-recovery-rehearsal.md
@@ -1,10 +1,10 @@
 # TASK-062 DB·Storage 복구 Rehearsal 보고서
 
-작성일: 2026-08-01
+작성일: 2026-08-05
 
 Source: DEV `ivgkqzwosbjukonlpfdw`
 
-상태: **IN-PROGRESS / Recovery project 대기**
+상태: **DEFERRED / 초기 출시 비차단**
 
 ## 준비 결과
 
@@ -13,8 +13,16 @@ Source: DEV `ivgkqzwosbjukonlpfdw`
 - backup 파일 checksum manifest와 원본·복구 canonical table/Storage digest 비교 도구를 추가했다.
 - capture 결과에는 count와 SHA-256만 남고 raw row, object path와 credential은 남지 않는다.
 
-## 차단 항목
+## 범위 재결정
 
-2026-08-01 `supabase projects list` 읽기 전용 확인 결과 계정에는 DEV와 Production만 있고 별도
-Recovery 프로젝트는 없다. Recovery Supabase project ref, 백업 접근 권한과 복구 operator 확인이
-필요하다. 격리 복원과 Web·Android smoke, RTO/RPO 측정 전까지 `G5`는 `NO-GO`다.
+2026-08-01 확인 당시 계정에는 DEV와 Production만 있고 별도 Recovery 프로젝트는 없었다. 2026-08-05
+초기 운영 규모와 비용 우선순위를 재평가해 Recovery 프로젝트를 지금 추가하지 않기로 결정했다.
+
+- `G5`와 `B-06`은 초기 Web·Android 출시 비차단·보류로 변경한다.
+- 초기 운영 기간의 DB·Storage 복구 미보장 위험을 수용한다.
+- Supabase Pro 전환 시 managed DB backup 상태를 확인하고 Recovery 프로젝트를 만든 뒤 본 보고서를
+  다시 연다.
+- Storage object byte의 별도 백업 여부는 Pro 전환 시 자산 중요도에 따라 결정한다.
+
+준비된 digest 도구와 Runbook은 후속 rehearsal에 재사용한다. 이 보류 결정은 `TASK-061`과
+`TASK-063`의 안정성, 권한, migration, 외부 연동 및 단계적 rollout Gate를 완화하지 않는다.

--- a/docs/refactor/runbooks/TASK-056-production-rollout-and-recovery.md
+++ b/docs/refactor/runbooks/TASK-056-production-rollout-and-recovery.md
@@ -43,7 +43,10 @@ supabase db push --linked --dry-run
 migration으로 목표 상태를 만든 뒤 원래 version의 history 처리 근거를 승인받는다. Production history는
 DEV 결과를 추정하지 않고 독립적으로 감사한다.
 
-## 배포 전 Backup
+## Pro 전환 후 Backup
+
+초기 Web·Android 출시에서는 아래 절차를 필수 Gate로 사용하지 않는다. 초기 운영 기간의 복구
+미보장 위험을 수용하고, Supabase Pro 전환 시 managed DB backup과 Storage 정책을 확인한 뒤 적용한다.
 
 1. Release SHA, project ref, migration list, active client version을 기록한다.
 2. Supabase managed DB backup 또는 snapshot을 생성한다.
@@ -74,8 +77,8 @@ find "backup/$PROJECT_REF/$RELEASE_SHA" -type f ! -name SHA256SUMS \
 3. TASK-055/056 원본 SQL을 다시 실행하지 않고 Local 전체 SQL/E2E와 DEV authenticated smoke를 실행한다.
 4. Web과 내부 Mobile build에서 Web/Web, Web/Mobile, Mobile/Mobile 테스트를 실행한다.
 5. DEV에서 연속 7일 동안 데이터·권한 incident 없이 지표 임계치를 통과한다.
-6. Recovery project에서 DB와 Storage를 함께 복구한다.
-7. Production 원격 전용 history 4건과 실제 schema drift 감사, pre-deploy backup을 완료한다.
+6. Production 원격 전용 history 4건과 실제 schema drift 감사를 완료한다.
+7. 현재 plan의 backup 제공 범위와 초기 복구 미보장 위험 승인 기록을 확인한다.
 8. Web, Mobile 내부, 5%, 25%, 100% 순서로 확대한다.
 
 Local SQL smoke와 service-role Playwright를 DEV나 Production에 직접 실행하지 않는다. 원격 검증은 전용
@@ -105,9 +108,10 @@ authenticated 계정과 `QA-` fixture를 사용하는 안전한 smoke로 수행�
 3. TASK-055에서 legacy runtime을 제거했으므로 retired feature flag를 롤백 수단으로 사용하지 않는다.
 4. `20260723000002` 동작을 되돌려야 하면 `20260717000001`의 이전 wrapper function 정의를 복원한다.
 5. 이미 commit된 canonical row는 삭제하거나 역변환하지 않는다.
-6. 데이터 손상은 별도 Recovery project에서 DB를 복구하고 검증한 뒤 cutover를 결정한다.
-7. 같은 기준 시점의 `place-photos` object를 복구하고 asset metadata와 manifest를 비교한다.
-8. 권한, duplicate, revision, asset, invitation 테스트를 다시 통과한 후에만 쓰기를 재개한다.
+6. Pro 전환 후 검증된 backup이 있다면 별도 Recovery project에서 복구하고 cutover를 결정한다.
+7. 같은 기준 시점의 `place-photos` backup이 있는 경우 asset metadata와 manifest를 비교한다.
+8. 초기 백업 미보장 기간에는 복구를 약속하지 않고 쓰기 중단, 영향 범위와 잔존 데이터 확인을 우선한다.
+9. 권한, duplicate, revision, asset, invitation 테스트를 다시 통과한 후에만 쓰기를 재개한다.
 
 외부 MAU 100명, 유료 사용 시작, 월 canonical mutation 50,000건, 허용 RPO 24시간 미만 중 하나가
 충족되면 PITR을 필수로 전환한다.

--- a/docs/refactor/runbooks/TASK-057-production-validation-runbook.md
+++ b/docs/refactor/runbooks/TASK-057-production-validation-runbook.md
@@ -17,7 +17,7 @@
 - [3단계: DEV history 정합화와 원격 안전 검증](#3단계-dev-history-정합화와-원격-안전-검증)
 - [4단계: Web·Android 실기기 통합 테스트](#4단계-webandroid-실기기-통합-테스트)
 - [5단계: 7일 관측](#5단계-7일-관측)
-- [6단계: DB와 Storage 복구 Rehearsal](#6단계-db와-storage-복구-rehearsal)
+- [6단계: DB와 Storage 복구 Rehearsal (보류)](#6단계-db와-storage-복구-rehearsal-보류)
 - [7단계: Production Preflight](#7단계-production-preflight)
 - [8단계: 단계적 출시](#8단계-단계적-출시)
 - [중단과 롤백](#중단과-롤백)
@@ -29,7 +29,7 @@
 |---|---|---|
 | DEV | `ivgkqzwosbjukonlpfdw` | migration, 실기기 테스트, 7일 관측 |
 | Production | `runbcaegpefqnljsswhv` | 승인된 migration과 단계적 출시 |
-| Recovery | 실행 시 기록 | DB+Storage 복구 rehearsal 전용 |
+| Recovery | Supabase Pro 전환 시 기록 | DB+Storage 복구 rehearsal 전용 |
 
 ## 안전 원칙
 
@@ -302,7 +302,11 @@ curl --fail-with-body --silent --show-error \
 임계치가 초과되거나 P0 incident가 발생하면 관측 기간을 중단한다. 수정 release로 G1부터 다시 시작하고
 7일 기간도 처음부터 다시 계산한다.
 
-## 6단계: DB와 Storage 복구 Rehearsal
+## 6단계: DB와 Storage 복구 Rehearsal (보류)
+
+초기 Web·Android 출시에서는 실행하지 않는다. 초기 운영 기간의 DB·Storage 복구 미보장 위험을
+승인 기록에 남기고, Supabase Pro 전환 시 managed DB backup을 실제 복구 원본으로 확인한 뒤 아래
+절차를 수행한다.
 
 ### 6.1 백업
 
@@ -364,7 +368,7 @@ where bucket_id = 'place-photos';
    schema 차이가 의도된 운영 차이인지 누락된 migration인지 판정한다.
 5. 원격 전용 version을 삭제하거나 local version 전체를 일괄 repair하지 않는다.
 6. 승인된 정합화 이후 `db push --dry-run` 결과를 release ticket에 저장한다.
-7. managed DB backup, logical export, Storage manifest/object export를 만든다.
+7. 현재 Supabase plan과 backup 제공 범위, 초기 복구 미보장 위험의 승인자를 기록한다.
 8. Web·Android env, OAuth redirect, 이메일 발신, Android push, Maps, analytics, alert를 검증한다.
 9. `ASSET_CLEANUP_SECRET`을 secret store에 등록하고 scheduler의 인증 header, 주기, timeout, 실패 alert를 검증한다.
 10. 약관·개인정보 처리방침 URL과 Google Play privacy/data safety 정보를 검토한다.
@@ -394,7 +398,7 @@ TASK-064에서 별도 실행한다.
 - 데이터 손실·변질 또는 duplicate canonical row
 - 계정 간 데이터/asset 노출
 - viewer/revoked/outsider 권한 우회
-- migration drift, DB corruption, 복구 실패
+- migration drift, DB corruption, Pro 전환 후 검증된 복구 절차의 실패
 - crash loop, retry storm, 인증 전면 장애
 
 ### 절차
@@ -405,7 +409,9 @@ TASK-064에서 별도 실행한다.
 4. Mobile은 store rollout을 중단하고 최소 버전/강제 업데이트 정책으로 안정 build를 유지한다.
 5. TASK-056 wrapper 문제라면 `20260717000001`의 이전 function 정의를 복원한다.
 6. committed canonical row를 임의 삭제하거나 legacy runtime을 다시 활성화하지 않는다.
-7. 데이터 손상 시 원본 Production에 덮어쓰지 않고 Recovery project에서 복구·검증한 뒤 cutover를 결정한다.
+7. 사용 가능한 검증된 backup이 있다면 원본 Production에 덮어쓰지 않고 Recovery project에서
+   복구·검증한 뒤 cutover를 결정한다. 초기 백업 미보장 기간에는 쓰기를 중단하고 잔존 데이터와
+   영향 범위를 우선 확인하며 복구 가능성을 보장하지 않는다.
 8. P0 incident review와 G1~영향 Gate 재실행 전에는 rollout을 재개하지 않는다.
 
 ## 증적 템플릿
@@ -426,7 +432,7 @@ TASK-064에서 별도 실행한다.
 ## 선행 조건
 - [ ] 이전 Gate PASS
 - [ ] project ref 교차 확인
-- [ ] backup 또는 cleanup 준비
+- [ ] backup 제공 범위·위험 승인 또는 cleanup 준비
 
 ## 실행 내용
 1.

--- a/docs/refactor/runbooks/TASK-062-disaster-recovery-rehearsal.md
+++ b/docs/refactor/runbooks/TASK-062-disaster-recovery-rehearsal.md
@@ -1,5 +1,14 @@
 # TASK-062 DB·Storage 복구 Rehearsal Runbook
 
+## 실행 상태
+
+초기 Web·Android 출시에 대해서는 **DEFERRED**다. 지금 Recovery 프로젝트를 만들거나 아래 복원 절차를
+실행하지 않는다. Supabase Pro 전환 시 managed DB backup을 실제 복구 원본으로 확인하고, Storage
+object byte의 별도 보관 정책을 결정한 뒤 본 Runbook을 다시 사용한다.
+
+초기 운영 기간에는 DB·Storage 복구가 보장되지 않는 위험을 명시적으로 수용한다. 로컬 IndexedDB와
+SQLite cache/outbox는 공식 복구 원본으로 간주하지 않는다.
+
 ## 목적과 중단 조건
 
 DEV `ivgkqzwosbjukonlpfdw`의 DB와 `place-photos`를 별도 Supabase Recovery 프로젝트에 복원한다.

--- a/docs/refactor/tasks/README.md
+++ b/docs/refactor/tasks/README.md
@@ -130,7 +130,7 @@ TASK-008a-web-checklist-read-through-hydration.md
 | `TASK-059-dev-migration-production-gate.md` | 완료 | DEV drift 0·authenticated smoke PASS, Production TASK-058/059 target-only 적용 |
 | `TASK-060-cross-platform-device-validation.md` | 완료 (G3 GO) | Web·Android 실기기 Gate, iOS는 TASK-064로 이관 |
 | `TASK-061-dev-stability-cost-soak.md` | 진행 중 | Web·Android DEV 연속 7일 안정성·비용 관측, Issue #382 |
-| `TASK-062-disaster-recovery-rehearsal.md` | 진행 중 | DB·Storage 복구와 Web·Android smoke, Issue #383 |
+| `TASK-062-disaster-recovery-rehearsal.md` | 보류 (초기 출시 비차단) | Supabase Pro 전환 시 DB·Storage 복구와 Web·Android smoke, Issue #383 |
 | `TASK-063-production-preflight-and-rollout.md` | 대기 | Web·Android Production 사전 점검과 단계적 출시 |
 | `TASK-064-ios-production-validation-and-rollout.md` | 보류 | Android 안정화 후 iOS 실기기·TestFlight/App Store 검증·출시 |
 | `TASK-065-app-brand-assets.md` | 구현 완료 | 온여정 앱 아이콘·스플래시·Android/Play Store 브랜드 자산, Issue [#387](https://github.com/ysjee141/nexvoy-frontend/issues/387) |
@@ -239,7 +239,7 @@ rotating room secret 보안 하드닝을 완료했다.
 - [x] `TASK-059-dev-migration-production-gate.md`: DEV 전체 Gate와 Production TASK-058/059 target-only 적용 완료
 - [x] `TASK-060-cross-platform-device-validation.md`: Web·Android 실기기 통합 검증
 - [ ] `TASK-061-dev-stability-cost-soak.md`: Web·Android DEV 안정성·비용 7일 관측
-- [ ] `TASK-062-disaster-recovery-rehearsal.md`: DB·Storage 복구와 Web·Android smoke
+- [ ] `TASK-062-disaster-recovery-rehearsal.md`: Supabase Pro 전환 시 DB·Storage 복구와 Web·Android smoke (초기 출시 비차단)
 - [ ] `TASK-063-production-preflight-and-rollout.md`: Web·Android Production 사전 점검과 단계적 출시
 
 ### Phase 11: iOS Production Validation (Deferred)
@@ -272,9 +272,8 @@ flowchart TD
     T58 --> T59["TASK-059 DEV schema/history"]
     T59 --> T60["TASK-060 Web·Android 실기기"]
     T60 --> T61["TASK-061 Web·Android 7일 관측"]
-    T60 --> T62["TASK-062 복구+Web·Android smoke"]
     T61 --> T63["TASK-063 Web·Android Production"]
-    T62 --> T63
+    T63 -. "Supabase Pro 전환" .-> T62["TASK-062 복구+Web·Android smoke"]
     T63 --> T64["TASK-064 iOS 검증·출시"]
 ```
 
@@ -286,6 +285,7 @@ flowchart TD
 6. `TASK-056`에서 Initial Production go/no-go를 판정한다.
 7. `TASK-057`에서 최종 검증 기준과 Runbook을 확정한다.
 8. `TASK-058`~`TASK-060`에서 자동화, DEV schema/history, Web·Android 실기기 Gate를 통과한다.
-9. `TASK-060`과 `G3`는 2026-08-01 실제 Android 기기 Gate로 완료했다. `TASK-061` 관측과
-   `TASK-062` 복구를 병렬 완료한 뒤 `TASK-063`에서 Web·Android 출시를 승인한다.
+9. `TASK-060`과 `G3`는 2026-08-01 실제 Android 기기 Gate로 완료했다. `TASK-061` 관측을 완료한 뒤
+   `TASK-063`에서 Web·Android 출시를 승인한다. `TASK-062` 복구는 초기 출시 비차단으로 보류하고
+   Supabase Pro 전환 시 재개한다.
 10. Android 안정화 이후 `TASK-064`에서 iOS 실기기와 App Store 출시를 별도 승인한다.

--- a/docs/refactor/tasks/TASK-056-production-data-integrity-and-cost-gate.md
+++ b/docs/refactor/tasks/TASK-056-production-data-integrity-and-cost-gate.md
@@ -51,7 +51,7 @@
 7. 계정 A/B 전환에서 local cache와 outbox가 혼합되지 않는다.
 8. 여행·일정·준비물·템플릿 삭제와 tombstone 정리가 다른 기기에 반영된다.
 9. asset upload/download/orphan cleanup이 권한과 CDN 정책을 지킨다.
-10. DB backup/export에서 canonical row를 복구하는 rehearsal을 수행한다.
+10. Supabase Pro 전환 시 DB backup/export에서 canonical row를 복구하는 rehearsal을 수행한다.
 
 ## Initial 품질 및 비용 기준
 
@@ -87,7 +87,8 @@
 
 - 쓰기를 동결하고 이전 안정 authority-only release로 client를 롤백한다.
 - destructive DB migration 전에는 revoke-only object를 복구한다.
-- Production 데이터는 managed backup/off-site export와 migration rollback script로 복구한다.
+- 초기 운영 기간에는 DB·Storage 복구 미보장 위험을 수용한다.
+- Supabase Pro 전환 이후 Production 데이터는 managed backup과 승인된 Storage 정책으로 복구한다.
 
 ## 완료 조건
 
@@ -110,6 +111,7 @@
 - Production rollout/recovery runbook, Initial 비용 baseline, go/no 판정서를 작성했다.
 
 자동화 가능한 코드 gate는 PASS다. TASK-055/056 핵심 객체는 DEV와 Production에서 확인됐지만
-migration history와 전체 schema fingerprint, 실기기 matrix, 7일 지표, DB+Storage restore rehearsal은
-운영 증적이 없으므로 DEV와 Production은 NO-GO로 유지한다. Legacy object 물리 삭제도 별도 destructive
+migration history와 전체 schema fingerprint, 실기기 matrix와 7일 지표는 운영 증적이 없으므로 DEV와
+Production은 NO-GO로 유지한다. DB+Storage restore rehearsal은 초기 출시 비차단으로 보류한다.
+Legacy object 물리 삭제도 별도 destructive
 migration 승인 전까지 유예한다.

--- a/docs/refactor/tasks/TASK-057-production-final-validation.md
+++ b/docs/refactor/tasks/TASK-057-production-final-validation.md
@@ -9,8 +9,9 @@
 
 TASK-057은 TASK-056의 코드 게이트 이후 필요한 검증 기준, 테스트 케이스, 실행 Runbook을 확정한다.
 현재 상태는 **Production NO-GO**다. 실제 검증과 출시는 `TASK-058`~`TASK-063`에서 단계적으로 수행하며,
-원격 객체와 migration history 정합화, 실기기 통합 테스트, 7일 관측, DB와 Storage 복구, 출시 책임자
-지정이 모두 끝나야 GO로 전환한다.
+원격 객체와 migration history 정합화, 실기기 통합 테스트, 7일 관측과 출시 책임자 지정이 끝나야
+GO로 전환한다. DB와 Storage 복구 rehearsal은 초기 출시 비차단으로 보류하고 Supabase Pro 전환 시
+재개한다.
 
 ## 산출물
 
@@ -28,7 +29,7 @@ TASK-057은 TASK-056의 코드 게이트 이후 필요한 검증 기준, 테스�
 - offline, 강제 종료, reconnect, Realtime 유실, 충돌, revoke 검증
 - DEV 객체 fingerprint와 migration history 정합화
 - 7일 운영 지표 관찰과 비용 기준 확인
-- DB와 `place-photos` Storage의 분리 백업·복구 rehearsal
+- Supabase Pro 전환 시 DB와 `place-photos` Storage의 분리 백업·복구 rehearsal
 - Production preflight, canary, 단계적 확대, 중단과 롤백
 
 ## 제외 범위
@@ -44,15 +45,16 @@ TASK-057은 TASK-056의 코드 게이트 이후 필요한 검증 기준, 테스�
 2. `TASK-059`에서 DEV schema fingerprint와 migration history를 정합화한다.
 3. `TASK-060`에서 원격 안전 smoke와 전체 실기기 매트릭스를 실행한다.
 4. `TASK-061`에서 7일 안정성·비용 지표를 수집한다.
-5. `TASK-062`에서 DB+Storage 복구 rehearsal을 통과한다.
-6. `TASK-063`에서 Production preflight와 내부·5%·25%·100% 출시를 수행한다.
+5. `TASK-063`에서 Production preflight와 내부·5%·25%·100% 출시를 수행한다.
+6. Supabase Pro 전환 시 `TASK-062`의 DB+Storage 복구 rehearsal을 수행한다.
 
 ## 완료 조건
 
 - 마스터 계획, 통합 테스트 명세, Runbook이 서로 같은 Gate와 차단 항목을 사용한다.
 - TASK-056의 남은 차단 항목이 `B-01`~`B-11`로 추적된다.
 - 실제 실행 범위가 `TASK-058`~`TASK-063`으로 분리되고 선행 관계와 종료 조건이 명시된다.
-- Production GO는 후속 작업 완료 전 선언하지 않는다.
+- Production GO는 초기 출시 필수 작업 완료 전 선언하지 않는다. 보류된 `TASK-062`는 Supabase Pro
+  전환 시 별도 Gate로 재개한다.
 
 ## 롤백 원칙
 

--- a/docs/refactor/tasks/TASK-062-disaster-recovery-rehearsal.md
+++ b/docs/refactor/tasks/TASK-062-disaster-recovery-rehearsal.md
@@ -1,14 +1,24 @@
 # TASK-062: DB·Storage 재해 복구 Rehearsal
 
-- 상태: 진행 중 (복구 harness 준비, Recovery project 대기)
-- 선행 작업: `TASK-060`
-- 해소 대상: `B-06`
+- 상태: 보류 (초기 Web·Android 출시 비차단, Supabase Pro 전환 시 재개)
+- 선행 작업: `TASK-060`, Supabase Pro 전환
+- 해소 대상: `B-06` (Growth 운영 강화)
 - GitHub Issue: [#383](https://github.com/ysjee141/nexvoy-frontend/issues/383)
 
 ## 목적
 
 같은 기준 시점의 DB와 `place-photos` object를 격리된 Supabase 프로젝트에 복구하고 핵심 제품
 데이터가 Web과 Android에서 읽기·수정 가능한 상태로 돌아오는지 검증한다.
+
+## 2026-08-05 범위 결정
+
+- 초기 Web·Android 출시는 `TASK-062` 완료를 요구하지 않는다.
+- 초기 운영 기간에는 별도 Recovery 프로젝트와 독립 DB·Storage 복구 보장을 두지 않는 위험을
+  명시적으로 수용한다.
+- Supabase Pro 전환 시 managed DB backup을 실제 복구 원본으로 확인한 뒤 이 작업을 재개한다.
+- Storage object byte는 DB backup과 별개이므로 Pro 전환 시 자산 중요도와 별도 보관 필요성을 함께
+  재평가한다.
+- 이 결정은 `TASK-061` 안정성·비용 관측이나 `TASK-063` Production preflight를 면제하지 않는다.
 
 ## 범위
 
@@ -28,11 +38,14 @@
 
 ## 제외 범위
 
+- 초기 Web·Android Production 출시 승인
 - Production 원본 프로젝트에서의 파괴적 복구
 - legacy authority로의 rollback
 - iOS 설치 빌드 smoke (`TASK-064`에서 동일 복구 기준을 재사용)
 
 ## 실행 도구
+
+아래 도구는 Pro 전환 시 실행하며 초기 출시 준비 중에는 Recovery 프로젝트를 만들기 위해 실행하지 않는다.
 
 - Runbook: [TASK-062 DB·Storage 복구](../runbooks/TASK-062-disaster-recovery-rehearsal.md)
 - preflight·manifest·정합성 비교: `pnpm task062:recovery`

--- a/docs/refactor/tasks/TASK-063-production-preflight-and-rollout.md
+++ b/docs/refactor/tasks/TASK-063-production-preflight-and-rollout.md
@@ -1,32 +1,33 @@
 # TASK-063: Web·Android Production 사전 점검 및 단계적 출시
 
 - 상태: 대기
-- 선행 작업: `TASK-061`, `TASK-062`
+- 선행 작업: `TASK-061`
 - 해소 대상: `B-07`~`B-10`, `B-11` 운영 설정
 
 ## 목적
 
-Production `runbcaegpefqnljsswhv`의 schema, backup, Web·Android 외부 연동과 운영 책임을 독립
-확인하고 Android 지원 대상의 100%까지 단계적으로 확대한다.
+Production `runbcaegpefqnljsswhv`의 schema, 현재 plan의 backup 제공 범위, Web·Android 외부 연동과
+운영 책임을 독립 확인하고 Android 지원 대상의 100%까지 단계적으로 확대한다.
 
 ## 범위
 
 - Production migration history·object drift 독립 감사
-- 배포 직전 DB와 Storage backup·checksum
+- 현재 Supabase plan과 backup 제공 범위, 초기 복구 위험 수용 기록
 - Web/Android release SHA, 환경변수, OAuth, 이메일, Android push·deep link, 도메인
 - `send-document-invitation` Production secret(`RESEND_API_KEY`,
   `ONVOY_APP_ORIGIN=https://app.nexvoy.xyz`)과 함수 배포, 인증·권한·실제 이메일 smoke
 - asset cleanup scheduler, `ASSET_CLEANUP_SECRET`, 실패 alert
 - API 인증·rate limit, Google Play 정보, 약관·개인정보, 지원·incident 연락망
 - 내부→5%→25%→100% rollout과 단계별 hold·GO 승인
-- 쓰기 동결, authority-only client rollback, 비파괴 DB 복원 훈련
+- 쓰기 동결, authority-only client rollback, 비파괴 migration/function rollback 훈련
 
 ## 완료 조건
 
-- 마스터 계획 `G0`~`G6`이 GO이고 미해결 P0/P1 결함이 없다.
+- 마스터 계획 `G0`~`G4`, `G6`이 GO이고 미해결 P0/P1 결함이 없다.
+- `G5`/`TASK-062`는 초기 출시 비차단·보류 상태이고 Supabase Pro 전환 시 재개한다.
 - release manager, DB operator, Web/Android 배포자, on-call 담당자가 승인한다.
 - 단계별 임계치와 최소 관찰 시간을 충족한 뒤에만 다음 비율로 확대한다.
-- 100% 전환 후에도 alert, backup, rollback 준비가 유지된다.
+- 100% 전환 후에도 alert, 현재 plan의 backup 범위·위험 승인과 rollback 준비가 유지된다.
 - iOS가 지원 대상 또는 출시 완료로 표시되지 않는다.
 - Production Android 이메일 초대가 Web 배포 보호 설정에 의존하지 않고, owner/editor 권한과
   수락 대기 상태가 Web과 동일하게 수렴한다.
@@ -39,5 +40,5 @@ Production `runbcaegpefqnljsswhv`의 schema, backup, Web·Android 외부 연동�
 ## 즉시 중단 조건
 
 - 데이터 손실·변질, 계정 간 노출, 권한 우회
-- migration drift, 복구 불일치, 미승인 schema 변경
+- migration drift, 미승인 schema 변경, Pro 전환 후 검증된 복구 절차의 불일치
 - 반복되는 command reject/retry 또는 RPC latency 임계치 초과

--- a/docs/refactor/test-plans/TASK-057-production-integration-test-cases.md
+++ b/docs/refactor/test-plans/TASK-057-production-integration-test-cases.md
@@ -38,7 +38,7 @@
 
 | 등급 | 의미 | 출시 조건 |
 |---|---|---|
-| P0 | 데이터 정합성, 권한, 계정 격리, 복구 | 100% PASS 필수 |
+| P0 | 데이터 정합성, 권한, 계정 격리 | 100% PASS 필수 |
 | P1 | 핵심 제품 기능과 지원 플랫폼 | 100% PASS 필수 |
 | P2 | 비핵심 UX, 장기 비용 최적화 | 승인된 예외만 허용 |
 
@@ -50,7 +50,7 @@
 |---|---|---|---|
 | Local Supabase | destructive SQL, service role seed, Playwright | reset, 전체 SQL/E2E | Production secret 사용 |
 | DEV `ivgkqzwosbjukonlpfdw` | 원격 migration, 실제 client smoke, 7일 관측 | 전용 계정의 제품 UI 테스트 | local-only guard 우회, 고객 데이터 사용 |
-| 복구 프로젝트 | DB+Storage restore rehearsal | dump/object 복구와 비교 | DEV/Production endpoint로 전환 |
+| 복구 프로젝트 (Pro 전환 시) | DB+Storage restore rehearsal | dump/object 복구와 비교 | DEV/Production endpoint로 전환 |
 | Production `runbcaegpefqnljsswhv` | preflight와 제한 smoke | read-only 점검, 승인된 내부 계정 smoke | destructive seed, service role E2E |
 
 ### 테스트 계정
@@ -66,7 +66,8 @@
 - DEV/Production에서는 전용 테스트 이메일과 가명만 사용한다.
 - 로그와 문서에는 실제 UUID, token, 초대 코드를 붙이지 않는다.
 - 데이터 이름은 `QA-<release>-<case-id>` 형식을 사용한다.
-- 삭제 검증이 끝난 데이터는 case 종료 후 cleanup한다. 복구 rehearsal fixture는 별도 보관한다.
+- 삭제 검증이 끝난 데이터는 case 종료 후 cleanup한다. Pro 전환 후 복구 rehearsal fixture는 별도
+  보관한다.
 
 ### 클라이언트 표기
 
@@ -266,14 +267,14 @@ TASK-064에서 다시 실행한다.
 | NFT-02 | 비용 | 7일 payload, full refresh, Realtime, egress 집계 | 비용 baseline과 quota 70% 미만 |
 | NFT-03 | 접근성 | Web keyboard/screen reader, Mobile VoiceOver/TalkBack | conflict·초대·오류 UI 조작 가능 |
 | NFT-04 | 보안 | RLS/RPC/Storage direct 접근, token 로그 검사 | 우회 0건, secret/UUID/content analytics 0건 |
-| NFT-05 | 복구 | DB+Storage 격리 복구 | row/object 정합성 100%, 합의 RTO/RPO 충족 |
+| NFT-05 | 복구 (Pro 전환 시) | DB+Storage 격리 복구 | row/object 정합성 100%, 합의 RTO/RPO 충족 |
 | NFT-06 | 호환성 | 지원 브라우저/OS와 최소 Mobile 버전 | crash·데이터 포맷 불일치 0건 |
 
 ## 결함 등급과 종료 기준
 
 | 등급 | 예시 | 조치 |
 |---|---|---|
-| P0 | 데이터 손실, 계정 간 노출, RLS 우회, 복구 실패 | 즉시 중단, GO 취소, 원인 제거 후 전체 Gate 재실행 |
+| P0 | 데이터 손실, 계정 간 노출, RLS 우회, Pro 전환 후 복구 실패 | 즉시 중단, GO 취소, 원인 제거 후 영향 Gate 재실행 |
 | P1 | 핵심 CRUD/초대/offline 불가, 반복 crash | release candidate 폐기, 수정 후 영향 매트릭스 재실행 |
 | P2 | 우회 가능한 비핵심 UX, 경미한 시각 문제 | owner·만료일·영향을 기록한 예외 승인 필요 |
 | P3 | 문구·개발 편의 개선 | backlog 허용 |

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,28 @@
+# Walkthrough: TASK-062 초기 출시 Gate 재분류
+
+## 결정
+
+- TASK-062 DB·Storage 복구 rehearsal은 초기 Web·Android 출시의 필수 Gate에서 제외했다.
+- 초기 운영 기간에는 별도 Recovery 프로젝트와 DB·Storage 복구 미보장 위험을 명시적으로 수용한다.
+- Supabase Pro 전환 시 managed DB backup을 실제 복구 원본으로 확인하고 TASK-062를 재개한다.
+- Storage object byte는 DB backup과 별개이므로 Pro 전환 시 자산 중요도와 별도 보관 필요성을
+  재평가한다.
+
+## 출시 흐름
+
+- TASK-061 DEV 7일 관측을 통과한 뒤 TASK-063 Production preflight와 단계적 Android rollout으로
+  진행한다.
+- G5/B-06은 초기 출시 비차단 보류 상태이며 G0~G4, G6, G7의 판정에는 포함하지 않는다.
+- TASK-062의 digest 도구와 Runbook은 삭제하지 않고 후속 운영 강화에 재사용한다.
+
+## 문서 정합화
+
+- Production 준비 현황, TASK-056/057/060/062/063, 작업 README와 진행 문서를 같은 선행 관계로
+  정리했다.
+- 복구 실패는 Pro 전환 후 TASK-062를 실제 실행한 경우의 운영 강화 NO-GO 조건으로 제한했다.
+
+---
+
 # Walkthrough: 모바일 프로필 여행 통계 복구
 
 ## 원인
@@ -106,10 +131,11 @@
   canonical table과 Storage digest를 비교한다.
 - 실제 증적은 Git에서 제외된 `_workspace` 또는 repository 밖의 암호화 저장소에만 둔다.
 
-## 현재 판정
+## 당시 판정 (2026-08-01)
 
 TASK-061의 7일 DEV 관측과 TASK-062의 별도 Recovery 프로젝트 복원이 남아 `G4`, `G5`와 Android
 Production은 `NO-GO`다. 두 작업 통과 후 TASK-063 preflight와 단계적 rollout을 진행한다.
+2026-08-05 결정으로 TASK-062/G5는 초기 출시 비차단 보류로 변경했다.
 
 # Walkthrough: TASK-060 Android 초대 수락·오프라인 준비물 회귀
 
@@ -183,10 +209,11 @@ Gate로 유지한다.
 - TASK-063: Web·Android Production preflight와 Android 단계적 rollout
 - TASK-064: iOS 실기기·OAuth·push·lifecycle·TestFlight/App Store 검증과 별도 rollout
 
-## 판정
+## 당시 판정 (2026-07-29)
 
 Android 실제 기기, 외부 연동, 관측과 복구가 남아 Web·Android Production은 계속 `NO-GO`다. iOS
 simulator PREPASS는 유지하지만 iOS Production 판정은 TASK-064 전까지 `DEFERRED`다.
+2026-08-05 결정으로 초기 출시에는 TASK-062 복구를 요구하지 않는다.
 
 ---
 
@@ -393,12 +420,15 @@ flowchart LR
 - DB managed backup과 logical export는 Storage object byte를 포함하지 않으므로 `place-photos`를 별도 복구한다.
 - TASK-055 이후 롤백은 직전 authority-only client와 비파괴 function 복원만 사용한다.
 
-## 다음 작업
+## 당시 다음 작업
 
 1. `TASK-058`에서 `NEW-A01`~`NEW-A13` P0 자동 테스트를 구현한다.
 2. `TASK-059`에서 DEV historical 9건과 TASK-056 전체를 fingerprint하고 history를 정합화한다.
 3. `TASK-060`에서 TASK-059에서 정합화한 schema를 기준으로 전체 실기기·asset 매트릭스를 실행한다.
 4. `TASK-061`·`TASK-062`의 7일 관측과 복구 후 `TASK-063` Production preflight를 진행한다.
+
+이 순서는 2026-08-05 결정으로 변경했다. 현재는 TASK-061 이후 TASK-063으로 진행하고 TASK-062는
+Supabase Pro 전환 시 재개한다.
 
 ---
 


### PR DESCRIPTION
## 결정

- TASK-062/G5/B-06을 초기 Web·Android 출시 비차단으로 재분류합니다.
- 초기 운영 기간의 DB·Storage 복구 미보장 위험을 명시적으로 수용합니다.
- Supabase Pro 전환 시 managed DB backup을 복구 원본으로 확인하고 TASK-062를 재개합니다.
- 초기 출시 경로를 TASK-061 -> TASK-063으로 정리합니다.

## 문서 정합화

- TASK-056/057/060/062/063과 Production 준비 문서의 Gate·선행 관계를 통일했습니다.
- TASK-062 도구와 Runbook은 삭제하지 않고 Pro 전환 이후 재사용하도록 유지했습니다.
- Storage object byte는 DB backup과 별개이므로 Pro 전환 시 별도 정책을 재평가하도록 기록했습니다.

## 검증

- `pnpm test:operational-gates` (8/8 PASS)
- 변경 Markdown 17개 로컬 링크 검사 PASS
- `git diff --check` PASS

Refs #383